### PR TITLE
PT-2186  Add specificEvent presets to the snowflake destination for Journeys

### DIFF
--- a/packages/warehouse-destinations/src/destinations/snowflake/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/index.ts
@@ -1,9 +1,10 @@
 import type { WarehouseDestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { defaultValues } from '@segment/actions-core'
-import aududienceDefaultFields from './sendCustomEvent/audience-default-fields'
+import audienceDefaultFields from './sendCustomEvent/audience-default-fields'
 
 import sendCustomEvent from './sendCustomEvent'
+import journeysDefaultFields from './sendCustomEvent/journeys-default-fields'
 
 const destination: WarehouseDestinationDefinition<Settings> = {
   name: 'Snowflake',
@@ -25,7 +26,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
-        ...defaultValues(aududienceDefaultFields)
+        ...defaultValues(audienceDefaultFields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_entity_added_track'
@@ -35,7 +36,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
-        ...defaultValues(aududienceDefaultFields)
+        ...defaultValues(audienceDefaultFields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_entity_removed_track'
@@ -45,7 +46,7 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
-        ...defaultValues(aududienceDefaultFields)
+        ...defaultValues(audienceDefaultFields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_entered_track'
@@ -55,10 +56,21 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
-        ...defaultValues(aududienceDefaultFields)
+        ...defaultValues(audienceDefaultFields)
       },
       type: 'specificEvent',
       eventSlug: 'warehouse_audience_exited_track'
+    },
+    {
+      name: 'Journeys Step Entered',
+      partnerAction: 'sendCustomEvent',
+      mapping: {
+        ...defaultValues(sendCustomEvent.fields),
+        // note that this must be `properties` to be processed by the warehouse pipeline
+        ...defaultValues(journeysDefaultFields)
+      },
+      type: 'specificEvent',
+      eventSlug: 'journeys_step_entered_track'
     }
   ],
 

--- a/packages/warehouse-destinations/src/destinations/snowflake/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/index.ts
@@ -66,7 +66,6 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       partnerAction: 'sendCustomEvent',
       mapping: {
         ...defaultValues(sendCustomEvent.fields),
-        // note that this must be `properties` to be processed by the warehouse pipeline
         ...defaultValues(journeysDefaultFields)
       },
       type: 'specificEvent',

--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/journeys-default-fields.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/journeys-default-fields.ts
@@ -1,0 +1,35 @@
+export default {
+  // note that this must be `properties` to be processed by the warehouse pipeline
+  properties: {
+    label: 'Columns',
+    description: `Additional columns to write to Snowflake.`,
+    type: 'object',
+    defaultObjectUI: 'keyvalue',
+    required: true,
+    additionalProperties: true,
+    default: {
+      journey_metadata: {
+        '@json': {
+          mode: 'encode',
+          value: {
+            '@path': '$.properties.journey_metadata'
+          }
+        }
+      },
+      journey_context: {
+        '@json': {
+          mode: 'encode',
+          value: {
+            '@path': '$.properties.journey_context'
+          }
+        }
+      },
+      user_id: { '@path': '$.userId' },
+      personas_computation_key: { '@path': '$.context.personas.computation_key' },
+      personas_computation_id: { '@path': '$.context.personas.computation_id' },
+      personas_activation_id: { '@path': '$.context.personas.event_emitter_id' },
+      personas_computation_class: { '@path': '$.context.personas.computation_class' },
+      event_name: { '@path': '$.event' }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Moves default fields to specificEvent journey presets for the snowflake warehouse destination. This a follow up to https://github.com/segmentio/action-destinations/pull/3145

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
