### PR TITLE
[liquid metrics ] Adds items from Subscription object to tags

### DIFF
--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -726,7 +726,15 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     const isBatch = Array.isArray(events)
 
     if (options?.statsContext?.tags !== undefined) {
-      options.statsContext.tags = [...options.statsContext.tags, `partnerAction:${subscription.partnerAction}`]
+      options.statsContext.tags = [
+        ...options.statsContext.tags,
+        `partnerAction:${subscription.partnerAction}`,
+        `actionId:${subscription.ActionID}`,
+        `configId:${subscription.ConfigID}`,
+        `projectId:${subscription.ProjectID}`,
+        `subscriptionName:${subscription.name}`,
+        `subscriptionSubscribe:${subscription.subscribe}`
+      ]
     }
 
     const subscriptionStartedAt = time()


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR adds new tags to the metrics tracked for Liquid Functions, including the projectId to narrow down metrics to users. This is a followup to https://github.com/segmentio/action-destinations/pull/3024

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

Successfully tested in staging - the tags come back as expected:
<img width="1070" height="769" alt="Screenshot 2025-08-18 at 10 01 56 AM" src="https://github.com/user-attachments/assets/fdf96ef7-d608-42e5-9aa3-7ec8694e817a" />



- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
