### PR TITLE
[Bing Ads Audiences] Registering Bing Ads Audiences Destination

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -208,6 +208,7 @@ register('6870f42bdaad87a11d764e91', './eagleeye-audiences')
 register('6874c64e5eda096bf3850ee0', './aampe')
 register('6880c39343b2271b41970fd9', './epsilon')
 register('6888c9ea14d648263fff811d', './clay')
+register('688b65709774ffcb4af8a03b', './bing-ads-audiences')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
Registering Bing Ads Audiences Destination
## Testing
N/R
_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
