### PR TITLE
[STRATCONN-6025] - Update default batch size for S3 action

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -85,7 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'number',
       unsafe_hidden: true,
       required: false,
-      default: 170000
+      default: 50000
     },
     s3_aws_bucket_path: {
       label: 'AWS Bucket Path [optional]',


### PR DESCRIPTION
As a follow up to recent SEV we have, updating S3 action batch to be same as SFTP.

## Testing

Testing already completed in production during a SEV by updating one customers workspace. More info [here](https://docs.google.com/document/d/1nhkpd2kYGI_VZlmE3Fr4tlwZvZ9Ou3F2cTyk5C6PXo0/edit?tab=t.0).


- [] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
