### PR TITLE
Marks newer browser destination packages as public packages

### DIFF
--- a/packages/browser-destinations/destinations/evolv-ai/package.json
+++ b/packages/browser-destinations/destinations/evolv-ai/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/browser-destinations/destinations/evolv-ai"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "main": "./dist/cjs",
   "module": "./dist/esm",
   "scripts": {

--- a/packages/browser-destinations/destinations/facebook-conversions-api-web/package.json
+++ b/packages/browser-destinations/destinations/facebook-conversions-api-web/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/browser-destinations/destinations/facebook-conversions-api-web"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "main": "./dist/cjs",
   "module": "./dist/esm",
   "scripts": {

--- a/packages/cli/templates/destinations/browser/package.json
+++ b/packages/cli/templates/destinations/browser/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/browser-destinations/destinations/{{slugWithoutActions}}"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "main": "./dist/cjs",
   "module": "./dist/esm",
   "scripts": {


### PR DESCRIPTION
This pull request adds a `publishConfig` section to the `package.json` files for several browser destinations and the browser destination template. This change ensures that these packages are published publicly to the npm registry.

Publishing configuration updates:

* Added `publishConfig` with `"access": "public"` and the npm registry URL to `packages/browser-destinations/destinations/evolv-ai/package.json` to enable public publishing.
* Added `publishConfig` with `"access": "public"` and the npm registry URL to `packages/browser-destinations/destinations/facebook-conversions-api-web/package.json` to enable public publishing.
* Added `publishConfig` with `"access": "public"` and the npm registry URL to the browser destination template in `packages/cli/templates/destinations/browser/package.json`, ensuring new destinations use the correct publish settings.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
