### PR TITLE
[wip] Trims whitespace from multiline liquid functions by default

### DIFF
--- a/packages/core/src/mapping-kit/liquid-directive.ts
+++ b/packages/core/src/mapping-kit/liquid-directive.ts
@@ -3,7 +3,12 @@ import { Liquid } from 'liquidjs'
 const liquidEngine = new Liquid({
   renderLimit: 500, // 500 ms
   parseLimit: 1000, // 1000 characters. This is also enforced by us to enable a custom error message
-  memoryLimit: 1e8 // 100 MB memory
+  memoryLimit: 1e8, // 100 MB memory
+  // trim whitespace to enable users to write multi line functions
+  trimOutputLeft: true,
+  trimOutputRight: true,
+  trimTagLeft: true,
+  trimTagRight: true
 })
 
 const disabledTags = ['case', 'for', 'include', 'layout', 'render', 'tablerow']


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
