### PR TITLE
Stackadapt-Audience: add isPii field to upsertExternalAudienceMapping query

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,14 +1,14 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - all fields 1`] = `
-{
+Object {
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: "segmentio",
-          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
-          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
+          externalProvider: \\"segmentio\\",
+          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
+          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
       ) {
         userErrors {
@@ -18,8 +18,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
-          mappableType: "segmentio",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
+          mappableType: \\"segmentio\\",
         }
       ) {
         userErrors {
@@ -29,8 +29,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
-          mappableType: "segmentio"
+          mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
+          mappableType: \\"segmentio\\"
         }
       ) {
         userErrors {
@@ -42,14 +42,14 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - required fields 1`] = `
-{
+Object {
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: "segmentio",
-          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
-          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
+          externalProvider: \\"segmentio\\",
+          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
+          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
       ) {
         userErrors {
@@ -59,8 +59,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
-          mappableType: "segmentio",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
+          mappableType: \\"segmentio\\",
         }
       ) {
         userErrors {
@@ -70,8 +70,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
-          mappableType: "segmentio"
+          mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
+          mappableType: \\"segmentio\\"
         }
       ) {
         userErrors {
@@ -83,14 +83,14 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardA
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - all fields 1`] = `
-{
+Object {
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: "segmentio",
-          syncId: "1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78",
-          profiles: "[{\\"email\\":\\"zobbufpop@usliz.mh\\",\\"firstName\\":\\"PsAwlRv%\\",\\"lastName\\":\\"PsAwlRv%\\",\\"phone\\":\\"PsAwlRv%\\",\\"city\\":\\"PsAwlRv%\\",\\"country\\":\\"PsAwlRv%\\",\\"state\\":\\"PsAwlRv%\\",\\"postalCode\\":\\"PsAwlRv%\\",\\"userId\\":\\"PsAwlRv%\\",\\"birthDay\\":null,\\"birthMonth\\":null}]"
+          externalProvider: \\"segmentio\\",
+          syncId: \\"1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78\\",
+          profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"zobbufpop@usliz.mh\\\\\\",\\\\\\"firstName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"lastName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"city\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"country\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"state\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"postalCode\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"birthDay\\\\\\":null,\\\\\\"birthMonth\\\\\\":null}]\\"
         }
       ) {
         userErrors {
@@ -100,8 +100,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
-          mappableType: "segmentio",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
+          mappableType: \\"segmentio\\",
         }
       ) {
         userErrors {
@@ -113,14 +113,14 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - required fields 1`] = `
-{
+Object {
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: "segmentio",
-          syncId: "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-          profiles: "[]"
+          externalProvider: \\"segmentio\\",
+          syncId: \\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\\",
+          profiles: \\"[]\\"
         }
       ) {
         userErrors {
@@ -130,8 +130,8 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
-          mappableType: "segmentio",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
+          mappableType: \\"segmentio\\",
         }
       ) {
         userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,7 +6,7 @@ Object {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segmentio\\",
+          externalProvider: \\"segment_io\\",
           syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
           profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
@@ -19,7 +19,7 @@ Object {
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-          mappableType: \\"segmentio\\",
+          mappableType: \\"segment_io\\",
         }
       ) {
         userErrors {
@@ -30,7 +30,7 @@ Object {
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\"
+          mappableType: \\"segment_io\\"
         }
       ) {
         userErrors {
@@ -47,7 +47,7 @@ Object {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segmentio\\",
+          externalProvider: \\"segment_io\\",
           syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
           profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
@@ -60,7 +60,7 @@ Object {
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-          mappableType: \\"segmentio\\",
+          mappableType: \\"segment_io\\",
         }
       ) {
         userErrors {
@@ -71,7 +71,7 @@ Object {
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\"
+          mappableType: \\"segment_io\\"
         }
       ) {
         userErrors {
@@ -88,7 +88,7 @@ Object {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segmentio\\",
+          externalProvider: \\"segment_io\\",
           syncId: \\"1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78\\",
           profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"zobbufpop@usliz.mh\\\\\\",\\\\\\"firstName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"lastName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"city\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"country\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"state\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"postalCode\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"birthDay\\\\\\":null,\\\\\\"birthMonth\\\\\\":null}]\\"
         }
@@ -101,7 +101,7 @@ Object {
         input: {
           advertiserId: PsAwlRv%,
           mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\",
+          mappableType: \\"segment_io\\",
         }
       ) {
         userErrors {
@@ -118,7 +118,7 @@ Object {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segmentio\\",
+          externalProvider: \\"segment_io\\",
           syncId: \\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\\",
           profiles: \\"[]\\"
         }
@@ -131,7 +131,7 @@ Object {
         input: {
           advertiserId: PsAwlRv%,
           mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\",
+          mappableType: \\"segment_io\\",
         }
       ) {
         userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,14 +1,14 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - all fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segmentio\\",
-          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
+          externalProvider: "segmentio",
+          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
+          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
         }
       ) {
         userErrors {
@@ -18,8 +18,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-          mappableType: \\"segmentio\\",
+          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
+          mappableType: "segmentio",
         }
       ) {
         userErrors {
@@ -29,8 +29,8 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}],
-          mappableType: \\"segmentio\\"
+          mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
+          mappableType: "segmentio"
         }
       ) {
         userErrors {
@@ -42,14 +42,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - required fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segmentio\\",
-          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
+          externalProvider: "segmentio",
+          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
+          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
         }
       ) {
         userErrors {
@@ -59,8 +59,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-          mappableType: \\"segmentio\\",
+          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
+          mappableType: "segmentio",
         }
       ) {
         userErrors {
@@ -70,8 +70,8 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}],
-          mappableType: \\"segmentio\\"
+          mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
+          mappableType: "segmentio"
         }
       ) {
         userErrors {
@@ -83,14 +83,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - all fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segmentio\\",
-          syncId: \\"1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78\\",
-          profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"zobbufpop@usliz.mh\\\\\\",\\\\\\"firstName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"lastName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"city\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"country\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"state\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"postalCode\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"birthDay\\\\\\":null,\\\\\\"birthMonth\\\\\\":null}]\\"
+          externalProvider: "segmentio",
+          syncId: "1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78",
+          profiles: "[{\\"email\\":\\"zobbufpop@usliz.mh\\",\\"firstName\\":\\"PsAwlRv%\\",\\"lastName\\":\\"PsAwlRv%\\",\\"phone\\":\\"PsAwlRv%\\",\\"city\\":\\"PsAwlRv%\\",\\"country\\":\\"PsAwlRv%\\",\\"state\\":\\"PsAwlRv%\\",\\"postalCode\\":\\"PsAwlRv%\\",\\"userId\\":\\"PsAwlRv%\\",\\"birthDay\\":null,\\"birthMonth\\":null}]"
         }
       ) {
         userErrors {
@@ -100,8 +100,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\",
+          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
+          mappableType: "segmentio",
         }
       ) {
         userErrors {
@@ -113,14 +113,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - required fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segmentio\\",
-          syncId: \\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\\",
-          profiles: \\"[]\\"
+          externalProvider: "segmentio",
+          syncId: "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+          profiles: "[]"
         }
       ) {
         userErrors {
@@ -130,8 +130,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-          mappableType: \\"segmentio\\",
+          mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
+          mappableType: "segmentio",
         }
       ) {
         userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -64,28 +64,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): {
-          "authorization": [
+        Symbol(map): Object {
+          "authorization": Array [
             "Bearer test-graphql-key",
           ],
-          "content-type": [
+          "content-type": Array [
             "application/json",
           ],
-          "user-agent": [
+          "user-agent": Array [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc",
-                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -95,8 +95,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -106,8 +106,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
-                mappableType: "segmentio"
+                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\"
               }
             ) {
               userErrors {
@@ -138,28 +138,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): {
-          "authorization": [
+        Symbol(map): Object {
+          "authorization": Array [
             "Bearer test-graphql-key",
           ],
-          "content-type": [
+          "content-type": Array [
             "application/json",
           ],
-          "user-agent": [
+          "user-agent": Array [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc",
-                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -169,8 +169,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -180,8 +180,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
-                mappableType: "segmentio"
+                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\"
               }
             ) {
               userErrors {
@@ -211,14 +211,14 @@ describe('forwardAudienceEvent', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3",
-                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"},{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"},{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -228,8 +228,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -239,8 +239,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
-                mappableType: "segmentio"
+                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\"
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -83,7 +83,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
                 profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
@@ -96,7 +96,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -107,7 +107,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\"
+                mappableType: \\"segment_io\\"
               }
             ) {
               userErrors {
@@ -157,7 +157,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
                 profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
@@ -170,7 +170,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -181,7 +181,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\"
+                mappableType: \\"segment_io\\"
               }
             ) {
               userErrors {
@@ -216,7 +216,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3\\",
                 profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"},{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
               }
@@ -229,7 +229,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -240,7 +240,7 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\",\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\"
+                mappableType: \\"segment_io\\"
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -64,28 +64,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                externalProvider: "segmentio",
+                syncId: "18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
               }
             ) {
               userErrors {
@@ -95,8 +95,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -106,8 +106,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}],
-                mappableType: \\"segmentio\\"
+                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
+                mappableType: "segmentio"
               }
             ) {
               userErrors {
@@ -138,28 +138,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                externalProvider: "segmentio",
+                syncId: "18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
               }
             ) {
               userErrors {
@@ -169,8 +169,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -180,8 +180,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}],
-                mappableType: \\"segmentio\\"
+                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
+                mappableType: "segmentio"
               }
             ) {
               userErrors {
@@ -211,14 +211,14 @@ describe('forwardAudienceEvent', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"},{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                externalProvider: "segmentio",
+                syncId: "c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"},{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
               }
             ) {
               userErrors {
@@ -228,8 +228,8 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"isPii\\":false,\\"label\\":\\"External Profile ID\\"}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -239,8 +239,8 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: [{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}],
-                mappableType: \\"segmentio\\"
+                mappingSchema: [{\\"incomingKey\\":\\"audienceId\\",\\"destinationKey\\":\\"external_id\\",\\"type\\":STRING,\\"label\\":\\"External Audience ID\\",\\"isPii\\":false},{\\"incomingKey\\":\\"audienceName\\",\\"destinationKey\\":\\"name\\",\\"type\\":STRING,\\"label\\":\\"External Audience Name\\",\\"isPii\\":false}],
+                mappableType: "segmentio"
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -7,13 +7,16 @@ const audienceMapping = stringifyJsonWithEscapedQuotes([
     incomingKey: 'audienceId',
     destinationKey: 'external_id',
     type: 'string',
-    label: 'External Audience ID'
+    label: 'External Audience ID',
+    isPii: false,
   },
   {
     incomingKey: 'audienceName',
     destinationKey: 'name',
     type: 'string',
-    label: 'External Audience Name'
+    label: 'External Audience Name',
+    isPii: false,
+
   }
 ])
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -100,28 +100,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
+                externalProvider: "segmentio",
+                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
               }
             ) {
               userErrors {
@@ -131,8 +131,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -163,28 +163,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
+                externalProvider: "segmentio",
+                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
               }
             ) {
               userErrors {
@@ -194,8 +194,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -225,14 +225,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2},{\\\\\\"email\\\\\\":\\\\\\"email2@stackadapt.com\\\\\\",\\\\\\"customField\\\\\\":\\\\\\"value\\\\\\",\\\\\\"numberCustomField\\\\\\":123,\\\\\\"userId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
+                externalProvider: "segmentio",
+                syncId: "fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2},{\\"email\\":\\"email2@stackadapt.com\\",\\"customField\\":\\"value\\",\\"numberCustomField\\":123,\\"userId\\":\\"user-id2\\"}]"
               }
             ) {
               userErrors {
@@ -242,8 +242,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":NUMBER,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false},{\\"incomingKey\\":\\"customField\\",\\"destinationKey\\":\\"customField\\",\\"label\\":\\"Custom Field\\",\\"type\\":STRING,\\"isPii\\":false},{\\"incomingKey\\":\\"numberCustomField\\",\\"destinationKey\\":\\"numberCustomField\\",\\"label\\":\\"Number Custom Field\\",\\"type\\":NUMBER,\\"isPii\\":false}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {
@@ -273,14 +273,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
-                syncId: \\"b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"previousId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
+                externalProvider: "segmentio",
+                syncId: "b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"previousId\\":\\"user-id2\\"}]"
               }
             ) {
               userErrors {
@@ -290,8 +290,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
+                mappableType: "segmentio",
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -119,7 +119,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
                 profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
               }
@@ -132,7 +132,7 @@ describe('forwardProfile', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -182,7 +182,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
                 profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
               }
@@ -195,7 +195,7 @@ describe('forwardProfile', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -230,7 +230,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2\\",
                 profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2},{\\\\\\"email\\\\\\":\\\\\\"email2@stackadapt.com\\\\\\",\\\\\\"customField\\\\\\":\\\\\\"value\\\\\\",\\\\\\"numberCustomField\\\\\\":123,\\\\\\"userId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
               }
@@ -243,7 +243,7 @@ describe('forwardProfile', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":NUMBER,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {
@@ -278,7 +278,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: \\"segmentio\\",
+                externalProvider: \\"segment_io\\",
                 syncId: \\"b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e\\",
                 profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"previousId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
               }
@@ -291,7 +291,7 @@ describe('forwardProfile', () => {
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
-                mappableType: \\"segmentio\\",
+                mappableType: \\"segment_io\\",
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -100,28 +100,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): {
-          "authorization": [
+        Symbol(map): Object {
+          "authorization": Array [
             "Bearer test-graphql-key",
           ],
-          "content-type": [
+          "content-type": Array [
             "application/json",
           ],
-          "user-agent": [
+          "user-agent": Array [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
-                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
+                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
               }
             ) {
               userErrors {
@@ -131,8 +131,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -163,28 +163,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): {
-          "authorization": [
+        Symbol(map): Object {
+          "authorization": Array [
             "Bearer test-graphql-key",
           ],
-          "content-type": [
+          "content-type": Array [
             "application/json",
           ],
-          "user-agent": [
+          "user-agent": Array [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
-                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
+                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
               }
             ) {
               userErrors {
@@ -194,8 +194,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -225,14 +225,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2",
-                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2},{\\"email\\":\\"email2@stackadapt.com\\",\\"customField\\":\\"value\\",\\"numberCustomField\\":123,\\"userId\\":\\"user-id2\\"}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2\\",
+                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2},{\\\\\\"email\\\\\\":\\\\\\"email2@stackadapt.com\\\\\\",\\\\\\"customField\\\\\\":\\\\\\"value\\\\\\",\\\\\\"numberCustomField\\\\\\":123,\\\\\\"userId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -242,8 +242,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false},{\\"incomingKey\\":\\"customField\\",\\"destinationKey\\":\\"customField\\",\\"label\\":\\"Custom Field\\",\\"type\\":STRING,\\"isPii\\":false},{\\"incomingKey\\":\\"numberCustomField\\",\\"destinationKey\\":\\"numberCustomField\\",\\"label\\":\\"Number Custom Field\\",\\"type\\":NUMBER,\\"isPii\\":false}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":NUMBER,\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {
@@ -273,14 +273,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      {
+      Object {
         "query": "mutation {
             upsertProfiles(
               input: {
                 advertiserId: 23,
-                externalProvider: "segmentio",
-                syncId: "b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e",
-                profiles: "[{\\"userId\\":\\"user-id\\",\\"previousId\\":\\"user-id2\\"}]"
+                externalProvider: \\"segmentio\\",
+                syncId: \\"b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"previousId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -290,8 +290,8 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{\\"incomingKey\\":\\"userId\\",\\"destinationKey\\":\\"external_id\\",\\"label\\":\\"User Id\\",\\"type\\":STRING,\\"isPii\\":false}],
-                mappableType: "segmentio",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":STRING,\\\\\\"isPii\\\\\\":false}],
+                mappableType: \\"segmentio\\",
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
@@ -24,7 +24,7 @@ interface TokenInfoResponse {
   }
 }
 
-export const EXTERNAL_PROVIDER = 'segmentio'
+export const EXTERNAL_PROVIDER = 'segment_io'
 export const GQL_ENDPOINT = 'https://api.stackadapt.com/graphql'
 
 export async function advertiserIdFieldImplementation(


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
