### PR TITLE
StackAdapt Audience Destination: Configure advertiser under basic settings instead of mappings

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,14 +1,14 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - all fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
+          externalProvider: "segment_io",
+          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
+          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
         }
       ) {
         userErrors {
@@ -18,8 +18,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",type:STRING,isPii:false,label:\\"External Profile ID\\"}],
-          mappableType: \\"segment_io\\"
+          mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {
@@ -29,8 +29,8 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-          mappableType: \\"segment_io\\"
+          mappingSchema: [{incomingKey:"audienceId",destinationKey:"external_id",type:STRING,label:"External Audience ID",isPii:false},{incomingKey:"audienceName",destinationKey:"name",type:STRING,label:"External Audience Name",isPii:false}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {
@@ -42,14 +42,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - required fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
+          externalProvider: "segment_io",
+          syncId: "7bcb527cec5517b1155595cd74dc96b6db6ed1d0c54b91ebe04297f3524bd775",
+          profiles: "[{\\"userId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceId\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"audienceName\\":\\"84GW[vK%wv2xv@UF5iy\\",\\"action\\":\\"exit\\"}]"
         }
       ) {
         userErrors {
@@ -59,8 +59,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",type:STRING,isPii:false,label:\\"External Profile ID\\"}],
-          mappableType: \\"segment_io\\"
+          mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {
@@ -70,8 +70,8 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-          mappableType: \\"segment_io\\"
+          mappingSchema: [{incomingKey:"audienceId",destinationKey:"external_id",type:STRING,label:"External Audience ID",isPii:false},{incomingKey:"audienceName",destinationKey:"name",type:STRING,label:"External Audience Name",isPii:false}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {
@@ -83,14 +83,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - all fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78\\",
-          profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"zobbufpop@usliz.mh\\\\\\",\\\\\\"firstName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"lastName\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"city\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"country\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"state\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"postalCode\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"birthDay\\\\\\":null,\\\\\\"birthMonth\\\\\\":null}]\\"
+          externalProvider: "segment_io",
+          syncId: "1187e62a973b77faa5387b91939d70295b25063e3439b583b997efa92d9c8e78",
+          profiles: "[{\\"email\\":\\"zobbufpop@usliz.mh\\",\\"firstName\\":\\"PsAwlRv%\\",\\"lastName\\":\\"PsAwlRv%\\",\\"phone\\":\\"PsAwlRv%\\",\\"city\\":\\"PsAwlRv%\\",\\"country\\":\\"PsAwlRv%\\",\\"state\\":\\"PsAwlRv%\\",\\"postalCode\\":\\"PsAwlRv%\\",\\"userId\\":\\"PsAwlRv%\\",\\"birthDay\\":null,\\"birthMonth\\":null}]"
         }
       ) {
         userErrors {
@@ -100,8 +100,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false}],
-          mappableType: \\"segment_io\\"
+          mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {
@@ -113,14 +113,14 @@ Object {
 `;
 
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - required fields 1`] = `
-Object {
+{
   "query": "mutation {
       upsertProfiles(
         input: {
           advertiserId: PsAwlRv%,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945\\",
-          profiles: \\"[]\\"
+          externalProvider: "segment_io",
+          syncId: "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+          profiles: "[]"
         }
       ) {
         userErrors {
@@ -130,8 +130,8 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false}],
-          mappableType: \\"segment_io\\"
+          mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false}],
+          mappableType: "segment_io"
         }
       ) {
         userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
@@ -39,13 +39,13 @@ describe('StackAdapt Audiences - Destination Tests', () => {
           }
         })
 
-      await expect(testDestination.testAuthentication(mockSettings)).resolves.not.toThrowError()
+      await expect(testDestination.testAuthentication(mockSettings)).resolves.not.toThrow()
     })
 
     it('should fail if authentication is invalid', async () => {
       nock(GQL_ENDPOINT).post('').reply(403, {})
 
-      await expect(testDestination.testAuthentication(mockSettings)).rejects.toThrowError('403Forbidden')
+      await expect(testDestination.testAuthentication(mockSettings)).rejects.toThrow('403Forbidden')
     })
   })
 
@@ -91,7 +91,7 @@ describe('StackAdapt Audiences - Destination Tests', () => {
         testDestination.onDelete!(event, {
           apiKey: 'test-api-key'
         })
-      ).rejects.toThrowError('Profile deletion was not successful: Deletion failed')
+      ).rejects.toThrow('Profile deletion was not successful: Deletion failed')
     })
   })
 })

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -10,12 +10,14 @@ const gqlHostUrl = 'https://api.stackadapt.com'
 const gqlPath = '/graphql'
 const mockUserId = 'user-id'
 const mockAdvertiserId = '23'
+const mockEmail = 'test@email.com'
 const mockMappings = { advertiser_id: mockAdvertiserId }
 
 const defaultEventPayload: Partial<SegmentEvent> = {
   userId: mockUserId,
   type: 'identify',
   traits: {
+    email: mockEmail,
     first_time_buyer: true
   },
   context: {
@@ -32,6 +34,7 @@ const trackEventPayload: Partial<SegmentEvent> = {
   type: 'track',
   event: 'Audience Entered',
   properties: {
+    email: mockEmail,
     audience_key: 'first_time_buyer',
     first_time_buyer: true
   },
@@ -64,28 +67,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "92dea893426582fc0d324d55831eb77d3c6d980baf8f18b9126ab258d0aaaa1c",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"exit\\"}]"
               }
             ) {
               userErrors {
@@ -94,9 +97,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",type:STRING,isPii:false,label:\\"External Profile ID\\"}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -105,9 +108,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertExternalAudienceMapping(
               input: {
-                advertiserId: 23,
-                mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchema: [{incomingKey:"audienceId",destinationKey:"external_id",type:STRING,label:"External Audience ID",isPii:false},{incomingKey:"audienceName",destinationKey:"name",type:STRING,label:"External Audience Name",isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -138,28 +141,28 @@ describe('forwardAudienceEvent', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "18173ad77a58c56aee5ef6ebde0ff2911b80807f32985ff1e10c03b02cd0b8bc",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
               }
             ) {
               userErrors {
@@ -168,9 +171,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",type:STRING,isPii:false,label:\\"External Profile ID\\"}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -179,9 +182,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertExternalAudienceMapping(
               input: {
-                advertiserId: 23,
-                mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchema: [{incomingKey:"audienceId",destinationKey:"external_id",type:STRING,label:"External Audience ID",isPii:false},{incomingKey:"audienceName",destinationKey:"name",type:STRING,label:"External Audience Name",isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -211,14 +214,14 @@ describe('forwardAudienceEvent', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"c371022fd0a74b3ff0376ee0a8838c0e7d21be220ba335bfdd7205bca9545bd3\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"},{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "bb034597bb8ca9ff6b1e4cf7919d8bb5920ed6cc5e596238b6bb05a88721e409",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"exit\\"},{\\"userId\\":\\"user-id\\",\\"audienceId\\":\\"aud_123\\",\\"audienceName\\":\\"first_time_buyer\\",\\"action\\":\\"enter\\"}]"
               }
             ) {
               userErrors {
@@ -227,9 +230,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",type:STRING,isPii:false,label:\\"External Profile ID\\"}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -238,9 +241,9 @@ describe('forwardAudienceEvent', () => {
             }
             upsertExternalAudienceMapping(
               input: {
-                advertiserId: 23,
-                mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchema: [{incomingKey:"audienceId",destinationKey:"external_id",type:STRING,label:"External Audience ID",isPii:false},{incomingKey:"audienceName",destinationKey:"name",type:STRING,label:"External Audience Name",isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -1,4 +1,4 @@
-import { RequestClient, InvalidAuthenticationError } from '@segment/actions-core'
+import { RequestClient } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { GQL_ENDPOINT, EXTERNAL_PROVIDER, sha256hash, stringifyJsonWithEscapedQuotes, stringifyMappingSchemaForGraphQL } from '../functions'

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -1,5 +1,6 @@
-import { RequestClient } from '@segment/actions-core'
+import { RequestClient, InvalidAuthenticationError } from '@segment/actions-core'
 import { Payload } from './generated-types'
+import { Settings } from '../generated-types'
 import { GQL_ENDPOINT, EXTERNAL_PROVIDER, sha256hash, stringifyJsonWithEscapedQuotes, stringifyMappingSchemaForGraphQL } from '../functions'
 
 const audienceMapping = stringifyMappingSchemaForGraphQL([
@@ -30,12 +31,13 @@ const profileMapping = stringifyMappingSchemaForGraphQL([
   }
 ])
 
-export async function performForwardAudienceEvents(request: RequestClient, events: Payload[]) {
-  const advertiserId = events[0].advertiser_id
+export async function performForwardAudienceEvents(request: RequestClient, events: Payload[], settings: Settings) {
+  const advertiserId = settings.advertiser_id
+
   const profileUpdates = events.map((event) => {
     const { segment_computation_key: audienceKey, segment_computation_id: audienceId, user_id, traits_or_props } = event
 
-    const { [audienceKey]: action } = traits_or_props
+    const action = traits_or_props[audienceKey]
     return {
       userId: user_id,
       audienceId,

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
@@ -54,7 +54,7 @@ export interface Payload {
    */
   user_id?: string
   /**
-   * The Segment event type (identify, alias, etc.)
+   * The Segment event type (identify or track)
    */
   event_type: string
   /**

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
@@ -2,11 +2,53 @@
 
 export interface Payload {
   /**
+   * The properties of the user.
+   */
+  traits?: {
+    /**
+     * The user's first name.
+     */
+    firstName?: string
+    /**
+     * The user's last name.
+     */
+    lastName?: string
+    /**
+     * The phone number of the user.
+     */
+    phone?: string
+    /**
+     * The city of the user.
+     */
+    city?: string
+    /**
+     * The country of the user.
+     */
+    country?: string
+    /**
+     * The state of the user.
+     */
+    state?: string
+    /**
+     * The postal code of the user.
+     */
+    postalCode?: string
+    /**
+     * The birthday of the user.
+     */
+    birthday?: string
+    [k: string]: unknown
+  }
+  /**
    * The properties of the user or event.
    */
   traits_or_props: {
     [k: string]: unknown
   }
+  /**
+   * The email address of the user.
+   */
+  email: string
   /**
    * The ID of the user in Segment
    */
@@ -14,7 +56,7 @@ export interface Payload {
   /**
    * The Segment event type (identify, alias, etc.)
    */
-  event_type?: string
+  event_type: string
   /**
    * When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.
    */
@@ -22,17 +64,13 @@ export interface Payload {
   /**
    * Segment computation class used to determine if input event is from an Engage Audience'.
    */
-  segment_computation_class?: string
+  segment_computation_class: string
   /**
    * For audience enter/exit events, this will be the audience ID.
    */
-  segment_computation_id?: string
+  segment_computation_id: string
   /**
    * For audience enter/exit events, this will be the audience key.
    */
   segment_computation_key: string
-  /**
-   * The StackAdapt advertiser to add the profile to.
-   */
-  advertiser_id: string
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -2,13 +2,120 @@ import { ActionDefinition } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { performForwardAudienceEvents } from './functions'
-import { advertiserIdFieldImplementation } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward Audience Event',
   description: 'Forward audience enter or exit events to StackAdapt',
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: {
+    traits: {
+      label: 'User Properties',
+      type: 'object',
+      description: 'The properties of the user.',
+      defaultObjectUI: 'keyvalue',
+      additionalProperties: true,
+      required: false,
+      properties: {
+        firstName: {
+          label: 'First Name',
+          type: 'string',
+          description: "The user's first name."
+        },
+        lastName: {
+          label: 'Last Name',
+          type: 'string',
+          description: "The user's last name."
+        },
+        phone: {
+          label: 'Phone',
+          type: 'string',
+          description: 'The phone number of the user.'
+        },
+        city: {
+          label: 'City',
+          type: 'string',
+          description: 'The city of the user.'
+        },
+        country: {
+          label: 'Country',
+          type: 'string',
+          description: 'The country of the user.'
+        },
+        state: {
+          label: 'State',
+          type: 'string',
+          description: 'The state of the user.'
+        },
+        postalCode: {
+          label: 'Postal Code',
+          type: 'string',
+          description: 'The postal code of the user.'
+        },
+        birthday: {
+          label: 'Birthday',
+          type: 'string',
+          description: 'The birthday of the user.'
+        }
+      },
+      default: {
+        firstName: {
+          '@if': {
+            exists: { '@path': '$.traits.first_name' },
+            then: { '@path': '$.traits.first_name' },
+            else: { '@path': '$.properties.first_name' }
+          }
+        },
+        lastName: {
+          '@if': {
+            exists: { '@path': '$.traits.last_name' },
+            then: { '@path': '$.traits.last_name' },
+            else: { '@path': '$.properties.last_name' }
+          }
+        },
+        phone: {
+          '@if': {
+            exists: { '@path': '$.traits.phone' },
+            then: { '@path': '$.traits.phone' },
+            else: { '@path': '$.properties.phone' }
+          }
+        },
+        city: {
+          '@if': {
+            exists: { '@path': '$.traits.address.city' },
+            then: { '@path': '$.traits.address.city' },
+            else: { '@path': '$.properties.address.city' }
+          }
+        },
+        country: {
+          '@if': {
+            exists: { '@path': '$.traits.address.country' },
+            then: { '@path': '$.traits.address.country' },
+            else: { '@path': '$.properties.address.country' }
+          }
+        },
+        state: {
+          '@if': {
+            exists: { '@path': '$.traits.address.state' },
+            then: { '@path': '$.traits.address.state' },
+            else: { '@path': '$.properties.address.state' }
+          }
+        },
+        postalCode: {
+          '@if': {
+            exists: { '@path': '$.traits.address.postalCode' },
+            then: { '@path': '$.traits.address.postalCode' },
+            else: { '@path': '$.properties.address.postalCode' }
+          }
+        },
+        birthday: {
+          '@if': {
+            exists: { '@path': '$.traits.birthday' },
+            then: { '@path': '$.traits.birthday' },
+            else: { '@path': '$.properties.birthday' }
+          }
+        }
+      }
+    },
     traits_or_props: {
       label: 'Event Properties',
       type: 'object',
@@ -17,11 +124,25 @@ const action: ActionDefinition<Settings, Payload> = {
       required: true,
       default: {
         '@if': {
-          exists: { '@path': '$.properties.audience_key' },
+          exists: { '@path': '$.properties' },
           then: { '@path': '$.properties' },
           else: { '@path': '$.traits' }
         }
       }
+    },
+    email: {
+      label: 'Email',
+      description: 'The email address of the user.',
+      type: 'string',
+      format: 'email',
+      required: true,
+      default: {
+        '@if': {
+          exists: { '@path': '$.traits.email' },
+          then: { '@path': '$.traits.email' },
+          else: { '@path': '$.properties.email' }
+        }
+      } 
     },
     user_id: {
       label: 'Segment User ID',
@@ -41,6 +162,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Event Type',
       description: 'The Segment event type (identify, alias, etc.)',
       type: 'string',
+      required: true,
       default: {
         '@path': '$.type'
       }
@@ -56,18 +178,21 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     segment_computation_class: {
       label: 'Segment Computation Class',
+      required: true,
       description: "Segment computation class used to determine if input event is from an Engage Audience'.",
       type: 'string',
       unsafe_hidden: true,
       default: {
         '@path': '$.context.personas.computation_class'
-      }
+      },
+      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
     },
     segment_computation_id: {
       label: 'Segment Computation ID',
       description: 'For audience enter/exit events, this will be the audience ID.',
       type: 'string',
       unsafe_hidden: true,
+      required: true,
       default: {
         '@path': '$.context.personas.computation_id'
       }
@@ -81,24 +206,13 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.personas.computation_key'
       }
-    },
-    advertiser_id: {
-      label: 'Advertiser',
-      description: 'The StackAdapt advertiser to add the profile to. Either this field or the main Settings Advertiser field is required.',
-      type: 'string',
-      disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
-      required: false,
-      dynamic: true
     }
   },
-  dynamicFields: {
-    advertiser_id: advertiserIdFieldImplementation
+  perform: async (request, { payload, settings }) => {
+    return await performForwardAudienceEvents(request, [payload], settings)
   },
-  perform: async (request, { payload }) => {
-    return await performForwardAudienceEvents(request, [payload])
-  },
-  performBatch: async (request, { payload }) => {
-    return await performForwardAudienceEvents(request, payload)
+  performBatch: async (request, { payload, settings }) => {
+    return await performForwardAudienceEvents(request, payload, settings)
   }
 }
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -84,10 +84,10 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     advertiser_id: {
       label: 'Advertiser',
-      description: 'The StackAdapt advertiser to add the profile to.',
+      description: 'The StackAdapt advertiser to add the profile to. Either this field or the main Settings Advertiser field is required.',
       type: 'string',
       disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
-      required: true,
+      required: false,
       dynamic: true
     }
   },

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -160,7 +160,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     event_type: {
       label: 'Event Type',
-      description: 'The Segment event type (identify, alias, etc.)',
+      description: 'The Segment event type (identify or track)',
       type: 'string',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -100,28 +100,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
               }
             ) {
               userErrors {
@@ -130,9 +130,9 @@ describe('forwardProfile', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -163,28 +163,28 @@ describe('forwardProfile', () => {
     expect(responses[0].status).toBe(200)
     expect(responses[0].request.headers).toMatchInlineSnapshot(`
       Headers {
-        Symbol(map): Object {
-          "authorization": Array [
+        Symbol(map): {
+          "authorization": [
             "Bearer test-graphql-key",
           ],
-          "content-type": Array [
+          "content-type": [
             "application/json",
           ],
-          "user-agent": Array [
+          "user-agent": [
             "Segment (Actions)",
           ],
         },
       }
     `)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "e6a568a61b0264fb8038ae64dbfb72032f7d1f5b32cf54acbe02979d9312f470",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2}]"
               }
             ) {
               userErrors {
@@ -193,9 +193,9 @@ describe('forwardProfile', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -225,14 +225,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2\\",
-                profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"birthDay\\\\\\":1,\\\\\\"birthMonth\\\\\\":2},{\\\\\\"email\\\\\\":\\\\\\"email2@stackadapt.com\\\\\\",\\\\\\"customField\\\\\\":\\\\\\"value\\\\\\",\\\\\\"numberCustomField\\\\\\":123,\\\\\\"userId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "fab5978d05bc4be0dadaed90eb6372333239e1c0c464a6a62b48d34cbaf676b2",
+                profiles: "[{\\"email\\":\\"admin@stackadapt.com\\",\\"userId\\":\\"user-id\\",\\"birthDay\\":1,\\"birthMonth\\":2},{\\"email\\":\\"email2@stackadapt.com\\",\\"customField\\":\\"value\\",\\"numberCustomField\\":123,\\"userId\\":\\"user-id2\\"}]"
               }
             ) {
               userErrors {
@@ -241,9 +241,9 @@ describe('forwardProfile', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false},{incomingKey:\\"customField\\",destinationKey:\\"customField\\",label:\\"Custom Field\\",type:STRING,isPii:false},{incomingKey:\\"numberCustomField\\",destinationKey:\\"numberCustomField\\",label:\\"Number Custom Field\\",type:NUMBER,isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false},{incomingKey:"customField",destinationKey:"customField",label:"Custom Field",type:STRING,isPii:false},{incomingKey:"numberCustomField",destinationKey:"numberCustomField",label:"Number Custom Field",type:NUMBER,isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {
@@ -273,14 +273,14 @@ describe('forwardProfile', () => {
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(requestBody).toMatchInlineSnapshot(`
-      Object {
+      {
         "query": "mutation {
             upsertProfiles(
               input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"previousId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
+                advertiserId: undefined,
+                externalProvider: "segment_io",
+                syncId: "b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e",
+                profiles: "[{\\"userId\\":\\"user-id\\",\\"previousId\\":\\"user-id2\\"}]"
               }
             ) {
               userErrors {
@@ -289,9 +289,9 @@ describe('forwardProfile', () => {
             }
             upsertProfileMapping(
               input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"userId\\",destinationKey:\\"external_id\\",label:\\"User Id\\",type:STRING,isPii:false}],
-                mappableType: \\"segment_io\\"
+                advertiserId: undefined,
+                mappingSchemaV2: [{incomingKey:"userId",destinationKey:"external_id",label:"User Id",type:STRING,isPii:false}],
+                mappableType: "segment_io"
               }
             ) {
               userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -1,4 +1,4 @@
-import { RequestClient, InvalidAuthenticationError } from '@segment/actions-core'
+import { RequestClient } from '@segment/actions-core'
 import camelCase from 'lodash/camelCase'
 import isEmpty from 'lodash/isEmpty'
 import { Payload } from './generated-types'

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -35,10 +35,8 @@ interface Mapping {
 export async function performForwardProfiles(request: RequestClient, events: Payload[], settings: Settings) {
   const fieldsToMap: Set<string> = new Set(['userId'])
   const fieldTypes: Record<string, string> = { userId: 'string' }
-  const advertiserId = events[0]?.advertiser_id ?? settings.advertiser_id
-  if(!advertiserId) {
-    throw new InvalidAuthenticationError("Advertiser value must be provided in either the main Settings Advertiser field or at the Action level Advertiser field.")
-  }
+  const advertiserId = settings.advertiser_id
+ 
   const profileUpdates = events.flatMap((event) => {
     const { event_type, previous_id, user_id, traits } = event
     const profile: Record<string, string | number | undefined> = {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
@@ -59,8 +59,4 @@ export interface Payload {
    * When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.
    */
   enable_batching: boolean
-  /**
-   * The StackAdapt advertiser to add the profile to.
-   */
-  advertiser_id: string
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -2,7 +2,6 @@ import { ActionDefinition } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { performForwardProfiles } from './functions'
-import { advertiserIdFieldImplementation } from '../functions'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward Profile',
@@ -167,19 +166,9 @@ const action: ActionDefinition<Settings, Payload> = {
         'When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.',
       required: true,
       default: true
-    },
-    advertiser_id: {
-      label: 'Advertiser',
-      description: 'The StackAdapt advertiser to add the profile to. Either this field or the main Settings Advertiser field is required.',
-      type: 'string',
-      disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
-      required: false,
-      dynamic: true
     }
   },
-  dynamicFields: {
-    advertiser_id: advertiserIdFieldImplementation
-  },
+  // Only being triggered when user use the event testing tool since batching is always enabled and hidden from user
   perform: async (request, { settings, payload }) => {
     return await performForwardProfiles(request, [payload], settings)
   },

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -170,21 +170,21 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     advertiser_id: {
       label: 'Advertiser',
-      description: 'The StackAdapt advertiser to add the profile to.',
+      description: 'The StackAdapt advertiser to add the profile to. Either this field or the main Settings Advertiser field is required.',
       type: 'string',
       disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
-      required: true,
+      required: false,
       dynamic: true
     }
   },
   dynamicFields: {
     advertiser_id: advertiserIdFieldImplementation
   },
-  perform: async (request, { payload }) => {
-    return await performForwardProfiles(request, [payload])
+  perform: async (request, { settings, payload }) => {
+    return await performForwardProfiles(request, [payload], settings)
   },
-  performBatch: async (request, { payload }) => {
-    return await performForwardProfiles(request, payload)
+  performBatch: async (request, { settings, payload }) => {
+    return await performForwardProfiles(request, payload, settings)
   }
 }
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
@@ -28,8 +28,20 @@ export const EXTERNAL_PROVIDER = 'segment_io'
 export const GQL_ENDPOINT = 'https://api.stackadapt.com/graphql'
 
 export async function advertiserIdFieldImplementation(
-  request: ReturnType<typeof createRequestClient>
+  request: ReturnType<typeof createRequestClient>,
+  { settings }: any
 ): Promise<DynamicFieldResponse> {
+  if (!settings?.apiKey) {
+    return {
+      choices: [],
+      nextPage: '',
+      error: {
+        message: 'Please configure the API Key field before setting the Advertiser field value',
+        code: 'API Key Missing'
+      }
+    }
+  }
+
   try {
     const query = `query {
         tokenInfo {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/functions.ts
@@ -27,55 +27,6 @@ interface TokenInfoResponse {
 export const EXTERNAL_PROVIDER = 'segment_io'
 export const GQL_ENDPOINT = 'https://api.stackadapt.com/graphql'
 
-export async function advertiserIdFieldImplementation(
-  request: ReturnType<typeof createRequestClient>,
-  { settings }: any
-): Promise<DynamicFieldResponse> {
-  if (!settings?.apiKey) {
-    return {
-      choices: [],
-      nextPage: '',
-      error: {
-        message: 'Please configure the API Key field before setting the Advertiser field value',
-        code: 'API Key Missing'
-      }
-    }
-  }
-
-  try {
-    const query = `query {
-        tokenInfo {
-          scopesByAdvertiser {
-            nodes {
-              advertiser {
-                id
-                name
-              }
-              scopes
-            }
-          }
-        }
-      }`
-    const response = await request<TokenInfoResponse>(GQL_ENDPOINT, {
-      body: JSON.stringify({ query })
-    })
-    const scopesByAdvertiser = response.data.data.tokenInfo.scopesByAdvertiser
-    const choices = scopesByAdvertiser.nodes
-      .filter((advertiserEntry) => advertiserEntry.scopes.includes('WRITE'))
-      .map((advertiserEntry) => ({ value: advertiserEntry.advertiser.id, label: advertiserEntry.advertiser.name }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-    return { choices }
-  } catch (error) {
-    return {
-      choices: [],
-      nextPage: '',
-      error: {
-        message: (error as APIError).message ?? 'Unknown error',
-        code: (error as APIError).status?.toString() ?? 'Unknown error'
-      }
-    }
-  }
-}
 
 export function sha256hash(data: string) {
   const hash = createHash('sha256')

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   apiKey: string
   /**
-   * The StackAdapt advertiser to add the profile to. The value in this field field can also be overridden at the Action level via the Action field of the same name.
+   * The StackAdapt advertiser ID to add the profile to. The value in this field field can also be overridden at the Action level via the Action field of the same name.
    */
   advertiser_id?: string
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * Your StackAdapt GQL API Token
    */
   apiKey: string
+  /**
+   * The StackAdapt advertiser to add the profile to. The value in this field field can also be overridden at the Action level via the Action field of the same name.
+   */
+  advertiser_id?: string
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -65,7 +65,6 @@ const destination: DestinationDefinition<Settings> = {
               }))
               .sort((a: any, b: any) => a.label.localeCompare(b.label))
             
-            console.log('=============choices', choices)
             return { choices }
           } catch (error: any) {
             return {
@@ -121,10 +120,7 @@ const destination: DestinationDefinition<Settings> = {
     const userId = payload.userId
     const formattedExternalIds = `["${userId}"]`
     const syncId = sha256hash(String(userId))
-    const advertiserId = settings.advertiser_id
-    if(!advertiserId) {
-      throw new InvalidAuthenticationError("To delete a user, the Advertiser field in Settings should be populated.")
-    }
+    const advertiserId = settings.advertiser_id as string
 
     const mutation = `mutation {
       deleteProfilesWithExternalIds(

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -24,8 +24,7 @@ const destination: DestinationDefinition<Settings> = {
         label: "Advertiser ID",
         description: "The StackAdapt advertiser ID to add the profile to. The value in this field field can also be overridden at the Action level via the Action field of the same name.",
         type: 'string', 
-        required: true,
-        disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
+        required: false,
         dynamic: advertiserIdFieldImplementation
       }
     },
@@ -73,7 +72,7 @@ const destination: DestinationDefinition<Settings> = {
     const syncId = sha256hash(String(userId))
     const advertiserId = settings.advertiser_id
     if(!advertiserId) {
-      throw new InvalidAuthenticationError("Advertiser value must be provided in either the main Settings Advertiser field or at the Action level Advertiser field.")
+      throw new InvalidAuthenticationError("To delete a user, the Advertiser field in Settings should be populated.")
     }
 
     const mutation = `mutation {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
