### PR TITLE
[MAIN] [STRATCONN-6111] : [Braze]  Remove devicePropertyAllowList in braze SDK initialization for empty string array and only pass devicePropertyAllowList when there is a non empty string is filled from UI side 

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/destinations/braze/src/__tests__/initialization.test.ts
@@ -136,4 +136,34 @@ describe('initialization', () => {
     expect(openSessionSpy).toHaveBeenCalled()
     expect(logCustomEventSpy).toHaveBeenCalledWith('FIFA', { goat: 'deno' })
   })
+
+  test('passes devicePropertyAllowlist to Braze SDK initialization', async () => {
+    const devicePropertyAllowlist = ['os', 'browser']
+    const [event] = await brazeDestination({
+      api_key: 'b_123',
+      endpoint: 'endpoint',
+      sdkVersion: '3.5',
+      doNotLoadFontAwesome: true,
+      devicePropertyAllowlist,
+      subscriptions: [
+        {
+          partnerAction: 'trackEvent',
+          name: 'Track Event',
+          enabled: true,
+          subscribe: 'type = "track"',
+          mapping: {
+            eventName: { '@path': '$.event' },
+            eventProperties: { '@path': '$.properties' }
+          }
+        }
+      ]
+    })
+
+    const initializeSpy = jest.spyOn(destination, 'initialize')
+    await event.load(Context.system(), {} as Analytics)
+
+    // Check that the config passed to initialize contains the allowlist
+    const callArgs = initializeSpy.mock.calls[0][0]?.settings || {}
+    expect(callArgs.devicePropertyAllowlist).toEqual(devicePropertyAllowlist)
+  })
 })

--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -322,8 +322,19 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         // @ts-expect-error same as above.
         subscriptions,
         deferUntilIdentified,
+        devicePropertyAllowlist,
         ...expectedConfig
       } = settings
+
+      type BrazeConfig = typeof expectedConfig & {
+        devicePropertyAllowlist?: string[]
+      }
+      const config: BrazeConfig = { ...expectedConfig }
+      if (Array.isArray(devicePropertyAllowlist)) {
+        if (devicePropertyAllowlist.some((item) => item.trim() !== '')) {
+          config.devicePropertyAllowlist = devicePropertyAllowlist
+        }
+      }
 
       const version = sdkVersion ?? defaultVersion
 
@@ -351,7 +362,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
           if (
             !client.instance.initialize(api_key, {
               baseUrl: window.BRAZE_BASE_URL || endpoint,
-              ...expectedConfig
+              ...config
             })
           ) {
             return false


### PR DESCRIPTION


<!-- Hello and thank you for contributing to Segment action-destinations! -->
 ## JIRA 
 
 https://twilio-engineering.atlassian.net/browse/STRATCONN-6111

<!-- Hello and thank you for contributing to Segment action-destinations! -->

_A summary of your pull request, including the what change you're making and why._

## Description 
1. This PR includes changes for braze browser destination for devicePropertyAllowList field in settings .
2. Pass devicePropertyAllowList field in SDK initialization only in case of at least one non empty string is added from UI side .
3. This change is done as per request done by Melio customer and for more information please refer above jira ticket.
<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing
Please find the testing document attached here .
https://docs.google.com/document/d/1h54Whz9omf3Kkz3Lg2b6vPBhy60PWROIbmB84mZ_n6Y/edit?tab=t.0

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
