### PR TITLE
@segment/analytics browser actions fullsession@1.0.0

### DIFF
--- a/packages/browser-destinations/destinations/fullsession/README.md
+++ b/packages/browser-destinations/destinations/fullsession/README.md
@@ -1,0 +1,31 @@
+# @segment/analytics-browser-{{slug}}
+
+The {{name}} browser action destination for use with @segment/analytics-next.
+
+## License
+
+MIT License
+
+Copyright (c) 2025 Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Contributing
+
+All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

--- a/packages/browser-destinations/destinations/fullsession/README.md
+++ b/packages/browser-destinations/destinations/fullsession/README.md
@@ -1,6 +1,6 @@
-# @segment/analytics-browser-{{slug}}
+# @segment/analytics-browser-actions-fullsession
 
-The {{name}} browser action destination for use with @segment/analytics-next.
+The FullSession browser action destination for use with @segment/analytics-next.
 
 ## License
 

--- a/packages/browser-destinations/destinations/fullsession/package.json
+++ b/packages/browser-destinations/destinations/fullsession/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@segment/analytics-browser-actions-fullsession",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/fullsession"
+  },
+  "main": "./dist/cjs",
+  "module": "./dist/esm",
+  "scripts": {
+    "build": "yarn build:esm && yarn build:cjs",
+    "build:cjs": "tsc --module commonjs --outDir ./dist/cjs",
+    "build:esm": "tsc --outDir ./dist/esm"
+  },
+  "typings": "./dist/esm",
+  "dependencies": {
+    "@segment/browser-destination-runtime": "^1.4.0",
+    "fullsession": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@segment/analytics-next": ">=1.55.0"
+  }
+}

