### PR TITLE
[MAIN] [STRATCONN-6079] :  SFMC-Mark specific error to retryable error status 500 if status code 400 is returned from SFMC in specific situation.

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
@@ -201,7 +201,7 @@ describe('Multistatus', () => {
       })
     })
 
-    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400', async () => {
+    it('should mark "Unable to save rows for data extension ID" error status as it is if additional error is present', async () => {
       const errorResponse = {
         status: 400,
         message: 'Invalid keys for ID: HS1',
@@ -251,31 +251,25 @@ describe('Multistatus', () => {
       })
 
       expect(response[0]).toMatchObject({
-        status: 500,
-        errortype: 'INTERNAL_SERVER_ERROR',
+        status: 400,
+        errortype: 'BAD_REQUEST',
         errormessage: 'Unable to save rows for data extension ID',
         errorreporter: 'DESTINATION'
       })
 
       expect(response[1]).toMatchObject({
-        status: 500,
-        errortype: 'INTERNAL_SERVER_ERROR',
+        status: 400,
+        errortype: 'BAD_REQUEST',
         errormessage: 'Unable to save rows for data extension ID',
         errorreporter: 'DESTINATION'
       })
     })
 
-    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble in outside of additionalErrors', async () => {
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble without additional error', async () => {
       const errorResponse = {
         status: 400,
-        message: 'Unable to save rows for data extension ID 4f2dd70a-0ab2-ef11-a5c2-d4f5ef42f422',
-        errorcode: 10006,
-        additionalErrors: [
-          {
-            errorcode: 10006,
-            message: 'Unable to save rows for data extension ID'
-          }
-        ]
+        message: 'Unable to save rows for data extension ID',
+        errorcode: 10006
       }
 
       nock(requestUrl).post('').reply(400, errorResponse)
@@ -597,17 +591,11 @@ describe('Multistatus', () => {
       })
     })
 
-    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble in outside of additionalErrors', async () => {
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble without additional errors', async () => {
       const errorResponse = {
         status: 400,
-        message: 'Unable to save rows for data extension ID 4f2dd70a-0ab2-ef11-a5c2-d4f5ef42f422',
-        errorcode: 10006,
-        additionalErrors: [
-          {
-            errorcode: 10006,
-            message: 'Unable to save rows for data extension ID'
-          }
-        ]
+        message: 'Unable to save rows for data extension ID',
+        errorcode: 10006
       }
 
       nock(requestUrl).post('').reply(400, errorResponse)
@@ -664,7 +652,7 @@ describe('Multistatus', () => {
       })
     })
 
