### PR TITLE
[ACTVTNS-161] Update Email Field Intercom 

### DIFF
--- a/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
+++ b/packages/destination-actions/src/destinations/intercom/identifyContact/index.ts
@@ -43,15 +43,6 @@ const action: ActionDefinition<Settings, Payload> = {
       format: 'email',
       default: {
         '@path': '$.traits.email'
-      },
-      depends_on: {
-        conditions: [
-          {
-            fieldKey: 'role',
-            operator: 'is',
-            value: 'user'
-          }
-        ]
       }
     },
     phone: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_This PR adds the 'email' field when the contact type is either lead or user because according to the intercom docs it is supported for both types._

https://developers.intercom.com/docs/references/rest-api/api.intercom.io/contacts/createcontact

## Testing

I have tested this in the staging environment: 

<img width="944" height="383" alt="image" src="https://github.com/user-attachments/assets/e3cd4483-3b93-495a-a7b8-e08aeabbd8bf" />


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing.


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