--- a/packages/browser-destinations/destinations/fullsession/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/__tests__/index.test.ts
@@ -136,7 +136,7 @@ describe('FullSession (actions)', () => {
   }, 10000) // Increase timeout to 10 seconds
 
   test('has correct presets configured', () => {
-    expect(destination.presets).toHaveLength(2)
+    expect(destination.presets).toHaveLength(3)
 
     const identifyPreset = destination.presets?.find((p) => p.name === 'Identify User')
     expect(identifyPreset).toBeDefined()
@@ -145,6 +145,10 @@ describe('FullSession (actions)', () => {
     const trackPreset = destination.presets?.find((p) => p.name === 'Record Event')
     expect(trackPreset).toBeDefined()
     expect(trackPreset?.partnerAction).toBe('recordEvent')
+
+    const pagePreset = destination.presets?.find((p) => p.name === 'Visit Page')
+    expect(pagePreset).toBeDefined()
+    expect(pagePreset?.partnerAction).toBe('visitPage')
   })
 
   test('has required settings defined', () => {

--- a/packages/browser-destinations/destinations/fullsession/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/__tests__/index.test.ts
@@ -1,0 +1,173 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+import fullSessionDestination, { destination } from '../index'
+
+// Mock the browser destination runtime functions
+jest.mock('@segment/browser-destination-runtime/load-script', () => ({
+  loadScript: (_src: any, _attributes: any) => Promise.resolve()
+}))
+
+jest.mock('@segment/browser-destination-runtime/resolve-when', () => ({
+  resolveWhen: (_fn: any, _timeout: any) => Promise.resolve()
+}))
+
+// Mock the fullsession package
+jest.mock('fullsession', () => ({
+  fullSessionTracker: {
+    initialize: jest.fn(),
+    identify: jest.fn(),
+    setSessionAttributes: jest.fn(),
+    event: jest.fn()
+  }
+}))
+
+// Setup a more complete mock environment
+const mockWorkerAndXMLHttpRequest = () => {
+  // @ts-ignore
+  global.Worker = class Worker {
+    constructor(stringUrl: string) {
+      // @ts-ignore
+      this.url = stringUrl
+      // @ts-ignore
+      this.onmessage = () => {}
+    }
+
+    postMessage() {
+      return {}
+    }
+  }
+
+  // @ts-ignore
+  global.XMLHttpRequest = class XMLHttpRequest {
+    open() {
+      return {}
+    }
+    send() {
+      return {}
+    }
+    setRequestHeader() {
+      return {}
+    }
+  }
+}
+
+const subscriptions: Subscription[] = [
+  {
+    partnerAction: 'identifyUser',
+    name: 'Identify User',
+    enabled: true,
+    subscribe: 'type = "identify"',
+    mapping: {
+      userId: {
+        '@path': '$.userId'
+      },
+      anonymousId: {
+        '@path': '$.anonymousId'
+      },
+      name: {
+        '@path': '$.traits.name'
+      },
+      email: {
+        '@path': '$.traits.email'
+      },
+      traits: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  {
+    partnerAction: 'recordEvent',
+    name: 'Record Event',
+    enabled: true,
+    subscribe: 'type = "track"',
+    mapping: {
+      name: {
+        '@path': '$.event'
+      },
+      properties: {
+        '@path': '$.properties'
+      }
+    }
+  }
+]
+
+describe('FullSession (actions)', () => {
+  const mockCustomerId = 'test-customer-id'
+
+  beforeAll(() => {
+    mockWorkerAndXMLHttpRequest()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Setup window.FUS mock if needed
+    if (typeof window !== 'undefined') {
+      // @ts-ignore
+      window.FUS = {}
+    }
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('loads FullSession with customerId', async () => {
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: subscriptions as any
+    })
+
+    jest.spyOn(destination, 'initialize')
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(destination.initialize).toHaveBeenCalled()
+  }, 10000) // Increase timeout to 10 seconds
+
+  test('initializes FullSession tracker with correct customer ID', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: subscriptions as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+    expect(fullSessionTracker.initialize).toHaveBeenCalledWith(mockCustomerId)
+  }, 10000) // Increase timeout to 10 seconds
+
+  test('has correct presets configured', () => {
+    expect(destination.presets).toHaveLength(2)
+
+    const identifyPreset = destination.presets?.find((p) => p.name === 'Identify User')
+    expect(identifyPreset).toBeDefined()
+    expect(identifyPreset?.partnerAction).toBe('identifyUser')
+
+    const trackPreset = destination.presets?.find((p) => p.name === 'Record Event')
+    expect(trackPreset).toBeDefined()
+    expect(trackPreset?.partnerAction).toBe('recordEvent')
+  })
+
+  test('has required settings defined', () => {
+    expect(destination.settings).toBeDefined()
+    expect(destination.settings?.customerId).toBeDefined()
+    expect(destination.settings?.customerId.required).toBe(true)
+    expect(destination.settings?.customerId.type).toBe('string')
+  })
+
+  test('has correct actions defined', () => {
+    expect(destination.actions.identifyUser).toBeDefined()
+    expect(destination.actions.recordEvent).toBeDefined()
+  })
+
+  test('destination mode is device', () => {
+    expect(destination.mode).toBe('device')
+  })
+
+  test('destination name is FullSession', () => {
+    expect(destination.name).toBe('FullSession')
+  })
+
+  test('destination slug is actions-fullsession', () => {
+    expect(destination.slug).toBe('actions-fullsession')
+  })
+})

--- a/packages/browser-destinations/destinations/fullsession/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The Customer ID for FullSession.
+   */
+  customerId: string
+}

--- a/packages/browser-destinations/destinations/fullsession/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * The Customer ID for FullSession.
+   * Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .
    */
   customerId: string
 }

--- a/packages/browser-destinations/destinations/fullsession/src/identifyUser/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/identifyUser/__tests__/index.test.ts
@@ -1,0 +1,305 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import fullSessionDestination from '../../index'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+
+// Mock the browser destination runtime functions
+jest.mock('@segment/browser-destination-runtime/load-script', () => ({
+  loadScript: (_src: any, _attributes: any) => Promise.resolve()
+}))
+
+jest.mock('@segment/browser-destination-runtime/resolve-when', () => ({
+  resolveWhen: (_fn: any, _timeout: any) => Promise.resolve()
+}))
+
+// Mock the fullsession package
+jest.mock('fullsession', () => ({
+  fullSessionTracker: {
+    initialize: jest.fn(),
+    identify: jest.fn(),
+    setSessionAttributes: jest.fn(),
+    event: jest.fn()
+  }
+}))
+
+const identifySubscription: Subscription = {
+  partnerAction: 'identifyUser',
+  name: 'Identify User',
+  enabled: true,
+  subscribe: 'type = "identify"',
+  mapping: {
+    userId: {
+      '@path': '$.userId'
+    },
+    anonymousId: {
+      '@path': '$.anonymousId'
+    },
+    name: {
+      '@path': '$.traits.name'
+    },
+    email: {
+      '@path': '$.traits.email'
+    },
+    traits: {
+      '@path': '$.traits'
+    }
+  }
+}
+
+describe('FullSession identifyUser action', () => {
+  const mockCustomerId = 'test-customer-id'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Setup window.FUS mock if needed
+    if (typeof window !== 'undefined') {
+      // @ts-ignore
+      window.FUS = {}
+    }
+  })
+
+  test('should identify user with userId and basic traits', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123',
+        traits: {
+          name: 'John Doe',
+          email: 'john@example.com'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: 'John Doe',
+      email: 'john@example.com'
+    })
+
+    // No additional traits to set as session attributes
+    expect(fullSessionTracker.setSessionAttributes).not.toHaveBeenCalled()
+  })
+
+  test('should identify user with userId and additional traits', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123',
+        traits: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          company: 'Test Corp',
+          role: 'Developer',
+          age: 30
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: 'John Doe',
+      email: 'john@example.com'
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      company: 'Test Corp',
+      role: 'Developer',
+      age: 30
+    })
+  })
+
+  test('should identify user with anonymousId when userId is not present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        anonymousId: 'anon123',
+        traits: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          company: 'Test Corp'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('anon123', {
+      name: 'Jane Doe',
+      email: 'jane@example.com'
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      company: 'Test Corp',
+      segmentAnonymousId: 'anon123'
+    })
+  })
+
+  test('should prefer userId over anonymousId when both are present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123',
+        anonymousId: 'anon123',
+        traits: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          company: 'Test Corp'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: 'John Doe',
+      email: 'john@example.com'
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      company: 'Test Corp',
+      segmentAnonymousId: 'anon123'
+    })
+  })
+
+  test('should handle empty or missing name and email', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123',
+        traits: {
+          company: 'Test Corp'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: '',
+      email: ''
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      company: 'Test Corp'
+    })
+  })
+
+  test('should not call identify when neither userId nor anonymousId is present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        traits: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          company: 'Test Corp'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).not.toHaveBeenCalled()
+    // Should still set session attributes for additional traits
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      company: 'Test Corp'
+    })
+  })
+
+  test('should not call setSessionAttributes when only name and email are present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123',
+        traits: {
+          name: 'John Doe',
+          email: 'john@example.com'
+        }
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: 'John Doe',
+      email: 'john@example.com'
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).not.toHaveBeenCalled()
+  })
+
+  test('should handle null or undefined traits', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [identifySubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    await event.identify?.(
+      new Context({
+        type: 'identify',
+        userId: 'user123'
+        // traits is undefined
+      })
+    )
+
+    expect(fullSessionTracker.identify).toHaveBeenCalledWith('user123', {
+      name: '',
+      email: ''
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).not.toHaveBeenCalled()
+  })
+})

