### PR TITLE
STRATCONN-6146 - [Dynamic Yield] - Support different id name in Segment

### DIFF
--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
@@ -18,11 +18,11 @@ export interface AudienceSettings {
    */
   audience_name: string
   /**
-   * The type of Identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.
+   * The Segment identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.
    */
   identifier_type: string
   /**
-   * The name of the identifier in Dynamic Yield. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield identifier name.
+   * The name of the identifier in Dynamic Yield by Mastercard. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield by Mastercard identifier name.
    */
-  dy_identifier_type: string
+  dy_identifier_type?: string
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
@@ -21,4 +21,8 @@ export interface AudienceSettings {
    * The type of Identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.
    */
   identifier_type: string
+  /**
+   * The name of the identifier in Dynamic Yield. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield identifier name.
+   */
+  dy_identifier_type: string
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/generated-types.ts
@@ -22,7 +22,7 @@ export interface AudienceSettings {
    */
   identifier_type: string
   /**
-   * The name of the identifier in Dynamic Yield by Mastercard. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield by Mastercard identifier name.
+   * The name of the identifier in Dynamic Yield by Mastercard. If you leave this empty, Segment will assume that the name of the identifier in Dynamic Yield by Mastercard matches the value specified in the "Segment Identifier Type" field.
    */
   dy_identifier_type?: string
 }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -21,7 +21,13 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       label: 'Identifier Type',
       required: true,
       description:
-        'The type of Identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.'
+        'The Segment identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.'
+    },
+    dy_identifier_type: {
+      type: 'string',
+      label: 'Dynamic Yield Identifier Type',
+      required: false,
+      description: 'The name of the identifier in Dynamic Yield by Mastercard. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield by Mastercard identifier name.'
     }
   },
   authentication: {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/index.ts
@@ -18,16 +18,16 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     },
     identifier_type: {
       type: 'string',
-      label: 'Identifier Type',
+      label: 'Segment Identifier Type (required)',
       required: true,
       description:
         'The Segment identifier to send to Dynamic Yield by Mastercard. E.g. `email`, `anonymousId`, `userId` or any other custom identifier. Make sure to configure the identifier in the `Customized Setup` below so that it is sent to Dynamic Yield by Mastercard.'
     },
     dy_identifier_type: {
       type: 'string',
-      label: 'Dynamic Yield Identifier Type',
+      label: 'Dynamic Yield Identifier Type (optional)',
       required: false,
-      description: 'The name of the identifier in Dynamic Yield by Mastercard. You can leave this field empty if the Segment identifier name is the same as the Dynamic Yield by Mastercard identifier name.'
+      description: 'The name of the identifier in Dynamic Yield by Mastercard. If you leave this empty, Segment will assume that the name of the identifier in Dynamic Yield by Mastercard matches the value specified in the "Segment Identifier Type" field.'
     }
   },
   authentication: {

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
@@ -1,48 +1,30 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import Destination from '../../index'
+import { DynamicYieldRequestJSON } from '../types'
 import { Settings } from '../../generated-types'
 
-const testDestination = createTestIntegration(Destination)
+let testDestination = createTestIntegration(Destination)
 
-// const goodTrackEvent = createTestEvent({
-//   type: 'track',
-//   context: {
-//     personas: {
-//       computation_class: 'audience',
-//       computation_key: 'dy_segment_test',
-//       computation_id: 'dy_segment_audience_id'
-//     },
-//     traits: {
-//       email: 'test@email.com'
-//     }
-//   },
-//   properties: {
-//     audience_key: 'dy_segment_test',
-//     dy_segment_test: true
-//   }
-// })
+const audienceSettings = {
+  audience_name: "test-audience",
+  identifier_type: "email",
+  dy_identifier_type: "externalid"
+}
 
-// const goodIdentifyEvent = createTestEvent({
-//   type: 'identify',
-//   context: {
-//     personas: {
-//       computation_class: 'audience',
-//       computation_key: 'dy_segment_test',
-//       computation_id: 'dy_segment_audience_id'
-//     }
-//   },
-//   traits: {
-//     audience_key: 'dy_segment_test',
-//     dy_segment_test: true
-//   },
-//   properties: undefined
-// })
-
-const badEvent = createTestEvent({
+const addToAudienceTrackPayload = createTestEvent({
+  type: 'track',
+  userId: "userId1",
+  anonymousId:"anonymousId1",
+  messageId: "messageid1",
+  timestamp: "2021-07-12T23:02:40.563Z",
   context: {
     personas: {
-      computation_key: 'dy_segment_test'
+      computation_class: 'audience',
+      computation_key: 'dy_segment_test',
+      computation_id: 'dy_segment_audience_id',
+      external_audience_id: "11122233344455", // This must be convertable to a number
+      audience_settings: audienceSettings
     },
     traits: {
       email: 'test@email.com'
@@ -54,31 +36,309 @@ const badEvent = createTestEvent({
   }
 })
 
+const settings = {
+  sectionId: 'test-section-id',
+  dataCenter: 'com',
+  accessKey: 'test-access-key'
+}
+
+const mapping = {
+  message_id: {
+    '@path': '$.messageId'
+  },
+  timestamp: {
+    '@path': '$.timestamp'
+  },
+  external_audience_id: {
+    '@path': '$.context.personas.external_audience_id'
+  },
+  segment_audience_key: {
+    '@path': '$.context.personas.computation_key'
+  },
+  traits_or_props: {'@path': '$.properties' },
+  segment_computation_action: {
+    '@path': '$.context.personas.computation_class'
+  },
+  email: {
+    '@if': {
+      exists: { '@path': '$.traits.email' },
+      then: { '@path': '$.traits.email' },
+      else: { '@path': '$.context.traits.email' }
+    }
+  },
+  anonymousId: { '@path': '$.anonymousId' },
+  userId: { '@path': '$.userId' }
+}
+
+const baseURL = "https://cdp-extensions-api.dev-use1.dynamicyield.com"
+const path = "/cdp/segment/audiences/membership-change"
+
+const header = {
+  "authorization": "mock-secret-DEV",
+  "content-type": "application/json",
+  "user-agent": "Segment (Actions)",
+  "accept": "*/*",
+  "content-length": "469",
+  "accept-encoding": "gzip,deflate",
+  "connection": "close"
+}
+
 describe('DynamicYieldAudiences.syncAudience', () => {
-  const settings = {
-    sectionId: 'test-section-id',
-    dataCenter: 'com',
-    accessKey: 'test-access-key'
-  }
-  it('should not throw an error if the audience creation succeed - track', async () => {
-    nock(/.*/).persist().post(/.*/).reply(200)
+  const OLD_ENV = process.env
 
-    expect(true).toBe(true)
+  beforeEach(() => {
+    testDestination = createTestIntegration(Destination)
+    nock.disableNetConnect()
+    jest.resetAllMocks()
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_US_CLIENT_SECRET = "mock-secret-US"
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_EU_CLIENT_SECRET = "mock-secret-EU"
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_DEV_CLIENT_SECRET = "mock-secret-DEV"
   })
 
-  it('should not throw an error if the audience creation succeed - identify', async () => {
-    nock(/.*/).persist().post(/.*/).reply(200)
-
-    expect(true).toBe(true)
+  afterEach(() => {
+    nock.enableNetConnect()
+    process.env = OLD_ENV
+    nock.cleanAll()
   })
 
-  it('should throw an error if audience creation event missing mandatory field', async () => {
-    await expect(
-      testDestination.testAction('syncAudience', {
-        event: badEvent,
-        useDefaultMappings: true,
-        settings: settings as Settings
+  describe('Should throw an error', () => {
+    it('if audience creation event missing mandatory field', async () => {
+      const badEvent = createTestEvent({
+        context: {
+          personas: {
+            computation_key: 'dy_segment_test'
+          },
+          traits: {
+            email: 'test@email.com'
+          }
+        },
+        properties: {
+          audience_key: 'dy_segment_test',
+          dy_segment_test: true
+        }
       })
-    ).rejects.toThrowError("The root value is missing the required field 'segment_computation_action'")
+
+      await expect(
+        testDestination.testAction('syncAudience', {
+          event: badEvent,
+          useDefaultMappings: true,
+          settings: settings as Settings
+        })
+      ).rejects.toThrowError("The root value is missing the required field 'segment_computation_action'")
+    })
+  })
+
+  describe('Should add a user to an audience', () => {
+    it('where Segment ID type is email but DY ID type is externalid', async () => {
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json: DynamicYieldRequestJSON = {
+        type: "audience_membership_change_request",
+        id: "messageid1",
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: "test-section-id",
+            identifier: "externalid",
+            connectionKey: "test-access-key"
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: "externalid",
+                encoding: "\"sha-256\"",
+                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: "test-audience",
+                action: "add"
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: header })
+        .post(path, json as any)
+        .reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
+
+    it('where Segment ID type is email an DY ID type undefined', async () => {
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      delete payload?.context?.personas.audience_settings.dy_identifier_type
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json = {
+        type: "audience_membership_change_request",
+        id: "messageid1",
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: "test-section-id",
+            identifier: "email",
+            connectionKey: "test-access-key"
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: "email",
+                encoding: "\"sha-256\"",
+                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: "test-audience",
+                action: "add"
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: { ...header,   "content-length": "459"} })
+        .post(path, json)
+        .reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
+    
+    it('where Segment ID type is userId an DY ID type undefined', async () => {
+     
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      delete payload?.context?.personas.audience_settings.dy_identifier_type
+      payload.context.personas.audience_settings.identifier_type = "userid"
+
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json = {
+        type: "audience_membership_change_request",
+        id: "messageid1",
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: "test-section-id",
+            identifier: "userid",
+            connectionKey: "test-access-key"
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: "userid",
+                encoding: "raw",
+                value: "userId1"
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: "test-audience",
+                action: "add"
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: { ...header,   "content-length": "396"} })
+        .post(path, json)
+        .reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
+  })
+
+  describe('Should remove a user from an audience', () => {
+
+    it('where Segment ID type is email an DY ID type undefined', async () => {
+     
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      payload.properties.dy_segment_test = false
+      delete payload?.context?.personas.audience_settings.dy_identifier_type
+
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json = {
+        type: "audience_membership_change_request",
+        id: "messageid1",
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: "test-section-id",
+            identifier: "email",
+            connectionKey: "test-access-key"
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: "email",
+                encoding: "\"sha-256\"",
+                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: "test-audience",
+                action: "delete"
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: { ...header,   "content-length": "462"} })
+        .post(path, json)
+        .reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
+    
   })
 })

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/index.ts
@@ -2,6 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { getUpsertURL, hashAndEncode, getDataCenter, getSectionId } from '../helpers'
+import { DynamicYieldRequestJSON } from './types'
 
 const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
   title: 'Sync Audience',
@@ -128,8 +129,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     const audienceName = audienceSettings?.audience_name
     const segIdType = audienceSettings?.identifier_type ?? ''
     const normalizedsegIdType = segIdType.toLowerCase().replace(/_/g, '')
-    const dyIdType = audienceSettings?.dy_identifier_type ?? ''
-
+    const dyIdType = audienceSettings?.dy_identifier_type
     const audienceValue = payload.traits_or_props[payload.segment_audience_key]
 
     let primaryIdentifier: string | undefined
@@ -158,7 +158,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
 
     const URL = getUpsertURL(dataCenter)
 
-    const json = {
+    const json: DynamicYieldRequestJSON = {
       type: 'audience_membership_change_request',
       id: payload.message_id,
       timestamp_ms: new Date(payload.timestamp).getTime(),
@@ -180,7 +180,7 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
           ],
           audiences: [
             {
-              audience_id: Number(external_audience_id), // must be sent as an integer
+              audience_id: Number(external_audience_id), 
               audience_name: audienceName,
               action: audienceValue ? 'add' : 'delete'
             }

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/types.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/types.ts
@@ -1,0 +1,31 @@
+
+
+export interface DynamicYieldRequestJSON {
+    type: 'audience_membership_change_request'
+    id: string
+    timestamp_ms: number
+    account: {
+        account_settings: {
+            sectionId: string,
+            identifier: string,
+            connectionKey: string
+        }
+    },
+    user_profiles: [
+    {
+        user_identities: [
+        {
+            type: string
+            encoding: '"sha-256"' | 'raw'
+            value: string
+        }
+        ],
+        audiences: [
+            {
+                audience_id: number, // must be sent as an integer
+                audience_name: string,
+                action: 'add' | 'delete'
+            }
+        ]
+    }]
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -59,9 +59,8 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-  onDelete: async (request, { payload, settings }) => {
+  onDelete: async (request, { payload }) => {
     const userId = payload.userId
-    const { apiKey } = settings
     const formattedExternalIds = `["${userId}"]`
     const syncId = sha256hash(String(userId))
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -59,8 +59,9 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
-  onDelete: async (request, { payload }) => {
+  onDelete: async (request, { payload, settings }) => {
     const userId = payload.userId
+    const { apiKey } = settings
     const formattedExternalIds = `["${userId}"]`
     const syncId = sha256hash(String(userId))
 


### PR DESCRIPTION
The current Segment <> DY Audience Destination allows customers to select an identifier to send to DY. 
The name of the identifier selected must be the same in Segment as it is in DY. However we've had a customer ask if we could allow for the names to be different. 

This PR allows customers to sync a Segment identifier (for example `user_id`) to a different identifier name in Dynamic Yield (for example `externalid`)

It does this by adding a new configuration field named `dy_identifier_type`. It's an optional field. 

If the customer wanted to sync a Segment identifier named userId to a DY identifier named `externalid`, then they would apply the following settings: 

```
identifier_type: userid
dy_identifier_type: externalid
```

The payload sent to DY would look like the following: 

```
{
      type: 'audience_membership_change_request',
      id: "message id value here",
      timestamp_ms: "date value here",
      account: {
        account_settings: {
          sectionId: getSectionId(settings.sectionId),
          identifier: dyIdType ?? segIdType,  // this defaults to the dy_identifier_type and falls back to the name of the segment identifier which is identifier_type
          connectionKey: settings.accessKey
        }
      },
      user_profiles: [
        {
          user_identities: [
            {
              type: dyIdType ?? segIdType, // this defaults to the dy_identifier_type and falls back to the name of the segment identifier which is identifier_type
              encoding: segIdType === 'email' ? '"sha-256"' : 'raw',
              value: segIdType === 'email' ? hashAndEncode(primaryIdentifier) : primaryIdentifier
            }
          ],
          audiences: [
            {
              audience_id: Number(external_audience_id), // must be sent as an integer
              audience_name: audienceName,
              action: audienceValue ? 'add' : 'delete'
            }
          ]
        }
      ]
    }
```


## Testing

Unit tests added

Tested locally. Staging test had a network issue. 

Old functionality: Checks that we can still send payloads to DY without using the new dy_identifier_type field. 
```
POST /syncAudience
header = {"Content-Type":"application/json","Authorization":"f3f('5Y[s6zyb!JSNguj2i[HqIZl&i"}
URL = https://cdp-extensions-api.use1.dev.pub.dydy.io/cdp/segment/audiences/membership-change
JSON = {
  "type": "audience_membership_change_request",
  "id": "test-message-ugl6vuyjzl",
  "timestamp_ms": 1756308279780,
  "account": {
    "account_settings": {
      "sectionId": "8790032",
      "identifier": "email",
      "connectionKey": "44feac4206cab6caaecd"
    }
  },
  "user_profiles": [
    {
      "user_identities": [
        {
          "type": "email",
          "encoding": "\"sha-256\"",
          "value": "388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69"
        }
      ],
      "audiences": [
        {
          "audience_id": 11122233344455,
          "audience_name": "audience_name_1",
          "action": "add"
        }
      ]
    }
  ]
}
```

New functionality: Makes use of the new dy_identifier_type field to use the name of the ID in DY. 
```
INFO: 💬  200 POST /syncAudience - 10055ms
header = {"Content-Type":"application/json","Authorization":"f3f('5Y[s6zyb!JSNguj2i[HqIZl&i"}
URL = https://cdp-extensions-api.use1.dev.pub.dydy.io/cdp/segment/audiences/membership-change
JSON = {
  "type": "audience_membership_change_request",
  "id": "test-message-ugl6vuyjzl",
  "timestamp_ms": 1756308279780,
  "account": {
    "account_settings": {
      "sectionId": "8790032",
      "identifier": "externalid",
      "connectionKey": "44feac4206cab6caaecd"
    }
  },
  "user_profiles": [
    {
      "user_identities": [
        {
          "type": "externalid",
          "encoding": "\"sha-256\"",
          "value": "388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69"
        }
      ],
      "audiences": [
        {
          "audience_id": 11122233344455,
          "audience_name": "audience_name_1",
          "action": "add"
        }
      ]
    }
  ]
}
```