### PR TITLE
Add carrayforward setup in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,3 +21,41 @@ coverage:
       default:
         target: 80%
         informational: false
+
+# Define flags for different parts of the codebase
+flags:
+  # Core packages
+  core:
+    paths:
+      - packages/core/**/*
+    carryforward: true
+
+  actions-shared:
+    paths:
+      - packages/actions-shared/**/*
+    carryforward: true
+
+  destination-actions:
+    paths:
+      - packages/destination-actions/**/*
+    carryforward: true
+
+  browser-destinations:
+    paths:
+      - packages/browser-destinations/**/*
+    carryforward: true
+
+  ajv-human-errors:
+    paths:
+      - packages/ajv-human-errors/**/*
+    carryforward: true
+
+  destination-subscriptions:
+    paths:
+      - packages/destination-subscriptions/**/*
+    carryforward: true
+
+  destinations-manifest:
+    paths:
+      - packages/destinations-manifest/**/*
+    carryforward: true


### PR DESCRIPTION
This pull request updates the `codecov.yml` configuration to improve coverage tracking across different parts of the codebase. The main change is the introduction of flags that allow code coverage to be reported separately for key package groups, making it easier to monitor and maintain coverage standards for each area.

Coverage configuration improvements:

* Added `flags` section to `codecov.yml` to track coverage for core packages and several sub-packages, including `core`, `actions-shared`, `destination-actions`, `browser-destinations`, `ajv-human-errors`, `destination-subscriptions`, and `destinations-manifest`. Each flag defines its relevant paths and enables coverage carryforward.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