--- a/packages/browser-destinations/destinations/fullsession/src/identifyUser/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/identifyUser/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId?: string
+  /**
+   * The user's anonymous id
+   */
+  anonymousId?: string
+  /**
+   * The user's name
+   */
+  name?: string
+  /**
+   * The user's email
+   */
+  email?: string
+  /**
+   * The Segment traits to be forwarded to FullSession
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullsession/src/identifyUser/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/identifyUser/generated-types.ts
@@ -2,23 +2,15 @@
 
 export interface Payload {
   /**
-   * The user's id
+   * The user's unique identifier.
    */
   userId?: string
   /**
-   * The user's anonymous id
+   * The user's anonymous identifier when no user ID is available.
    */
   anonymousId?: string
   /**
-   * The user's name
-   */
-  name?: string
-  /**
-   * The user's email
-   */
-  email?: string
-  /**
-   * The Segment traits to be forwarded to FullSession
+   * User traits and properties to be sent to FullSession.
    */
   traits?: {
     [k: string]: unknown

--- a/packages/browser-destinations/destinations/fullsession/src/identifyUser/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/identifyUser/index.ts
@@ -1,0 +1,90 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { FUS } from '../types'
+
+const action: BrowserActionDefinition<Settings, FUS, Payload> = {
+  title: 'Identify User',
+  description: 'Describe your users',
+  platform: 'web',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: false,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: false,
+      description: "The user's anonymous id",
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    name: {
+      type: 'string',
+      required: false,
+      description: "The user's name",
+      label: 'Name',
+      default: {
+        '@path': '$.traits.name'
+      }
+    },
+    email: {
+      type: 'string',
+      required: false,
+      description: "The user's email",
+      label: 'Email',
+      default: {
+        '@path': '$.traits.email'
+      }
+    },
+    traits: {
+      type: 'object',
+      required: false,
+      description: 'The Segment traits to be forwarded to FullSession',
+      label: 'Traits',
+      default: {
+        '@path': '$.traits'
+      }
+    }
+  },
+  perform: (FUS, data) => {
+    const { userId, anonymousId, name, email, traits = {} } = data.payload
+
+    // Build the user traits object for identify
+    const identifyTraits = {
+      name: name ?? '',
+      email: email ?? ''
+    }
+
+    // Only call identify if we have a userId or anonymousId
+    if (userId) {
+      FUS.identify(userId, identifyTraits)
+    } else if (anonymousId) {
+      FUS.identify(anonymousId, identifyTraits)
+    }
+
+    // Remove name and email from traits before sending to setSessionAttributes
+    const { name: _ignoredName, email: _ignoredEmail, ...restTraits } = traits || {}
+
+    // Build session attributes
+    const sessionAttributes = {
+      ...restTraits,
+      ...(anonymousId ? { segmentAnonymousId: anonymousId } : {})
+    }
+
+    // Only call if we have something to set
+    if (Object.keys(sessionAttributes).length > 0) {
+      FUS.setSessionAttributes(sessionAttributes)
+    }
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/fullsession/src/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/index.ts
@@ -8,7 +8,7 @@ import { defaultValues } from '@segment/actions-core'
 
 import recordEvent from './recordEvent'
 
-// import visitPage from './visitPage'
+import visitPage from './visitPage'
 
 declare global {
   interface Window {
@@ -32,13 +32,13 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
       subscribe: 'type = "track"',
       partnerAction: 'recordEvent',
       mapping: defaultValues(recordEvent.fields)
+    },
+    {
+      name: 'Visit Page',
+      subscribe: 'type = "page"',
+      partnerAction: 'visitPage',
+      mapping: defaultValues(visitPage.fields)
     }
-    // {
-    //   name: 'Visit Page',
-    //   subscribe: 'type = "page"',
-    //   partnerAction: 'visitPage',
-    //   mapping: defaultValues(visitPage.fields)
-    // }
   ],
   settings: {
     customerId: {
@@ -57,8 +57,8 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
 
   actions: {
     identifyUser,
-    recordEvent
-    // visitPage
+    recordEvent,
+    visitPage
   }
 }
 

--- a/packages/browser-destinations/destinations/fullsession/src/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/index.ts
@@ -1,0 +1,65 @@
+import type { Settings } from './generated-types'
+import type { BrowserDestinationDefinition } from '@segment/browser-destination-runtime/types'
+import { browserDestination } from '@segment/browser-destination-runtime/shim'
+import type { FUS } from './types'
+import { fullSessionTracker } from './types'
+import identifyUser from './identifyUser'
+import { defaultValues } from '@segment/actions-core'
+
+import recordEvent from './recordEvent'
+
+// import visitPage from './visitPage'
+
+declare global {
+  interface Window {
+    FUS: FUS
+  }
+}
+// Switch from unknown to the partner SDK client types
+export const destination: BrowserDestinationDefinition<Settings, FUS> = {
+  name: 'FullSession',
+  slug: 'actions-fullsession',
+  mode: 'device',
+  presets: [
+    {
+      name: 'Identify User',
+      subscribe: 'type = "identify"',
+      partnerAction: 'identifyUser',
+      mapping: defaultValues(identifyUser.fields)
+    },
+    {
+      name: 'Record Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'recordEvent',
+      mapping: defaultValues(recordEvent.fields)
+    }
+    // {
+    //   name: 'Visit Page',
+    //   subscribe: 'type = "page"',
+    //   partnerAction: 'visitPage',
+    //   mapping: defaultValues(visitPage.fields)
+    // }
+  ],
+  settings: {
+    customerId: {
+      description: 'The Customer ID for FullSession.',
+      label: 'FullSession Customer',
+      type: 'string',
+      required: true
+    }
+  },
+
+  initialize: async ({ settings }, deps) => {
+    fullSessionTracker.initialize(settings.customerId)
+    await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'FUS'), 1000)
+    return fullSessionTracker
+  },
+
+  actions: {
+    identifyUser,
+    recordEvent
+    // visitPage
+  }
+}
+
+export default browserDestination(destination)

--- a/packages/browser-destinations/destinations/fullsession/src/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/index.ts
@@ -25,19 +25,22 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
       name: 'Identify User',
       subscribe: 'type = "identify"',
       partnerAction: 'identifyUser',
-      mapping: defaultValues(identifyUser.fields)
+      mapping: defaultValues(identifyUser.fields),
+      type: 'automatic'
     },
     {
       name: 'Record Event',
       subscribe: 'type = "track"',
       partnerAction: 'recordEvent',
-      mapping: defaultValues(recordEvent.fields)
+      mapping: defaultValues(recordEvent.fields),
+      type: 'automatic'
     },
     {
       name: 'Visit Page',
       subscribe: 'type = "page"',
       partnerAction: 'visitPage',
-      mapping: defaultValues(visitPage.fields)
+      mapping: defaultValues(visitPage.fields),
+      type: 'automatic'
     }
   ],
   settings: {

--- a/packages/browser-destinations/destinations/fullsession/src/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/index.ts
@@ -29,14 +29,14 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
       type: 'automatic'
     },
     {
-      name: 'Record Event',
+      name: 'Track Event',
       subscribe: 'type = "track"',
       partnerAction: 'recordEvent',
       mapping: defaultValues(recordEvent.fields),
       type: 'automatic'
     },
     {
-      name: 'Visit Page',
+      name: 'Page View',
       subscribe: 'type = "page"',
       partnerAction: 'visitPage',
       mapping: defaultValues(visitPage.fields),
@@ -45,8 +45,8 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
   ],
   settings: {
     customerId: {
-      description: 'The Customer ID for FullSession.',
-      label: 'FullSession Customer',
+      description: 'Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .',
+      label: 'Customer ID',
       type: 'string',
       required: true
     }

--- a/packages/browser-destinations/destinations/fullsession/src/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/index.ts
@@ -29,14 +29,14 @@ export const destination: BrowserDestinationDefinition<Settings, FUS> = {
       type: 'automatic'
     },
     {
-      name: 'Track Event',
+      name: 'Record Event',
       subscribe: 'type = "track"',
       partnerAction: 'recordEvent',
       mapping: defaultValues(recordEvent.fields),
       type: 'automatic'
     },
     {
-      name: 'Page View',
+      name: 'Visit Page',
       subscribe: 'type = "page"',
       partnerAction: 'visitPage',
       mapping: defaultValues(visitPage.fields),

--- a/packages/browser-destinations/destinations/fullsession/src/recordEvent/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/recordEvent/__tests__/index.test.ts
@@ -1,0 +1,274 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import fullSessionDestination from '../../index'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+
+// Mock the browser destination runtime functions
+jest.mock('@segment/browser-destination-runtime/load-script', () => ({
+  loadScript: (_src: any, _attributes: any) => Promise.resolve()
+}))
+
+jest.mock('@segment/browser-destination-runtime/resolve-when', () => ({
+  resolveWhen: (_fn: any, _timeout: any) => Promise.resolve()
+}))
+
+// Mock the fullsession package
+jest.mock('fullsession', () => ({
+  fullSessionTracker: {
+    initialize: jest.fn(),
+    identify: jest.fn(),
+    setSessionAttributes: jest.fn(),
+    event: jest.fn()
+  }
+}))
+
+const trackSubscription: Subscription = {
+  partnerAction: 'recordEvent',
+  name: 'Record Event',
+  enabled: true,
+  subscribe: 'type = "track"',
+  mapping: {
+    name: {
+      '@path': '$.event'
+    },
+    properties: {
+      '@path': '$.properties'
+    }
+  }
+}
+
+describe('FullSession recordEvent action', () => {
+  const mockCustomerId = 'test-customer-id'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Setup window.FUS mock if needed
+    if (typeof window !== 'undefined') {
+      // @ts-ignore
+      window.FUS = {}
+    }
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should record event with name and properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Product Purchased'
+    const properties = {
+      product_id: 'ABC123',
+      product_name: 'Widget',
+      price: 29.99,
+      currency: 'USD',
+      category: 'Electronics'
+    }
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, properties)
+  })
+
+  test('should record event with only name', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Simple Event'
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, {})
+  })
+
+  test('should record event with string and number properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Page View'
+    const properties = {
+      page_url: 'https://example.com/product/123',
+      page_title: 'Product Details',
+      load_time: 1.5,
+      session_id: 'sess_123',
+      user_count: 42
+    }
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, properties)
+  })
+
+  test('should handle empty properties object', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Button Clicked'
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties: {}
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, {})
+  })
+
+  test('should handle null properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Null Properties Event'
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties: undefined
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, {})
+  })
+
+  test('should record multiple events in sequence', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    // First event
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: 'Event 1',
+        properties: { prop1: 'value1' }
+      })
+    )
+
+    // Second event
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: 'Event 2',
+        properties: { prop2: 'value2', count: 10 }
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledTimes(2)
+    expect(fullSessionTracker.event).toHaveBeenNthCalledWith(1, 'Event 1', { prop1: 'value1' })
+    expect(fullSessionTracker.event).toHaveBeenNthCalledWith(2, 'Event 2', { prop2: 'value2', count: 10 })
+  })
+
+  test('should record event with mixed property types', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Mixed Properties Event'
+    const properties = {
+      string_prop: 'test string',
+      number_prop: 123.45,
+      boolean_prop: true,
+      array_prop: [1, 2, 3],
+      object_prop: { nested: 'value' },
+      null_prop: null,
+      undefined_prop: undefined
+    }
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, properties)
+  })
+
+  test('should handle event with special characters in name', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [trackSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const eventName = 'Event with Special Characters! @#$%^&*()'
+    const properties = {
+      special_chars: 'åäöüñ',
+      unicode: '🎉🚀'
+    }
+
+    await event.track?.(
+      new Context({
+        type: 'track',
+        event: eventName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.event).toHaveBeenCalledWith(eventName, properties)
+  })
+})

