### PR TITLE
[Klaviyo] [Multistatus] Add Multistatus for Klaviyo upsertProfile action

### DIFF
--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -270,7 +270,7 @@ exports[`Testing snapshot for actions-klaviyo destination: upsertProfile action 
 Object {
   "data": Object {
     "attributes": Object {
-      "email": "embivbe@edebemto.ga",
+      "email": "rob@cagtud.eu",
       "external_id": "$Fd4HHQmxNI0jTCTt(t",
       "first_name": "$Fd4HHQmxNI0jTCTt(t",
       "image": "$Fd4HHQmxNI0jTCTt(t",

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -270,7 +270,7 @@ exports[`Testing snapshot for actions-klaviyo destination: upsertProfile action 
 Object {
   "data": Object {
     "attributes": Object {
-      "email": "rob@cagtud.eu",
+      "email": "embivbe@edebemto.ga",
       "external_id": "$Fd4HHQmxNI0jTCTt(t",
       "first_name": "$Fd4HHQmxNI0jTCTt(t",
       "image": "$Fd4HHQmxNI0jTCTt(t",

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/multistatus.test.ts
@@ -883,7 +883,7 @@ describe('MultiStatus', () => {
       expect(response[1]).toMatchObject({
         status: 400,
         errortype: 'PAYLOAD_VALIDATION_FAILED',
-        errormessage: 'Email is not valid.',
+        errormessage: 'Email must be a valid email address string but it was not.',
         errorreporter: 'INTEGRATIONS'
       })
     })

--- a/packages/destination-actions/src/destinations/klaviyo/__tests__/multistatus.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/__tests__/multistatus.test.ts
@@ -548,6 +548,347 @@ describe('MultiStatus', () => {
       })
     })
   })
