### PR TITLE
Amazon Conversions API - Adding validation to pass currencyCode and unitsSold only when event type is OFF_AMAZON_PURCHASES

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
@@ -570,6 +570,50 @@ describe('trackConversion utils', () => {
       expect(() => prepareEventData(payload, settings)).toThrow('At least one valid match key must be provided')
     })
 
+    it('should include currencyCode and unitsSold when eventType is OFF_AMAZON_PURCHASES', () => {
+      const payload: Payload = {
+        name: 'purchase_event',
+        eventType: ConversionTypeV2.OFF_AMAZON_PURCHASES,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        currencyCode: 'USD',
+        unitsSold: 2,
+        matchKeys: {
+          email: 'test@example.com'
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+
+      // Check that OFF_AMAZON_PURCHASES fields are included
+      expect(result.currencyCode).toBe('USD')
+      expect(result.unitsSold).toBe(2)
+    })
+
+    it('should exclude currencyCode and unitsSold when eventType is not OFF_AMAZON_PURCHASES', () => {
+      const payload: Payload = {
+        name: 'view_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        currencyCode: 'USD',
+        unitsSold: 2,
+        matchKeys: {
+          email: 'test@example.com'
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+
+      // Check that OFF_AMAZON_PURCHASES fields are excluded
+      expect(result.currencyCode).toBeUndefined()
+      expect(result.unitsSold).toBeUndefined()
+    })
+
     it('should include optional fields when provided', () => {
       const payload: Payload = {
         name: 'purchase_event',

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -17,11 +17,10 @@ import type {
   EventDataSuccessResponseV1,
   EventDataErrorResponseV1,
   MatchKeyV1,
-  ConversionTypeV2,
   CurrencyCodeV1,
   CustomAttributeV1
 } from '../types'
-import { MatchKeyTypeV1, Region } from '../types'
+import { MatchKeyTypeV1, Region, ConversionTypeV2 } from '../types'
 import type { Payload } from './generated-types'
 
 /**
@@ -393,8 +392,12 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
 
   Object.assign(eventData, {
     ...(payload.value !== undefined && { value: payload.value }),
-    ...(payload.currencyCode && { currencyCode: payload.currencyCode as CurrencyCodeV1 }),
-    ...(payload.unitsSold !== undefined && { unitsSold: payload.unitsSold }),
+    ...(payload.eventType === ConversionTypeV2.OFF_AMAZON_PURCHASES && payload.currencyCode && {
+      currencyCode: payload.currencyCode as CurrencyCodeV1
+    }),
+    ...(payload.eventType === ConversionTypeV2.OFF_AMAZON_PURCHASES && payload.unitsSold !== undefined && {
+      unitsSold: payload.unitsSold
+    }),
     ...(payload.clientDedupeId && { clientDedupeId: payload.clientDedupeId }),
     ...(payload.dataProcessingOptions && { dataProcessingOptions: payload.dataProcessingOptions }),
     ...(consent && { consent }),


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Amazon Conversions API - Adding validation to pass currencyCode and unitsSold only when event type is OFF_AMAZON_PURCHASES

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