--- a/packages/browser-destinations/destinations/fullsession/src/recordEvent/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/recordEvent/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object with information about the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullsession/src/recordEvent/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/recordEvent/generated-types.ts
@@ -2,11 +2,11 @@
 
 export interface Payload {
   /**
-   * The name of the event.
+   * The name of the event being tracked.
    */
   name: string
   /**
-   * A JSON object with information about the event.
+   * Additional properties and metadata associated with the event.
    */
   properties?: {
     [k: string]: unknown

--- a/packages/browser-destinations/destinations/fullsession/src/recordEvent/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/recordEvent/index.ts
@@ -1,0 +1,43 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { FUS } from '../types'
+
+type LocalCustomEventData = {
+  [key: string]: string | number
+  [stringKey: `${string}_str`]: string
+  [numberKey: `${string}_real`]: number
+}
+
+const action: BrowserActionDefinition<Settings, FUS, Payload> = {
+  title: 'Record Event',
+  description: 'Send an event to FullSession',
+  platform: 'web',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object with information about the event.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (FUS, data) => {
+    const { name, properties } = data.payload
+    FUS.event(name, (properties ?? {}) as LocalCustomEventData)
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/fullsession/src/recordEvent/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/recordEvent/index.ts
@@ -1,23 +1,17 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import type { FUS } from '../types'
-
-type LocalCustomEventData = {
-  [key: string]: string | number
-  [stringKey: `${string}_str`]: string
-  [numberKey: `${string}_real`]: number
-}
+import type { FUS, CustomEventData } from '../types'
 
 const action: BrowserActionDefinition<Settings, FUS, Payload> = {
-  title: 'Record Event',
-  description: 'Send an event to FullSession',
+  title: 'Track Event',
+  description: 'Track custom events and user interactions in FullSession for behavioral analysis.',
   platform: 'web',
   defaultSubscription: 'type = "track"',
   fields: {
     name: {
-      description: 'The name of the event.',
-      label: 'Name',
+      description: 'The name of the event being tracked.',
+      label: 'Event Name',
       required: true,
       type: 'string',
       default: {
@@ -25,8 +19,8 @@ const action: BrowserActionDefinition<Settings, FUS, Payload> = {
       }
     },
     properties: {
-      description: 'A JSON object with information about the event.',
-      label: 'Properties',
+      description: 'Additional properties and metadata associated with the event.',
+      label: 'Event Properties',
       required: false,
       type: 'object',
       default: {
@@ -36,7 +30,7 @@ const action: BrowserActionDefinition<Settings, FUS, Payload> = {
   },
   perform: (FUS, data) => {
     const { name, properties } = data.payload
-    FUS.event(name, (properties ?? {}) as LocalCustomEventData)
+    FUS.event(name, (properties ?? {}) as CustomEventData)
   }
 }
 

--- a/packages/browser-destinations/destinations/fullsession/src/types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/types.ts
@@ -1,0 +1,4 @@
+import { fullSessionTracker } from 'fullsession'
+
+export type FUS = typeof fullSessionTracker
+export { fullSessionTracker }

--- a/packages/browser-destinations/destinations/fullsession/src/types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/types.ts
@@ -1,4 +1,14 @@
 import { fullSessionTracker } from 'fullsession'
 
+type CustomEventData = {
+  [key: string]: string | number
+  [stringKey: `${string}_str`]: string
+  [numberKey: `${string}_real`]: number
+}
+
+type UserCustomAttributes = {
+  [attribute: string]: string
+}
+
 export type FUS = typeof fullSessionTracker
-export { fullSessionTracker }
+export { fullSessionTracker, CustomEventData, UserCustomAttributes }

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/__tests__/index.test.ts
@@ -16,7 +16,7 @@ jest.mock('fullsession', () => ({
   fullSessionTracker: {
     initialize: jest.fn(),
     identify: jest.fn(),
-    setSessionAttributes: jest.fn(),
+    setPageAttributes: jest.fn(),
     event: jest.fn()
   }
 }))
@@ -27,13 +27,6 @@ const pageSubscription: Subscription = {
   enabled: true,
   subscribe: 'type = "page"',
   mapping: {
-    name: {
-      '@if': {
-        exists: { '@path': '$.category' },
-        then: { '@path': '$.category' },
-        else: { '@path': '$.name' }
-      }
-    },
     properties: {
       '@path': '$.properties'
     }
@@ -52,7 +45,7 @@ describe('FullSession visitPage action', () => {
     }
   })
 
-  test('should set session attributes with page name and properties', async () => {
+  test('should set session attributes with page properties', async () => {
     const { fullSessionTracker } = await import('fullsession')
 
     const [event] = await fullSessionDestination({
@@ -62,7 +55,6 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Home Page'
     const properties = {
       title: 'Welcome to Our Site',
       url: 'https://example.com',
@@ -74,18 +66,17 @@ describe('FullSession visitPage action', () => {
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'Home Page',
         properties
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })
 
-  test('should use category as name when present', async () => {
+  test('should handle page with category and properties', async () => {
     const { fullSessionTracker } = await import('fullsession')
 
     const [event] = await fullSessionDestination({
@@ -95,8 +86,6 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Product Details'
-    const category = 'Products'
     const properties = {
       title: 'Amazing Product',
       url: 'https://example.com/products/amazing-product',
@@ -106,20 +95,18 @@ describe('FullSession visitPage action', () => {
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
-        category: category,
+        name: 'Product Details',
+        category: 'Products',
         properties
       })
     )
 
-    // Should use category as name when present
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: category,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })
 
-  test('should use page name when category is not present', async () => {
+  test('should handle page with properties', async () => {
     const { fullSessionTracker } = await import('fullsession')
 
     const [event] = await fullSessionDestination({
@@ -129,7 +116,6 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'About Us'
     const properties = {
       title: 'About Our Company',
       url: 'https://example.com/about',
@@ -139,13 +125,12 @@ describe('FullSession visitPage action', () => {
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'About Us',
         properties
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })
@@ -160,19 +145,15 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Simple Page'
-
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'Simple Page',
         properties: {}
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName
-    })
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({})
   })
 
   test('should handle page with null properties', async () => {
@@ -185,19 +166,15 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Null Properties Page'
-
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'Null Properties Page',
         properties: undefined
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName
-    })
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({})
   })
 
   test('should handle page without name and category', async () => {
@@ -223,8 +200,7 @@ describe('FullSession visitPage action', () => {
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: undefined,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })
@@ -239,7 +215,6 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Complex Page'
     const properties = {
       title: 'Complex Page Title',
       url: 'https://example.com/complex',
@@ -257,13 +232,12 @@ describe('FullSession visitPage action', () => {
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'Complex Page',
         properties
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })
@@ -287,8 +261,7 @@ describe('FullSession visitPage action', () => {
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: 'Home',
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       url: 'https://example.com'
     })
 
@@ -301,15 +274,14 @@ describe('FullSession visitPage action', () => {
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: 'Products',
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       url: 'https://example.com/products'
     })
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledTimes(2)
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledTimes(2)
   })
 
-  test('should handle page visit with special characters in name and properties', async () => {
+  test('should handle page visit with special characters in properties', async () => {
     const { fullSessionTracker } = await import('fullsession')
 
     const [event] = await fullSessionDestination({
@@ -319,7 +291,6 @@ describe('FullSession visitPage action', () => {
 
     await event.load(Context.system(), {} as Analytics)
 
-    const pageName = 'Page with "Special" Characters & Symbols'
     const properties = {
       title: 'Title with émojis 🚀 and symbols!',
       url: 'https://example.com/special-chars?q=test&lang=en',
@@ -329,13 +300,12 @@ describe('FullSession visitPage action', () => {
     await event.page?.(
       new Context({
         type: 'page',
-        name: pageName,
+        name: 'Page with "Special" Characters & Symbols',
         properties
       })
     )
 
-    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
-      name: pageName,
+    expect(fullSessionTracker.setPageAttributes).toHaveBeenCalledWith({
       ...properties
     })
   })

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/__tests__/index.test.ts
@@ -1,0 +1,342 @@
+import { Analytics, Context } from '@segment/analytics-next'
+import fullSessionDestination from '../../index'
+import { Subscription } from '@segment/browser-destination-runtime/types'
+
+// Mock the browser destination runtime functions
+jest.mock('@segment/browser-destination-runtime/load-script', () => ({
+  loadScript: (_src: any, _attributes: any) => Promise.resolve()
+}))
+
+jest.mock('@segment/browser-destination-runtime/resolve-when', () => ({
+  resolveWhen: (_fn: any, _timeout: any) => Promise.resolve()
+}))
+
+// Mock the fullsession package
+jest.mock('fullsession', () => ({
+  fullSessionTracker: {
+    initialize: jest.fn(),
+    identify: jest.fn(),
+    setSessionAttributes: jest.fn(),
+    event: jest.fn()
+  }
+}))
+
+const pageSubscription: Subscription = {
+  partnerAction: 'visitPage',
+  name: 'Visit Page',
+  enabled: true,
+  subscribe: 'type = "page"',
+  mapping: {
+    name: {
+      '@if': {
+        exists: { '@path': '$.category' },
+        then: { '@path': '$.category' },
+        else: { '@path': '$.name' }
+      }
+    },
+    properties: {
+      '@path': '$.properties'
+    }
+  }
+}
+
+describe('FullSession visitPage action', () => {
+  const mockCustomerId = 'test-customer-id'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Setup window.FUS mock if needed
+    if (typeof window !== 'undefined') {
+      // @ts-ignore
+      window.FUS = {}
+    }
+  })
+
+  test('should set session attributes with page name and properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Home Page'
+    const properties = {
+      title: 'Welcome to Our Site',
+      url: 'https://example.com',
+      path: '/',
+      referrer: 'https://google.com',
+      search: '?utm_source=google'
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName,
+      ...properties
+    })
+  })
+
+  test('should use category as name when present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Product Details'
+    const category = 'Products'
+    const properties = {
+      title: 'Amazing Product',
+      url: 'https://example.com/products/amazing-product',
+      product_id: 'prod_123'
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        category: category,
+        properties
+      })
+    )
+
+    // Should use category as name when present
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: category,
+      ...properties
+    })
+  })
+
+  test('should use page name when category is not present', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'About Us'
+    const properties = {
+      title: 'About Our Company',
+      url: 'https://example.com/about',
+      section: 'company'
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName,
+      ...properties
+    })
+  })
+
+  test('should handle page with empty properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Simple Page'
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties: {}
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName
+    })
+  })
+
+  test('should handle page with null properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Null Properties Page'
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties: undefined
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName
+    })
+  })
+
+  test('should handle page without name and category', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const properties = {
+      title: 'Unnamed Page',
+      url: 'https://example.com/unnamed',
+      path: '/unnamed'
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: undefined,
+      ...properties
+    })
+  })
+
+  test('should handle complex properties with various data types', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Complex Page'
+    const properties = {
+      title: 'Complex Page Title',
+      url: 'https://example.com/complex',
+      load_time: 2.5,
+      user_agent: 'Mozilla/5.0...',
+      is_authenticated: true,
+      visitor_count: 1500,
+      tags: ['homepage', 'featured'],
+      metadata: {
+        experiment_id: 'exp_123',
+        variant: 'A'
+      }
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName,
+      ...properties
+    })
+  })
+
+  test('should track multiple page visits in sequence', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    // First page visit
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: 'Home',
+        properties: { url: 'https://example.com' }
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: 'Home',
+      url: 'https://example.com'
+    })
+
+    // Second page visit
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: 'Products',
+        properties: { url: 'https://example.com/products' }
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: 'Products',
+      url: 'https://example.com/products'
+    })
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledTimes(2)
+  })
+
+  test('should handle page visit with special characters in name and properties', async () => {
+    const { fullSessionTracker } = await import('fullsession')
+
+    const [event] = await fullSessionDestination({
+      customerId: mockCustomerId,
+      subscriptions: [pageSubscription] as any
+    })
+
+    await event.load(Context.system(), {} as Analytics)
+
+    const pageName = 'Page with "Special" Characters & Symbols'
+    const properties = {
+      title: 'Title with émojis 🚀 and symbols!',
+      url: 'https://example.com/special-chars?q=test&lang=en',
+      description: 'A page with special characters: àáâãäåæçèéêë'
+    }
+
+    await event.page?.(
+      new Context({
+        type: 'page',
+        name: pageName,
+        properties
+      })
+    )
+
+    expect(fullSessionTracker.setSessionAttributes).toHaveBeenCalledWith({
+      name: pageName,
+      ...properties
+    })
+  })
+})

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/generated-types.ts
@@ -2,11 +2,7 @@
 
 export interface Payload {
   /**
-   * the page visited
-   */
-  name?: string
-  /**
-   * properties associated with the page visited
+   * Properties and metadata associated with the page being viewed
    */
   properties?: {
     [k: string]: unknown

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/generated-types.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/generated-types.ts
@@ -1,0 +1,14 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * the page visited
+   */
+  name?: string
+  /**
+   * properties associated with the page visited
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
@@ -1,44 +1,30 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import type { FUS } from '../types'
+import type { FUS, UserCustomAttributes } from '../types'
 
 // Change from unknown to the partner SDK types
 const action: BrowserActionDefinition<Settings, FUS, Payload> = {
-  title: 'Visit Page',
-  description: 'set properties for visited page',
+  title: 'Page View',
+  description: 'Track page views and set page-specific attributes in FullSession for navigation analysis.',
   defaultSubscription: 'type = "page"',
   platform: 'web',
   fields: {
-    name: {
-      type: 'string',
-      required: false,
-      description: 'the page visited',
-      label: 'Page Name',
-      default: {
-        '@if': {
-          exists: { '@path': '$.category' },
-          then: { '@path': '$.category' },
-          else: { '@path': '$.name' }
-        }
-      }
-    },
     properties: {
       type: 'object',
       required: false,
-      description: 'properties associated with the page visited',
-      label: 'Properties',
+      description: 'Properties and metadata associated with the page being viewed',
+      label: 'Page Properties',
       default: {
         '@path': '$.properties'
       }
     }
   },
   perform: (FUS, data) => {
-    const { name, properties } = data.payload
-    FUS.setSessionAttributes({
-      name: name ?? '',
+    const { properties } = data.payload
+    FUS.setPageAttributes({
       ...properties
-    })
+    } as UserCustomAttributes)
   }
 }
 

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
@@ -1,0 +1,45 @@
+import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import type { FUS } from '../types'
+
+// Change from unknown to the partner SDK types
+const action: BrowserActionDefinition<Settings, FUS, Payload> = {
+  title: 'Visit Page',
+  description: 'set properties for visited page',
+  defaultSubscription: 'type = "page"',
+  platform: 'web',
+  fields: {
+    name: {
+      type: 'string',
+      required: false,
+      description: 'the page visited',
+      label: 'Page Name',
+      default: {
+        '@if': {
+          exists: { '@path': '$.category' },
+          then: { '@path': '$.category' },
+          else: { '@path': '$.name' }
+        }
+      }
+    },
+    properties: {
+      type: 'object',
+      required: false,
+      description: 'properties associated with the page visited',
+      label: 'Properties',
+      default: {
+        '@path': '$.properties'
+      }
+    }
+  },
+  perform: (FUS, data) => {
+    const { name, properties } = data.payload
+    FUS.setSessionAttributes({
+      name,
+      ...properties
+    })
+  }
+}
+
+export default action

--- a/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
+++ b/packages/browser-destinations/destinations/fullsession/src/visitPage/index.ts
@@ -36,7 +36,7 @@ const action: BrowserActionDefinition<Settings, FUS, Payload> = {
   perform: (FUS, data) => {
     const { name, properties } = data.payload
     FUS.setSessionAttributes({
-      name,
+      name: name ?? '',
       ...properties
     })
   }

--- a/packages/browser-destinations/destinations/fullsession/tsconfig.json
+++ b/packages/browser-destinations/destinations/fullsession/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["dist", "**/__tests__"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11465,6 +11465,11 @@ fsevents@^2.3.3:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
+fullsession@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fullsession/-/fullsession-1.1.0.tgz#3dcefc88f1e50d0e1dddea8a53d9cb6644e91491"
+  integrity sha512-vWm4zrhZCyYaX0qxrWXu32RIq5nGpS1hKW5kMZxfWQCwIReT/Y60fO+2xjVPV2VE/FKY1/asSwwgbbVT6hRdAA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
# PR Summary: Add FullSession Browser Destination

## Overview
This PR introduces a new browser-mode destination for FullSession, a session recording and analytics platform. The destination enables customers to stream Segment events to FullSession for user identification, event tracking, and page visit recording.

## 🚀 New Features

### **1. FullSession Browser Destination**
- **Mode**: Device/Browser mode destination
- **Package**: `@segment/analytics-browser-actions-fullsession`
- **Integration**: Uses FullSession's JavaScript SDK to track user interactions

### **2. Three Actions Implemented**

#### **Identify User Action**
- Maps Segment `identify` events to FullSession user identification


#### **Record Event Action** 
- Maps Segment `track` events to FullSession custom events

#### **Visit Page Action**
- Maps Segment `page` events to FullSession page visit tracking



### **Test Coverage**
- **33 total tests** across all actions and main destination
- **100% action coverage** with edge cases and error scenarios



## 🔧 Configuration

### **Required Settings**
- **Customer ID**: FullSession account identifier for initialization 

### **Default Subscriptions**
- `type = "identify"` → Identify User action
- `type = "track"` → Record Event action  
- `type = "page"` → Visit Page action




## **Test Coverage**
- **33 total tests** across all actions and main destination
- **100% action coverage** with edge cases and error scenarios


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
