### PR TITLE
Added testAuth method in TTD

### DIFF
--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/index.ts
@@ -61,6 +61,15 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         required: true,
         default: true
       }
+    },
+    testAuthentication: (request, { settings }) => {
+      return request(`${BASE_URL}/crmdata/segment/${settings.advertiser_id}`, {
+        method: 'GET',
+        headers: {
+          'TTD-Auth': settings.auth_token,
+          'Content-Type': 'application/json'
+        }
+      })
     }
   },
   extendRequest({ settings }) {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->
[JIRA](https://twilio-engineering.atlassian.net/browse/STRATCONN-6117)
Adding a `testAuthentication` method for the TTD pipeline using the method from the actions destinations repo to filter out invalid users early and prevent late-stage errors. This will reduce unnecessary processing and improve error handling.
This method gets triggered when user hits the `save changes` button in the UI.

## Testing

Earlier when we hit the `save` button credentials got saved without any validations. 
<img width="2552" height="900" alt="image" src="https://github.com/user-attachments/assets/6eb6f626-8dd1-4051-8f02-28b812913a41" />

Now, an error message is popped up if the credentials are invalid.
<img width="1887" height="886" alt="Screenshot 2025-08-14 at 4 11 44 PM" src="https://github.com/user-attachments/assets/6a7d3d91-66ea-4131-bda6-24c1136b93bd" />

With the correct credentials:
<img width="2560" height="1117" alt="Screenshot 2025-08-14 at 4 17 10 PM" src="https://github.com/user-attachments/assets/9380e1ff-70a7-4181-bfec-815648d677c6" />




- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
