### PR TITLE
STRATCONN-6128 - fix unsubscribe list bug

### DIFF
--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
@@ -1,7 +1,7 @@
 import { RequestClient, PayloadValidationError } from '@segment/actions-core'
 
 import { Settings, AudienceSettings } from '../generated-types'
-import { Unsubscriber, Subscriber } from '../types'
+import { Unsubscriber, Subscriber, IterableSubscribePayload, IterableUnsubscribePayload } from '../types'
 import { Payload } from './generated-types'
 
 import { CONSTANTS } from '../constants'
@@ -65,30 +65,32 @@ export class IterableListsClient {
     const unSubcribeRequests = []
 
     subscribersGroup.forEach((subscribers, listId) => {
+      const json: IterableSubscribePayload = {
+        listId: Number(listId),
+        subscribers,
+        updateExistingUsersOnly: this.updateExistingUsersOnly
+      }
       subcribeRequests.push(
         this.request(`${CONSTANTS.API_BASE_URL}/lists/subscribe`, {
           method: 'post',
           skipResponseCloning: true,
-          json: {
-            listId: Number(listId),
-            subscribers,
-            updateExistingUsersOnly: this.updateExistingUsersOnly
-          }
+          json
         })
       )
     })
 
     unsubscribersGroup.forEach((subscribers, listId) => {
+      const json: IterableUnsubscribePayload = {
+        listId: Number(listId),
+        subscribers,
+        campaignId: typeof this.campaignId === 'number' ? this.campaignId : undefined,
+        channelUnsubscribe: this.globalUnsubscribe
+      }
       unSubcribeRequests.push(
         this.request(`${CONSTANTS.API_BASE_URL}/lists/unsubscribe`, {
           method: 'post',
           skipResponseCloning: true,
-          json: {
-            listId: Number(listId),
-            subscribers,
-            campaignId: typeof this.campaignId === 'number' ? this.campaignId : undefined,
-            channelUnsubscribe: this.globalUnsubscribe
-          }
+          json
         })
       )
     })

--- a/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/syncAudience/iterable-client.ts
@@ -87,7 +87,7 @@ export class IterableListsClient {
             listId: Number(listId),
             subscribers,
             campaignId: typeof this.campaignId === 'number' ? this.campaignId : undefined,
-            channelUnsubscribe: this.updateExistingUsersOnly
+            channelUnsubscribe: this.globalUnsubscribe
           }
         })
       )

--- a/packages/destination-actions/src/destinations/iterable-lists/types.ts
+++ b/packages/destination-actions/src/destinations/iterable-lists/types.ts
@@ -14,7 +14,7 @@ export interface Subscriber {
 export interface IterableUnsubscribePayload {
   listId: number
   subscribers: Array<Unsubscriber>
-  campaignId?: string
+  campaignId?: number
   channelUnsubscribe?: boolean
 }
 


### PR DESCRIPTION
This PR fixes the [bug](https://twilio-engineering.atlassian.net/browse/STRATCONN-6128) in the Iterable sync audience action.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
