### PR TITLE
Validate iam for liveramp S3

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
@@ -76,8 +76,11 @@ describe('Liveramp Audiences', () => {
       })
       .reply(200)
 
-    // Mock S3 HeadBucket request for permission validation
-    nock('https://s3-aws-bucket-name.s3.amazonaws.com').persist().head('/').reply(200)
+    // Mock S3 HeadBucket requests for permission validation (all bucket names)
+    nock(/https:\/\/.*\.s3\.amazonaws\.com/)
+      .persist()
+      .head('/')
+      .reply(200)
   })
   describe('audienceEnteredS3', () => {
     it('should send events with valid payload size and events', async () => {

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/liveramp.test.ts
@@ -75,6 +75,9 @@ describe('Liveramp Audiences', () => {
         return true
       })
       .reply(200)
+
+    // Mock S3 HeadBucket request for permission validation
+    nock('https://s3-aws-bucket-name.s3.amazonaws.com').persist().head('/').reply(200)
   })
   describe('audienceEnteredS3', () => {
     it('should send events with valid payload size and events', async () => {
@@ -326,6 +329,80 @@ describe('Liveramp Audiences', () => {
           `received payload count below LiveRamp's ingestion limits. expected: >=${LIVERAMP_MIN_RECORD_COUNT} actual: 3`
         )
         expect(e.status).toEqual(400)
+      }
+    })
+  })
+
+  describe('S3 Permissions Validation', () => {
+    it('should throw InvalidAuthenticationError if IAM credentials are invalid (403)', async () => {
+      // Mock S3 HeadBucket request to return 403 Forbidden
+      nock('https://test-bucket.s3.amazonaws.com').head('/').reply(403)
+
+      try {
+        await testDestination.executeBatch('audienceEnteredS3', {
+          events: mockedEvents,
+          mapping: {
+            s3_aws_access_key: 'invalid-access-key',
+            s3_aws_secret_key: 'invalid-secret-key',
+            s3_aws_bucket_name: 'test-bucket',
+            s3_aws_region: 'us-west-2',
+            audience_key: 'audience_key',
+            delimiter: ',',
+            filename: 'filename.csv',
+            enable_batching: true
+          },
+          subscriptionMetadata: {
+            destinationConfigId: 'destinationConfigId',
+            actionConfigId: 'actionConfigId'
+          },
+          settings: {
+            __segment_internal_engage_force_full_sync: true,
+            __segment_internal_engage_batch_sync: true
+          },
+          features: { 'liveramp-legacy-flow': true }
+        })
+        // Should not reach here
+        expect(true).toBe(false)
+      } catch (e) {
+        expect(e.message).toEqual(
+          'AWS IAM credentials are invalid or do not have permission to access S3 bucket "test-bucket". Please verify your access key, secret key, and bucket permissions.'
+        )
+      }
+    })
+
+    it('should throw InvalidAuthenticationError if S3 bucket does not exist (404)', async () => {
+      // Mock S3 HeadBucket request to return 404 Not Found
+      nock('https://nonexistent-bucket.s3.amazonaws.com').head('/').reply(404)
+
+      try {
+        await testDestination.executeBatch('audienceEnteredS3', {
+          events: mockedEvents,
+          mapping: {
+            s3_aws_access_key: 's3_aws_access_key',
+            s3_aws_secret_key: 's3_aws_secret_key',
+            s3_aws_bucket_name: 'nonexistent-bucket',
+            s3_aws_region: 'us-west-2',
+            audience_key: 'audience_key',
+            delimiter: ',',
+            filename: 'filename.csv',
+            enable_batching: true
+          },
+          subscriptionMetadata: {
+            destinationConfigId: 'destinationConfigId',
+            actionConfigId: 'actionConfigId'
+          },
+          settings: {
+            __segment_internal_engage_force_full_sync: true,
+            __segment_internal_engage_batch_sync: true
+          },
+          features: { 'liveramp-legacy-flow': true }
+        })
+        // Should not reach here
+        expect(true).toBe(false)
+      } catch (e) {
+        expect(e.message).toContain(
+          'S3 bucket "nonexistent-bucket" does not exist or is not accessible with the provided credentials.'
+        )
       }
     })
   })

--- a/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/__tests__/snapshot.test.ts
@@ -41,6 +41,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredS3 destinatio
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const events = new Array(25).fill(0).map(() =>
       createTestEvent({
@@ -86,6 +87,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredS3 destinatio
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const events = new Array(25).fill(0).map(() =>
       createTestEvent({
@@ -123,6 +125,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredS3 destinatio
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData
@@ -165,6 +168,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredSFTP destinat
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const events = new Array(25).fill(0).map(() =>
       createTestEvent({
@@ -197,6 +201,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredSFTP destinat
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const events = new Array(25).fill(0).map(() =>
       createTestEvent({
@@ -225,6 +230,7 @@ describe(`Testing snapshot for ${destinationSlug}'s audienceEnteredSFTP destinat
     nock(/.*/).persist().get(/.*/).reply(200)
     nock(/.*/).persist().post(/.*/).reply(200)
     nock(/.*/).persist().put(/.*/).reply(200)
+    nock(/.*/).persist().head(/.*/).reply(200)
 
     const event = createTestEvent({
       properties: eventData

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
-import { isValidS3Path, isValidS3BucketName, normalizeS3Path, uploadS3 } from './s3'
+import { isValidS3Path, isValidS3BucketName, normalizeS3Path, uploadS3, validateS3Permissions } from './s3'
 import { generateFile } from '../operations'
 import { sendEventToAWS } from '../awsClient'
 import {
@@ -142,6 +142,9 @@ async function processData(input: ProcessDataInput<Payload>, subscriptionMetadat
       `Invalid S3 bucket name: "${input.payloads[0].s3_aws_bucket_name}". Bucket names cannot contain '/' characters, must be lowercase, and follow AWS naming conventions.`
     )
   }
+
+  // validate IAM permissions for S3 access
+  await validateS3Permissions(input.payloads[0], input.request)
 
   // validate s3 path
   input.payloads[0].s3_aws_bucket_path = normalizeS3Path(input.payloads[0].s3_aws_bucket_path)

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/s3.ts
@@ -1,6 +1,7 @@
 import generateS3RequestOptions from '../../../lib/AWS/s3'
 import { InvalidAuthenticationError, ModifiedResponse, RequestOptions } from '@segment/actions-core'
 import { Payload } from './generated-types'
+import { PayloadValidationError } from '@segment/actions-core/*'
 
 function validateS3(payload: Payload) {
   if (!payload.s3_aws_access_key) {
@@ -147,14 +148,13 @@ async function validateS3Permissions(
   payload: Payload,
   request: <Data = unknown>(url: string, options?: RequestOptions) => Promise<ModifiedResponse<Data>>
 ) {
-  // Only validate if all required S3 credentials are provided
   if (
     !payload.s3_aws_access_key ||
     !payload.s3_aws_secret_key ||
     !payload.s3_aws_bucket_name ||
     !payload.s3_aws_region
   ) {
-    return
+    throw new PayloadValidationError('Missing required S3 credentials.')
   }
 
   try {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This change adds a validation logic to validate the IAM role for the liveramp audienceEnteredS3 action. This is done using HEAD request to the S3 bucket.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
