### PR TITLE
Update kafka types

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/generated-types.ts
+++ b/packages/destination-actions/src/destinations/kafka/generated-types.ts
@@ -10,7 +10,7 @@ export interface Settings {
    */
   brokers: string
   /**
-   * Select the Authentication Mechanism to use. For SCRAM or PLAIN populate the 'Username' and 'Password' fields. For AWS IAM populated the 'AWS Access Key ID' and 'AWS Secret Key' fields. For 'Client Certificate' populated the 'SSL Client Key' and 'SSL Client Certificate' fields
+   * Select the Authentication Mechanism to use. For SCRAM or PLAIN populate the 'Username' and 'Password' fields. For 'Client Certificate' populated the 'SSL Client Key' and 'SSL Client Certificate' fields
    */
   mechanism: string
   /**

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -29,7 +29,7 @@ const destination: DestinationDefinition<Settings> = {
       mechanism: {
         label: 'Authentication Mechanism',
         description:
-          "Select the Authentication Mechanism to use. For SCRAM or PLAIN populate the 'Username' and 'Password' fields. For AWS IAM populated the 'AWS Access Key ID' and 'AWS Secret Key' fields. For 'Client Certificate' populated the 'SSL Client Key' and 'SSL Client Certificate' fields",
+          "Select the Authentication Mechanism to use. For SCRAM or PLAIN populate the 'Username' and 'Password' fields. For 'Client Certificate' populated the 'SSL Client Key' and 'SSL Client Certificate' fields",
         type: 'string',
         required: true,
         choices: [

--- a/packages/destination-actions/src/destinations/kafka/send/generated-types.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/generated-types.ts
@@ -29,4 +29,12 @@ export interface Payload {
    * The key for the message (optional)
    */
   key?: string
+  /**
+   * If true, Segment will batch events before sending to Kafka.
+   */
+  enable_batching?: boolean
+  /**
+   * The keys to use for batching the events.
+   */
+  batch_keys?: string[]
 }

--- a/packages/destination-actions/src/destinations/kafka/send/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/index.ts
@@ -42,6 +42,22 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Message Key',
       description: 'The key for the message (optional)',
       type: 'string'
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Data to Kafka?',
+      description: 'If true, Segment will batch events before sending to Kafka.',
+      default: true,
+      unsafe_hidden: true
+    },
+    batch_keys: {
+      label: 'Batch Keys',
+      description: 'The keys to use for batching the events.',
+      type: 'string',
+      unsafe_hidden: true,
+      required: false,
+      multiple: true,
+      default: ['partition', 'default_partition']
     }
   },
   dynamicFields: {


### PR DESCRIPTION
This pull request updates the Kafka destination integration by improving the batching capabilities and clarifying authentication options. The most significant changes include adding new batching-related fields to the payload and action definition, and removing AWS IAM as a selectable authentication mechanism in the documentation and configuration.

**Batching Enhancements:**

* Added `enable_batching` (boolean) and `batch_keys` (string array) fields to the `Payload` interface in `generated-types.ts`, allowing events to be optionally batched before sending to Kafka.
* Updated the action definition in `send/index.ts` to support the new batching options, including labels, descriptions, default values, and hiding these fields from the UI by default.

**Authentication Mechanism Clarification:**

* Removed AWS IAM as an authentication mechanism from the documentation as it is not supported at the moment and configuration for the `mechanism` property in both `generated-types.ts` and `index.ts`, leaving only SCRAM, PLAIN, and Client Certificate as options. [[1]](diffhunk://#diff-c49982bd83998cc00884e365572d266c4df5743cd24b5018cb529147014c3e26L13-R13) [[2]](diffhunk://#diff-ffbc988aa1005b5ab0c0be11e19a84878161b0f67e1befbc75506be5723d61b0L32-R32)

Screenshots:
<img width="1493" height="705" alt="Screenshot 2025-08-28 at 6 49 37 PM" src="https://github.com/user-attachments/assets/629e2920-e6d7-44c0-9500-be1851f904a8" />
Instance: https://app.segment.build/arijit-dev/destinations/actions-kafka/sources/http_api/instances/6880c59b62bcbb1aabdd3887/actions/mQBdMEYYKWsh6Fx2JCQeEt


**Note:** We need to run a ctl-plane-migration to enable batching as default for kafka.
WIP: https://github.com/segmentio/control-plane/pull/6191


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