-    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400', async () => {
+    it('should mark "Unable to save rows for data extension ID" error status as it is if additional error is present', async () => {
       const errorResponse = {
         status: 400,
         message: 'Invalid keys for ID: HS1',
@@ -716,15 +704,15 @@ describe('Multistatus', () => {
       })
 
       expect(response[0]).toMatchObject({
-        status: 500,
-        errortype: 'INTERNAL_SERVER_ERROR',
+        status: 400,
+        errortype: 'BAD_REQUEST',
         errormessage: 'Unable to save rows for data extension ID',
         errorreporter: 'DESTINATION'
       })
 
       expect(response[1]).toMatchObject({
-        status: 500,
-        errortype: 'INTERNAL_SERVER_ERROR',
+        status: 400,
+        errortype: 'BAD_REQUEST',
         errormessage: 'Unable to save rows for data extension ID',
         errorreporter: 'DESTINATION'
       })

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/multistatus.test.ts
@@ -200,6 +200,136 @@ describe('Multistatus', () => {
         errorreporter: 'DESTINATION'
       })
     })
+
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400', async () => {
+      const errorResponse = {
+        status: 400,
+        message: 'Invalid keys for ID: HS1',
+        additionalErrors: [
+          {
+            errorcode: 10006,
+            message: 'Unable to save rows for data extension ID'
+          }
+        ]
+      }
+
+      nock(requestUrl).post('').reply(400, errorResponse)
+
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-1',
+          properties: {
+            id: '1234567890',
+            keys: {
+              id: 'HS1' // Valid key
+            },
+            values: {
+              name: 'Harry Styles'
+            }
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-2',
+          properties: {
+            id: '1234567890',
+            keys: {
+              id: 'HS2' // Invalid key
+            },
+            values: {
+              name: 'Harry Potter'
+            }
+          }
+        })
+      ]
+
+      const response = await testDestination.executeBatch('dataExtension', {
+        events,
+        settings,
+        mapping
+      })
+
+      expect(response[0]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+
+      expect(response[1]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+    })
+
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble in outside of additionalErrors', async () => {
+      const errorResponse = {
+        status: 400,
+        message: 'Unable to save rows for data extension ID 4f2dd70a-0ab2-ef11-a5c2-d4f5ef42f422',
+        errorcode: 10006,
+        additionalErrors: [
+          {
+            errorcode: 10006,
+            message: 'Unable to save rows for data extension ID'
+          }
+        ]
+      }
+
+      nock(requestUrl).post('').reply(400, errorResponse)
+
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-1',
+          properties: {
+            id: '1234567890',
+            keys: {
+              id: 'HS1' // Valid key
+            },
+            values: {
+              name: 'Harry Styles'
+            }
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-2',
+          properties: {
+            id: '1234567890',
+            keys: {
+              id: 'HS2' // Invalid key
+            },
+            values: {
+              name: 'Harry Potter'
+            }
+          }
+        })
+      ]
+
+      const response = await testDestination.executeBatch('dataExtension', {
+        events,
+        settings,
+        mapping
+      })
+
+      expect(response[0]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+
+      expect(response[1]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+    })
+
     it('should handle multistatus errors and set correct status code', async () => {
       const errorResponse = {
         status: 429,
@@ -463,6 +593,139 @@ describe('Multistatus', () => {
         status: 400,
         errortype: 'BAD_REQUEST',
         errormessage: 'No record found for ID: HS2',
+        errorreporter: 'DESTINATION'
+      })
+    })
+
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400 and message and code availble in outside of additionalErrors', async () => {
+      const errorResponse = {
+        status: 400,
+        message: 'Unable to save rows for data extension ID 4f2dd70a-0ab2-ef11-a5c2-d4f5ef42f422',
+        errorcode: 10006,
+        additionalErrors: [
+          {
+            errorcode: 10006,
+            message: 'Unable to save rows for data extension ID'
+          }
+        ]
+      }
+
+      nock(requestUrl).post('').reply(400, errorResponse)
+
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-1',
+          properties: {
+            id: '1234567890',
+            keys: {
+              contactKey: 'harry-1',
+              id: 'HS1'
+            },
+            values: {
+              name: 'Harry Styles'
+            }
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-2',
+          properties: {
+            id: '1234567890',
+            keys: {
+              contactKey: 'harry-2',
+              id: 'HS2'
+            },
+            values: {
+              name: 'Harry Potter'
+            }
+          }
+        })
+      ]
+
+      const response = await testDestination.executeBatch('contactDataExtension', {
+        events,
+        settings,
+        mapping
+      })
+
+      expect(response[0]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+
+      expect(response[1]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+    })
+
+    it('should mark "Unable to save rows for data extension ID" error as retryable even if SFMC returns 400', async () => {
+      const errorResponse = {
+        status: 400,
+        message: 'Invalid keys for ID: HS1',
+        additionalErrors: [
+          {
+            errorcode: 10006,
+            message: 'Unable to save rows for data extension ID'
+          }
+        ]
+      }
+
+      nock(requestUrl).post('').reply(400, errorResponse)
+
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-1',
+          properties: {
+            id: '1234567890',
+            keys: {
+              contactKey: 'harry-1',
+              id: 'HS1'
+            },
+            values: {
+              name: 'Harry Styles'
+            }
+          }
+        }),
+        createTestEvent({
+          type: 'track',
+          userId: 'harry-2',
+          properties: {
+            id: '1234567890',
+            keys: {
+              contactKey: 'harry-2',
+              id: 'HS2'
+            },
+            values: {
+              name: 'Harry Potter'
+            }
+          }
+        })
+      ]
+
+      const response = await testDestination.executeBatch('contactDataExtension', {
+        events,
+        settings,
+        mapping
+      })
+
+      expect(response[0]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
+        errorreporter: 'DESTINATION'
+      })
+
+      expect(response[1]).toMatchObject({
+        status: 500,
+        errortype: 'INTERNAL_SERVER_ERROR',
+        errormessage: 'Unable to save rows for data extension ID',
         errorreporter: 'DESTINATION'
       })
     })

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -12,7 +12,7 @@ import {
 } from '@segment/actions-core'
 import { Payload as payload_dataExtension } from './dataExtension/generated-types'
 import { Payload as payload_contactDataExtension } from './contactDataExtension/generated-types'
