### PR TITLE
STRATCONN-4121:Customer.io timestamp fix to convert ISO-8601 timestam…

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/utils.test.ts
@@ -1,4 +1,42 @@
-import { resolveIdentifiers } from '../utils'
+import { resolveIdentifiers, isIsoDate } from '../utils'
+
+describe('isIsoDate', () => {
+  it('should return true for valid ISO date with fractional seconds from 1-9 digits', () => {
+    expect(isIsoDate('2023-12-25T14:30:45.1')).toBe(true) // 1 digit
+    expect(isIsoDate('2023-12-25T14:30:45.12')).toBe(true) // 2 digits
+    expect(isIsoDate('2023-12-25T14:30:45.123')).toBe(true) // 3 digits
+    expect(isIsoDate('2023-12-25T14:30:45.1234')).toBe(true) // 4 digits
+    expect(isIsoDate('2023-12-25T14:30:45.12345')).toBe(true) // 5 digits
+    expect(isIsoDate('2023-12-25T14:30:45.123456')).toBe(true) // 6 digits
+    expect(isIsoDate('2023-12-25T14:30:45.1234567')).toBe(true) // 7 digits
+    expect(isIsoDate('2023-12-25T14:30:45.12345678')).toBe(true) // 8 digits
+    expect(isIsoDate('2023-12-25T14:30:45.123456789')).toBe(true) // 9 digits
+  })
+
+  it('should return true for valid ISO date with fractional seconds and timezone', () => {
+    expect(isIsoDate('2023-12-25T14:30:45.123Z')).toBe(true) // UTC
+    expect(isIsoDate('2023-12-25T14:30:45.123456+05:30')).toBe(true) // timezone offset
+    expect(isIsoDate('2023-12-25T14:30:45.123456789-08:00')).toBe(true) // negative timezone
+  })
+
+  it('should return true for valid ISO date without fractional seconds', () => {
+    expect(isIsoDate('2023-12-25T14:30:45')).toBe(true)
+    expect(isIsoDate('2023-12-25T14:30:45Z')).toBe(true)
+    expect(isIsoDate('2023-12-25')).toBe(true) // date only
+  })
+
+  it('should return false for invalid fractional seconds i.e more than 9 digits', () => {
+    expect(isIsoDate('2023-12-25T14:30:45.1234567890')).toBe(false) // 10 digits
+    expect(isIsoDate('2023-12-25T14:30:45.12345678901')).toBe(false) // 11 digits
+  })
+
+  it('should return false for invalid date formats', () => {
+    expect(isIsoDate('invalid-date')).toBe(false)
+    expect(isIsoDate('2023-13-25')).toBe(false) // invalid month
+    expect(isIsoDate('2023-12-32')).toBe(false) // invalid day
+    expect(isIsoDate('2023-12-25T25:30:45')).toBe(false) // invalid hour
+  })
+})
 
 describe('resolveIdentifiers', () => {
   it('should return object_id and object_type_id if both are provided', () => {

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -15,7 +15,7 @@ const isIsoDate = (value: string): boolean => {
   const isoformat =
     '^\\d{4}-\\d{2}-\\d{2}' + // Match YYYY-MM-DD
     '((T\\d{2}:\\d{2}(:\\d{2})?)' + // Match THH:mm:ss
-    '(\\.\\d{1,6})?' + // Match .sssss
+    '(\\.\\d{1,9})?' + // Match .sssssss
     '(Z|(\\+|-)\\d{2}:?\\d{2})?)?$' // Time zone (Z or ±hh:mm or ±hhmm)
 
   const matcher = new RegExp(isoformat)
@@ -213,9 +213,10 @@ export const sendBatch = <Payload extends BasePayload>(request: Function, option
 
 export const sendSingle = <Payload extends BasePayload>(request: Function, options: RequestPayload<Payload>) => {
   const json = buildPayload(options)
-
   return request(`${trackApiEndpoint(options.settings)}/api/v2/entity`, {
     method: 'post',
     json
   })
 }
+
+export { isIsoDate }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This pull request is for fixing Customer.io timestamp validation to properly handle high-precision fractional seconds in ISO 8601 date strings.

- Updated the [[isIsoDate](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/customerio/utils.ts#L13)] function to support fractional seconds with up to 9 digits instead of the previous 6-digit limit 
- Improved Regex Pattern: Changed (\\.\\d{1,6})? to (\\.\\d{1,9})? to match ISO 8601 standard that allows more than 6 fractional digits

**Testing improvements:**
- Exported [[isIsoDate](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/customerio/utils.ts#L13)] function and added test coverage for fractional seconds validation from 1-9 digits along with edge cases including invalid dates with more than 9 fractional digits

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