+
+  describe('upsertProfile', () => {
+    beforeEach(() => {
+      nock.cleanAll()
+      jest.resetAllMocks()
+    })
+
+    it('should handle multistatus response when some profiles have validation errors', async () => {
+      const events = [
+        // Valid profile with email
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'valid@example.com',
+            first_name: 'John',
+            last_name: 'Doe'
+          }
+        }),
+        // Invalid profile - no identifiers
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            first_name: 'Jane',
+            last_name: 'Smith'
+          }
+        }),
+        // Invalid profile - invalid phone number
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            phone_number: 'invalid-phone',
+            first_name: 'Bob'
+          }
+        }),
+        // Valid profile with phone
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            phone_number: '+17702126011',
+            first_name: 'Alice'
+          }
+        })
+      ]
+
+      const mapping = {
+        email: { '@path': '$.traits.email' },
+        phone_number: { '@path': '$.traits.phone_number' },
+        first_name: { '@path': '$.traits.first_name' },
+        last_name: { '@path': '$.traits.last_name' }
+      }
+
+      // Mock successful response for valid profiles
+      nock(API_URL)
+        .post('/profile-bulk-import-jobs/')
+        .reply(202, { data: { id: 'job123' } })
+
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // First profile: valid - should succeed
+      expect(response[0]).toMatchObject({
+        status: 200,
+        sent: expect.objectContaining({
+          email: 'valid@example.com',
+          first_name: 'John',
+          last_name: 'Doe'
+        })
+      })
+
+      // Second profile: invalid - no identifiers
+      expect(response[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'One of External ID, Phone Number or Email is required.',
+        errorreporter: 'INTEGRATIONS'
+      })
+
+      // Third profile: invalid - bad phone number
+      expect(response[2]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'Phone number could not be converted to E.164 format.',
+        errorreporter: 'INTEGRATIONS'
+      })
+
+      // Fourth profile: valid - should succeed
+      expect(response[3]).toMatchObject({
+        status: 200,
+        sent: expect.objectContaining({
+          phone_number: '+17702126011',
+          first_name: 'Alice'
+        })
+      })
+    })
+
+    it('should handle multistatus response when phone number validation fails with country code', async () => {
+      const events = [
+        // Valid profile with email
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'valid@example.com'
+          }
+        }),
+        // Invalid phone with country code
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            phone_number: '123', // invalid
+            country_code: 'US'
+          }
+        })
+      ]
+
+      const mapping = {
+        email: { '@path': '$.traits.email' },
+        phone_number: { '@path': '$.traits.phone_number' },
+        country_code: { '@path': '$.traits.country_code' }
+      }
+
+      nock(API_URL)
+        .post('/profile-bulk-import-jobs/')
+        .reply(202, { data: { id: 'job123' } })
+
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // First profile: valid
+      expect(response[0]).toMatchObject({
+        status: 200,
+        sent: expect.objectContaining({
+          email: 'valid@example.com'
+        })
+      })
+
+      // Second profile: invalid phone
+      expect(response[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'Phone number could not be converted to E.164 format.',
+        errorreporter: 'INTEGRATIONS'
+      })
+    })
+
+    it('should handle multistatus response when all profiles are invalid', async () => {
+      const events = [
+        // No identifiers
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            first_name: 'John'
+          }
+        }),
+        // Invalid phone
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            phone_number: 'not-a-number'
+          }
+        })
+      ]
+
+      const mapping = {
+        phone_number: { '@path': '$.traits.phone_number' },
+        first_name: { '@path': '$.traits.first_name' }
+      }
+
+      // No API call should be made since all profiles are invalid
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // All profiles should have validation errors
+      expect(response[0]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'One of External ID, Phone Number or Email is required.',
+        errorreporter: 'INTEGRATIONS'
+      })
+
+      expect(response[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'Phone number could not be converted to E.164 format.',
+        errorreporter: 'INTEGRATIONS'
+      })
+    })
+
+    it('should handle multistatus response with list_id assignment', async () => {
+      const events = [
+        // Valid profile with list assignment
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'user@example.com',
+            first_name: 'Test'
+          }
+        }),
+        // Invalid profile
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            first_name: 'NoEmail'
+          }
+        })
+      ]
+
+      const mapping = {
+        email: { '@path': '$.traits.email' },
+        first_name: { '@path': '$.traits.first_name' },
+        list_id: listId
+      }
+
+      nock(API_URL)
+        .post('/profile-bulk-import-jobs/')
+        .reply(202, { data: { id: 'job123' } })
+
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // First profile: valid - should succeed with list_id
+      expect(response[0]).toMatchObject({
+        status: 200,
+        sent: expect.objectContaining({
+          email: 'user@example.com',
+          first_name: 'Test'
+        })
+      })
+
+      // Second profile: invalid
+      expect(response[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'One of External ID, Phone Number or Email is required.',
+        errorreporter: 'INTEGRATIONS'
+      })
+    })
+
+    it('should handle Klaviyo API errors in multistatus response', async () => {
+      const events = [
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'valid@example.com'
+          }
+        })
+      ]
+
+      const mapping = {
+        email: { '@path': '$.traits.email' }
+      }
+
+      // Mock API error response
+      nock(API_URL)
+        .post('/profile-bulk-import-jobs/')
+        .reply(400, {
+          errors: [
+            {
+              code: 'invalid',
+              detail: 'Invalid request data'
+            }
+          ]
+        })
+
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // Should handle API error
+      expect(response[0]).toMatchObject({
+        status: 400,
+        errormessage: 'Bad Request',
+        sent: expect.objectContaining({
+          email: 'valid@example.com'
+        })
+      })
+    })
+
+    it('should handle email validation errors', async () => {
+      const events = [
+        // Valid email
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'valid@example.com'
+          }
+        }),
+        // Invalid email format
+        createTestEvent({
+          type: 'identify',
+          traits: {
+            email: 'invalid-email'
+          }
+        })
+      ]
+
+      const mapping = {
+        email: { '@path': '$.traits.email' }
+      }
+
+      nock(API_URL)
+        .post('/profile-bulk-import-jobs/')
+        .reply(202, { data: { id: 'job123' } })
+
+      const response = await testDestination.executeBatch('upsertProfile', {
+        events,
+        settings,
+        mapping
+      })
+
+      // First profile: valid email
+      expect(response[0]).toMatchObject({
+        status: 200,
+        sent: expect.objectContaining({
+          email: 'valid@example.com'
+        })
+      })
+
+      // Second profile: invalid email format
+      expect(response[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: 'Email is not valid.',
+        errorreporter: 'INTEGRATIONS'
+      })
+    })
+  })
+
   describe('removeProfile', () => {
     beforeEach(() => {
       nock.cleanAll()

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -903,7 +903,6 @@ export function updateMultiStatusWithSuccessData(
  *
  * Ensures that at least one of `email`, `phone_number`, or `external_id` is present.
  * If `phone_number` is provided, it validates and converts it to E.164 format using the `country_code`.
- * If `email` is provided, it validates the email format.
  * Returns an object containing the validated payload or an error response if validation fails.
  *
  * @param payload - The profile payload to validate.

--- a/packages/destination-actions/src/destinations/klaviyo/functions.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/functions.ts
@@ -899,19 +899,6 @@ export function updateMultiStatusWithSuccessData(
 }
 
 /**
- * Validates whether the given string is a properly formatted email address.
- *
- * Uses a regular expression to check for a standard email pattern.
- *
- * @param email - The email address to validate.
- * @returns `true` if the email is valid, otherwise `false`.
- */
-function validateEmail(email: string): boolean {
-  const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
-  return emailRegex.test(email)
-}
-
-/**
  * Validates the given profile payload for required fields and formats.
  *
  * Ensures that at least one of `email`, `phone_number`, or `external_id` is present.
@@ -946,17 +933,6 @@ export function validateProfilePayload(payload: Payload): validateProfilePayload
     }
     payload.phone_number = validPhoneNumber
     delete payload.country_code
-  }
-
-  if (payload.email) {
-    if (!validateEmail(payload.email)) {
-      response.error = {
-        status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
-        errormessage: 'Email is not valid.'
-      }
-      return response
-    }
   }
 
   response.payload = payload

--- a/packages/destination-actions/src/destinations/klaviyo/types.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/types.ts
@@ -1,5 +1,6 @@
 import { HTTPError } from '@segment/actions-core'
 import { Payload } from './upsertProfile/generated-types'
+import { ActionDestinationErrorResponseType } from '@segment/actions-core/destination-kit/types'
 export class KlaviyoAPIError extends HTTPError {
   response: Response & {
     data: {
@@ -224,10 +225,6 @@ export interface UnsubscribeEventData {
   }
 }
 
-export interface GroupedProfiles {
-  [listId: string]: Payload[]
-}
-
 export interface AdditionalAttributes {
   first_name?: string
   last_name?: string
@@ -252,4 +249,9 @@ export interface KlaviyoAPIErrorResponse {
 export interface KlaviyoProfile {
   type: string
   attributes: ProfileAttributes
+}
+
+export interface validateProfilePayloadResult {
+  payload?: Payload
+  error?: ActionDestinationErrorResponseType
 }

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/__tests__/index.test.ts
@@ -599,36 +599,6 @@ describe('Upsert Profile Batch', () => {
     })
     expect(response).toHaveLength(1)
   })
-
-  it('should handle errors when sending profiles to Klaviyo', async () => {
-    const events = [createTestEvent({ traits: { email: 'error@example.com' } })]
-
-    nock(API_URL).post('/profile-bulk-import-jobs/').reply(500, { error: 'Server error' })
-
-    await expect(
-      testDestination.testBatchAction('upsertProfile', {
-        settings,
-        events,
-        useDefaultMappings: true
-      })
-    ).rejects.toThrow()
-  })
-
-  it('should group profiles by list_id correctly', () => {
-    const profiles = [
-      { email: 'profile1@example.com', list_id: 'listA', override_list_id: 'overridelistA' },
-      { email: 'profile2@example.com', list_id: 'listB' },
-      { email: 'profile3@example.com', list_id: 'listA' },
-      { email: 'profile4@example.com', override_list_id: 'overridelistA' }
-    ]
-
-    const grouped = Functions.groupByListId(profiles)
-
-    expect(Object.keys(grouped)).toEqual(['overridelistA', 'listB', 'listA'])
-    expect(grouped['listA']).toHaveLength(1)
-    expect(grouped['listB']).toHaveLength(1)
-    expect(grouped['overridelistA']).toHaveLength(2)
-  })
 })
 
 describe('retlOnMappingSave hook', () => {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -1,9 +1,9 @@
-import type { ActionDefinition, DynamicFieldResponse, IntegrationError } from '@segment/actions-core'
+import type { ActionDefinition, DynamicFieldResponse, IntegrationError, JSONLikeObject } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 import { API_URL } from '../config'
-import { PayloadValidationError } from '@segment/actions-core'
+import { HTTPError, MultiStatusResponse, PayloadValidationError } from '@segment/actions-core'
 import { KlaviyoAPIError, ProfileData } from '../types'
 import {
   addProfileToList,
@@ -12,10 +12,10 @@ import {
   sendImportJobRequest,
   getList,
   createList,
-  groupByListId,
-  processProfilesByGroup,
-  validateAndConvertPhoneNumber,
-  processPhoneNumber
+  processPhoneNumber,
+  validateProfilePayload,
+  updateMultiStatusWithSuccessData,
+  updateMultiStatusWithKlaviyoErrors
 } from '../functions'
 import { batch_size, country_code } from '../properties'
 
@@ -28,7 +28,6 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email',
       description: `Individual's email address. One of External ID, Phone Number and Email required.`,
       type: 'string',
-      format: 'email',
       default: { '@path': '$.traits.email' }
     },
     enable_batching: {
@@ -310,20 +309,23 @@ const action: ActionDefinition<Settings, Payload> = {
   },
 
   performBatch: async (request, { payload, hookOutputs, statsContext }) => {
-    payload = payload.filter((profile) => {
-      // Validate and convert the phone number using the provided country code
-      const validPhoneNumber = validateAndConvertPhoneNumber(profile.phone_number, profile.country_code)
+    const multiStatusResponse = new MultiStatusResponse()
+    const filteredPayloads: JSONLikeObject[] = []
+    const validPayloadIndicesBitmap: number[] = []
 
-      // If the phone number is valid, update the profile's phone number with the validated format
-      if (validPhoneNumber) {
-        profile.phone_number = validPhoneNumber
+    payload.forEach((payload, originalBatchIndex) => {
+      const { payload: validPayload, error } = validateProfilePayload(payload)
+      if (error) {
+        multiStatusResponse.setErrorResponseAtIndex(originalBatchIndex, error)
+      } else {
+        filteredPayloads.push(validPayload as JSONLikeObject)
+        validPayloadIndicesBitmap.push(originalBatchIndex)
       }
-      // If the phone number is invalid (null), exclude this profile
-      else if (validPhoneNumber === null) {
-        return false
-      }
-      return profile.email || profile.phone_number || profile.external_id
     })
+
+    if (filteredPayloads.length === 0) {
+      return multiStatusResponse
+    }
 
     if (statsContext) {
       const { tags, statsClient } = statsContext
@@ -332,38 +334,31 @@ const action: ActionDefinition<Settings, Payload> = {
       statsClient?.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
     }
 
-    const profilesWithList: Payload[] = []
-    const profilesWithoutList: Payload[] = []
-
     payload.forEach((profile) => {
       if (hookOutputs?.retlOnMappingSave?.outputs?.id) {
         profile.list_id = hookOutputs.retlOnMappingSave.outputs.id
       }
-      if (profile.list_id || profile.override_list_id) {
-        profilesWithList.push(profile)
-      } else {
-        profilesWithoutList.push(profile)
-      }
     })
 
-    let importResponseWithList
-    let importResponseWithoutList
-
-    if (profilesWithList.length > 0) {
-      // Group profiles based on list_id
-      const groupedByListId = groupByListId(profilesWithList)
-      importResponseWithList = await processProfilesByGroup(request, groupedByListId)
+    const listId: string = (filteredPayloads[0]?.override_list_id as string) || (filteredPayloads[0]?.list_id as string)
+    const importJobPayload = createImportJobPayload(filteredPayloads, listId)
+    try {
+      const response = await sendImportJobRequest(request, importJobPayload)
+      updateMultiStatusWithSuccessData(filteredPayloads, validPayloadIndicesBitmap, multiStatusResponse, response)
+    } catch (error) {
+      // If one of the payloads causes a HTTPError, we want to capture the error for each payload in the batch
+      if (error instanceof HTTPError) {
+        await updateMultiStatusWithKlaviyoErrors(
+          filteredPayloads,
+          error,
+          multiStatusResponse,
+          validPayloadIndicesBitmap
+        )
+      } else {
+        throw error
+      }
     }
-
-    if (profilesWithoutList.length > 0) {
-      const importJobPayload = createImportJobPayload(profilesWithoutList)
-      importResponseWithoutList = await sendImportJobRequest(request, importJobPayload)
-    }
-
-    return {
-      withList: importResponseWithList,
-      withoutList: importResponseWithoutList
-    }
+    return multiStatusResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -28,6 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Email',
       description: `Individual's email address. One of External ID, Phone Number and Email required.`,
       type: 'string',
+      format: 'email',
       default: { '@path': '$.traits.email' }
     },
     enable_batching: {

--- a/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/klaviyo/upsertProfile/index.ts
@@ -308,7 +308,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
 
-  performBatch: async (request, { payload, hookOutputs, statsContext }) => {
+  performBatch: async (request, { payload, hookOutputs }) => {
     const multiStatusResponse = new MultiStatusResponse()
     const filteredPayloads: JSONLikeObject[] = []
     const validPayloadIndicesBitmap: number[] = []
@@ -325,13 +325,6 @@ const action: ActionDefinition<Settings, Payload> = {
 
     if (filteredPayloads.length === 0) {
       return multiStatusResponse
-    }
-
-    if (statsContext) {
-      const { tags, statsClient } = statsContext
-      const set = new Set()
-      payload.forEach((x) => set.add(`${x.list_id}-${x.override_list_id}`))
-      statsClient?.histogram('actions-klaviyo.remove_profile_from_list.unique_list_id', set.size, tags)
     }
 
     payload.forEach((profile) => {


### PR DESCRIPTION
Add multistatus for upsert profile.
Removed the group by list Id logic since we have batch keys now.
Added explicit email validation to support multistatus.

## Testing

[Stage Testing Doc.](https://docs.google.com/document/d/1T4ew6rbRnJ2FHikjtfDWfbghavquV6RJ-wAjjEEeUfY/edit?tab=t.a0ntnwwitug1)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
