### PR TITLE
STRATCONN-5939 - Cleanup flagon gate

### DIFF
--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/__tests__/index.test.ts
@@ -654,9 +654,6 @@ describe('BrazeCohorts.syncAudiences', () => {
         external_id: {
           '@path': '$.notGiven'
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -733,9 +730,6 @@ describe('BrazeCohorts.syncAudiences', () => {
             '@path': '$.context.traits.email'
           }
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -799,9 +793,6 @@ describe('BrazeCohorts.syncAudiences', () => {
       useDefaultMappings: true,
       mapping: {
         personas_audience_key: 'j_o_jons__step_1_ns3i7'
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -875,9 +866,6 @@ describe('BrazeCohorts.syncAudiences', () => {
         external_id: {
           '@path': '$.notGiven'
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -954,9 +942,6 @@ describe('BrazeCohorts.syncAudiences', () => {
             '@path': '$.context.traits.email'
           }
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -1035,9 +1020,6 @@ describe('BrazeCohorts.syncAudiences', () => {
         external_id: {
           '@path': '$.notGiven'
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 
@@ -1113,9 +1095,6 @@ describe('BrazeCohorts.syncAudiences', () => {
             '@path': '$.context.traits.email'
           }
         }
-      },
-      features: {
-        'dedupe-braze-cohorts-v2': true
       }
     })
 

--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/index.ts
@@ -1,4 +1,4 @@
-import { ActionDefinition, RequestClient, PayloadValidationError, Features } from '@segment/actions-core'
+import { ActionDefinition, RequestClient, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { SyncAudiences } from '../api'
@@ -112,19 +112,18 @@ const action: ActionDefinition<Settings, Payload> = {
       required: false
     }
   },
-  perform: async (request, { settings, payload, stateContext, features }) => {
-    return processPayload(request, settings, [payload], stateContext, features)
+  perform: async (request, { settings, payload, stateContext }) => {
+    return processPayload(request, settings, [payload], stateContext)
   },
-  performBatch: async (request, { settings, payload, stateContext, features }) => {
-    return processPayload(request, settings, payload, stateContext, features)
+  performBatch: async (request, { settings, payload, stateContext }) => {
+    return processPayload(request, settings, payload, stateContext)
   }
 }
 async function processPayload(
   request: RequestClient,
   settings: Settings,
   payloads: Payload[],
-  stateContext?: StateContext,
-  features?: Features
+  stateContext?: StateContext
 ) {
   validate(payloads)
   const syncAudiencesApiClient: SyncAudiences = new SyncAudiences(request, settings)
@@ -136,12 +135,8 @@ async function processPayload(
     //setting cohort_name in cache context with ttl 0 so that it can keep the value as long as possible.
     stateContext?.setResponseContext?.(`cohort_name`, cohort_name, {})
   }
-  let addUsers: CohortChanges, removeUsers: CohortChanges
-  if (features?.['dedupe-braze-cohorts-v2']) {
-    ;({ addUsers, removeUsers } = extractUsersV2(payloads))
-  } else {
-    ;({ addUsers, removeUsers } = extractUsers(payloads))
-  }
+  const { addUsers, removeUsers } = extractUsers(payloads)
+
   const hasAddUsers = hasUsersToAddOrRemove(addUsers)
   const hasRemoveUsers = hasUsersToAddOrRemove(removeUsers)
 
@@ -169,7 +164,7 @@ function validate(payloads: Payload[]): void {
   }
 }
 
-function extractUsersV2(payloads: Payload[]) {
+function extractUsers(payloads: Payload[]) {
   // sort by time in descending order
   // This is important because if a user is added and removed in the same batch,
   // we want to ensure that the last action is taken.
@@ -212,30 +207,6 @@ function extractUsersV2(payloads: Payload[]) {
       aliases: transformAliases(removeUsers.aliases),
       should_remove: removeUsers.should_remove
     } as CohortChanges
-  }
-}
-
-function extractUsers(payloads: Payload[]) {
-  const addUsers: CohortChanges = { user_ids: [], device_ids: [], aliases: [] }
-  const removeUsers: CohortChanges = { user_ids: [], device_ids: [], aliases: [], should_remove: true }
-
-  payloads.forEach((payload: Payload) => {
-    const { event_properties, external_id, device_id, user_alias, personas_audience_key } = payload
-    const userEnteredOrRemoved: boolean = event_properties[`${personas_audience_key}`] as boolean
-    const user = userEnteredOrRemoved ? addUsers : removeUsers
-
-    if (external_id) {
-      user?.user_ids?.push(external_id)
-    } else if (device_id) {
-      user?.device_ids?.push(device_id)
-    } else if (user_alias) {
-      user?.aliases?.push(user_alias)
-    }
-  })
-
-  return {
-    addUsers,
-    removeUsers
   }
 }
 


### PR DESCRIPTION
Successfully rolled out the [PR](https://github.com/segmentio/action-destinations/pull/3036). This PR is to cleanup the flagon gates.


## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