-import { ErrorResponse } from './types'
+import { ErrorResponse, ErrorData } from './types'
 import { OnMappingSaveInputs } from './dataExtensionV2/generated-types'
 import { Settings } from './generated-types'
 import { xml2js } from 'xml-js'
@@ -26,6 +26,21 @@ function generateRows(payloads: payload_dataExtension[] | payload_contactDataExt
     })
   })
   return rows
+}
+
+function hasError10006WithMessage(errData: ErrorData): boolean {
+  // Check main errorcode and message
+  if (errData?.errorcode === 10006 && errData?.message.includes('Unable to save rows for data extension ID')) {
+    return true
+  }
+
+  // Also check additionalErrors array if present
+  if (Array.isArray(errData?.additionalErrors)) {
+    return errData?.additionalErrors?.some(
+      (err) => err?.errorcode === 10006 && err?.message.includes('Unable to save rows for data extension ID')
+    )
+  }
+  return false
 }
 
 export function upsertRows(
@@ -141,9 +156,13 @@ export async function executeUpsertWithMultiStatus(
       err.response.data.additionalErrors.length > 0 &&
       err.response.data.additionalErrors
 
+    let status = 500 // default status is 500
+    if (!hasError10006WithMessage(errData) && err?.response?.status) {
+      status = err.response.status
+    }
     payloads.forEach((_, index) => {
       multiStatusResponse.setErrorResponseAtIndex(index, {
-        status: err?.response?.status || 500,
+        status: status,
         errormessage: additionalError ? additionalError[0].message : errData?.message || '',
         sent: rows[index] as Object as JSONLikeObject,
         /*

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -28,19 +28,13 @@ function generateRows(payloads: payload_dataExtension[] | payload_contactDataExt
   return rows
 }
 
-function hasError10006WithMessage(errData: ErrorData): boolean {
-  // Check main errorcode and message
-  if (errData?.errorcode === 10006 && errData?.message.includes('Unable to save rows for data extension ID')) {
-    return true
-  }
-
-  // Also check additionalErrors array if present
-  if (Array.isArray(errData?.additionalErrors)) {
-    return errData?.additionalErrors?.some(
-      (err) => err?.errorcode === 10006 && err?.message.includes('Unable to save rows for data extension ID')
-    )
-  }
-  return false
+function hasError10006WithMessage(errData: ErrorData, status: number): boolean {
+  return (
+    status === 400 &&
+    errData?.errorcode === 10006 &&
+    errData?.message.includes('Unable to save rows for data extension ID') &&
+    !errData?.additionalErrors
+  )
 }
 
 export function upsertRows(
@@ -157,7 +151,12 @@ export async function executeUpsertWithMultiStatus(
       err.response.data.additionalErrors
 
     let status = 500 // default status is 500
-    if (!hasError10006WithMessage(errData) && err?.response?.status) {
+    const hasAnyRetryableError = hasError10006WithMessage(errData, err?.response?.status)
+    statsContext?.statsClient?.incr('sfmc_upsert_rows_error', 1, [
+      ...statsContext.tags,
+      `retryable:${hasAnyRetryableError}`
+    ])
+    if (!hasAnyRetryableError && err?.response?.status) {
       status = err.response.status
     }
     payloads.forEach((_, index) => {

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/types.ts
@@ -4,9 +4,11 @@ interface AdditionalError {
   documentation: string
 }
 
-interface ErrorData {
+export interface ErrorData {
   additionalErrors: AdditionalError[]
   message: string
+  errorcode?: number
+  documentation?: string
 }
 
 interface ErrorResponseData {


### PR DESCRIPTION
 ## JIRA 
 
 https://twilio-engineering.atlassian.net/browse/STRATCONN-6079
<!-- Hello and thank you for contributing to Segment action-destinations! -->

_A summary of your pull request, including the what change you're making and why._

## Description 
1. This PR includes changes done for SFMC which states that if the particular error occur with 400 status code  then change status to 500 for making retryable errors

2. This change is done as per request done by JPMC and for more information please refer above jira ticket.
<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


## Testing
Please find the testing document attached here .
https://docs.google.com/document/d/129xed4lokmVEN22Hy1IY_Flc-R39djOCppaNU3TJGqc/edit?addon_store&tab=t.0

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
