### PR TITLE
NTTS-341 Add specificEvent presets to the snowflake destination for linked audiences

### DIFF
--- a/packages/warehouse-destinations/src/destinations/snowflake/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/index.ts
@@ -21,7 +21,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
 
   presets: [
     {
-      name: 'Associated Entity Added',
+      name: 'Linked Audience Entity Added',
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
@@ -31,7 +31,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       eventSlug: 'warehouse_entity_added_track'
     },
     {
-      name: 'Associated Entity Removed',
+      name: 'Linked Audience Associated Entity Removed',
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
@@ -41,7 +41,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       eventSlug: 'warehouse_entity_removed_track'
     },
     {
-      name: 'Entities Audience Entered',
+      name: 'Linked Audience Profile Entered',
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
@@ -51,8 +51,8 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       eventSlug: 'warehouse_audience_entered_track'
     },
     {
-      name: 'Entities Exited',
-      partnerAction: 'trackEvent',
+      name: 'Linked Audience Profile Exited',
+      partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
         ...defaultValues(aududienceDefaultFields)

--- a/packages/warehouse-destinations/src/destinations/snowflake/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/index.ts
@@ -1,5 +1,7 @@
 import type { WarehouseDestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
+import { defaultValues } from '@segment/actions-core'
+import aududienceDefaultFields from './sendCustomEvent/audience-default-fields'
 
 import sendCustomEvent from './sendCustomEvent'
 
@@ -16,6 +18,49 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       required: true
     }
   },
+
+  presets: [
+    {
+      name: 'Associated Entity Added',
+      partnerAction: 'sendCustomEvent',
+      mapping: {
+        ...defaultValues(sendCustomEvent.fields),
+        ...defaultValues(aududienceDefaultFields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_entity_added_track'
+    },
+    {
+      name: 'Associated Entity Removed',
+      partnerAction: 'sendCustomEvent',
+      mapping: {
+        ...defaultValues(sendCustomEvent.fields),
+        ...defaultValues(aududienceDefaultFields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_entity_removed_track'
+    },
+    {
+      name: 'Entities Audience Entered',
+      partnerAction: 'sendCustomEvent',
+      mapping: {
+        ...defaultValues(sendCustomEvent.fields),
+        ...defaultValues(aududienceDefaultFields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_entered_track'
+    },
+    {
+      name: 'Entities Exited',
+      partnerAction: 'trackEvent',
+      mapping: {
+        ...defaultValues(sendCustomEvent.fields),
+        ...defaultValues(aududienceDefaultFields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'warehouse_audience_exited_track'
+    }
+  ],
 
   actions: {
     sendCustomEvent

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/audience-default-fields.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/audience-default-fields.ts
@@ -21,7 +21,8 @@ export default {
       personas_computation_key: { '@path': '$.context.personas.computation_key' },
       personas_computation_id: { '@path': '$.context.personas.computation_id' },
       personas_computation_run_id: { '@path': '$.context.personas.computation_run_id' },
-      personas_activation_id: { '@path': '$.context.personas.event_emitter_id' }
+      personas_activation_id: { '@path': '$.context.personas.event_emitter_id' },
+      event_name: { '@path': '$.event' }
     }
   }
 }

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/audience-default-fields.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/audience-default-fields.ts
@@ -1,0 +1,27 @@
+export default {
+  // note that this must be `properties` to be processed by the warehouse pipeline
+  properties: {
+    label: 'Columns',
+    description: `Additional columns to write to Snowflake.`,
+    type: 'object',
+    defaultObjectUI: 'keyvalue',
+    required: true,
+    additionalProperties: true,
+    default: {
+      entity_context: {
+        '@json': {
+          mode: 'encode',
+          value: {
+            '@path': '$.properties.data_graph_entity_context'
+          }
+        }
+      },
+      user_id: { '@path': '$.userId' },
+      audience_key: { '@path': '$.properties.audience_key' },
+      personas_computation_key: { '@path': '$.context.personas.computation_key' },
+      personas_computation_id: { '@path': '$.context.personas.computation_id' },
+      personas_computation_run_id: { '@path': '$.context.personas.computation_run_id' },
+      personas_activation_id: { '@path': '$.context.personas.event_emitter_id' }
+    }
+  }
+}

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/generated-types.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/generated-types.ts
@@ -2,37 +2,21 @@
 
 export interface Payload {
   /**
-   * Name of column for the unique identifier for the message.
-   */
-  messageId: string
-  /**
-   * Name of the table. This will be the event name.
-   */
-  event: string
-  /**
-   * The type of event
-   */
-  type: string
-  /**
    * Additional columns to write to Snowflake.
    */
   properties: {
     [k: string]: unknown
   }
   /**
-   * Timestamp of the event
+   * Name of column for the unique identifier for the message.
    */
-  timestamp: string | number
+  messageId: string
   /**
-   * Time on the client device when call was invoked.
+   * The type of event.
    */
-  originalTimestamp: string | number
+  type: string
   /**
-   * Time on client device when call was sent.
+   * Time when event was received.
    */
-  sentAt?: string | number
-  /**
-   * Time on Segment server clock when call was received.
-   */
-  receivedAt?: string | number
+  receivedAt: string | number
 }

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/generated-types.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/generated-types.ts
@@ -2,6 +2,10 @@
 
 export interface Payload {
   /**
+   * The name of the table.
+   */
+  event: string
+  /**
    * Additional columns to write to Snowflake.
    */
   properties: {

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
@@ -40,7 +40,10 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: true,
       default: { '@path': '$.type' },
-      readOnly: true
+      readOnly: true,
+      // this is required for the warehouse pipeline to process the event,
+      // but it's removed before being sent to Snowflake
+      unsafe_hidden: true
     },
     receivedAt: {
       label: 'Received At',

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
@@ -6,6 +6,13 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Custom Event',
   description: 'Record custom events in Snowflake',
   fields: {
+    event: {
+      label: 'Table Name',
+      description: 'The name of the table.',
+      type: 'string',
+      required: true,
+      default: { '@path': '$.event' }
+    },
     // note that this must be `properties` to be processed by the warehouse pipeline
     properties: {
       label: 'Columns',

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
@@ -6,30 +6,6 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Custom Event',
   description: 'Record custom events in Snowflake',
   fields: {
-    messageId: {
-      label: 'Message ID',
-      description: 'Name of column for the unique identifier for the message.',
-      type: 'string',
-      required: true,
-      default: { '@path': '$.messageId' },
-      readOnly: true
-    },
-    event: {
-      label: 'Table Name',
-      description: 'Name of the table. This will be the event name.',
-      type: 'string',
-      required: true,
-      default: { '@path': '$.event' },
-      readOnly: true
-    },
-    type: {
-      label: 'Event Type',
-      description: 'The type of event',
-      type: 'string',
-      required: true,
-      default: { '@path': '$.type' },
-      readOnly: true
-    },
     // note that this must be `properties` to be processed by the warehouse pipeline
     properties: {
       label: 'Columns',
@@ -39,49 +15,31 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       additionalProperties: true,
       default: {
-        entity_context: {
-          '@json': {
-            mode: 'encode',
-            value: {
-              '@path': '$.properties.data_graph_entity_context'
-            }
-          }
-        },
-        user_id: { '@path': '$.userId' },
-        audience_key: { '@path': '$.properties.audience_key' },
-        personas_computation_key: { '@path': '$.context.personas.computation_key' },
-        personas_computation_id: { '@path': '$.context.personas.computation_id' },
-        personas_computationRun_id: { '@path': '$.context.personas.computation_run_id' },
-        personas_activation_id: { '@path': '$.context.personas.event_emitter_id' }
+        user_id: { '@path': '$.userId' }
       }
     },
-    // include all segment timestamp fields - https://segment.com/docs/connections/spec/common/#timestamp-overview
-    timestamp: {
-      label: 'Timestamp',
-      description: 'Timestamp of the event',
-      type: 'datetime',
+    // These are all required for data to be processed by the warehouse pipeline
+    messageId: {
+      label: 'ID',
+      description: 'Name of column for the unique identifier for the message.',
+      type: 'string',
       required: true,
-      default: { '@path': '$.timestamp' }
+      default: { '@path': '$.messageId' },
+      readOnly: true
     },
-    originalTimestamp: {
-      label: 'Original Timestamp',
-      description: 'Time on the client device when call was invoked.',
-      type: 'datetime',
+    type: {
+      label: 'Event Type',
+      description: 'The type of event.',
+      type: 'string',
       required: true,
-      default: { '@path': '$.originalTimestamp' }
-    },
-    sentAt: {
-      label: 'Sent At',
-      description: 'Time on client device when call was sent.',
-      type: 'datetime',
-      required: false,
-      default: { '@path': '$.sentAt' }
+      default: { '@path': '$.type' },
+      readOnly: true
     },
     receivedAt: {
       label: 'Received At',
-      description: 'Time on Segment server clock when call was received.',
+      description: 'Time when event was received.',
       type: 'datetime',
-      required: false,
+      required: true,
       default: { '@path': '$.receivedAt' }
     }
   },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Moves default fields to `specificEvent` linked audience presets for the snowflake warehouse destination. This is in preparation for journeys to begin using the snowflake warehouse destination as well.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
