### PR TITLE
Added discountApplication object property to Cordial's upsertOrder action payload

### DIFF
--- a/packages/destination-actions/src/destinations/cordial/cordial-client.ts
+++ b/packages/destination-actions/src/destinations/cordial/cordial-client.ts
@@ -129,7 +129,8 @@ class CordialClient {
         status: payload.status,
         totalAmount: payload.totalAmount,
         properties: payload.properties,
-        items: payload.items
+        items: payload.items,
+        discountApplication: payload.discountApplication
       }
     })
   }

--- a/packages/destination-actions/src/destinations/cordial/cordial-client.ts
+++ b/packages/destination-actions/src/destinations/cordial/cordial-client.ts
@@ -8,6 +8,7 @@ import { Payload as AddProductToCartPayload } from './addProductToCart/generated
 import { Payload as RemoveProductFromCartPayload } from './removeProductFromCart/generated-types'
 import { Payload as UpsertOrder } from './upsertOrder/generated-types'
 import { Payload as MergeContacts } from './mergeContacts/generated-types'
+import isEmpty from 'lodash/isEmpty'
 
 export interface IdentifiableRequest {
   segmentId?: string | null,
@@ -130,7 +131,9 @@ class CordialClient {
         totalAmount: payload.totalAmount,
         properties: payload.properties,
         items: payload.items,
-        discountApplication: payload.discountApplication
+        discountApplication: (!isEmpty(payload.discountApplication) && payload?.discountApplication?.type === 'fixed' && payload?.discountApplication?.amount)
+          ? payload.discountApplication
+          : null
       }
     })
   }

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`Testing snapshot for Cordial's upsertOrder destination action: all fields 1`] = `
 Object {
   "anonymousId": "5)FqhW#w85$",
+  "discountApplication": Object {
+    "amount": -17352532573552.64,
+    "type": "5)FqhW#w85$",
+  },
   "items": Array [
     Object {
       "category": "5)FqhW#w85$",

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/__tests__/index.test.ts
@@ -187,4 +187,91 @@ describe('Cordial.upsertOrder', () => {
       ]
     })
   })
+  it('should work with discountApplication only', async () => {
+    nock(/api.cordial.io/).post('/api/segment/upsertOrder').once().reply(202, {success: 'success'})
+
+    const event = createTestEvent({
+      event: 'Order Completed',
+      userId: 'abc123',
+      timestamp: '1631210000',
+      properties: {
+        order_id: "test-order",
+        total: 546.05,
+        discount: 11.43,
+        products: [
+          {
+            product_id: '51easf12',
+            sku: 'TEST-SKU',
+            name: 'TEST-SKU',
+          },
+          {
+            product_id: 'gserq3eas',
+            sku: 'TEST-SKU2',
+            name: 'TEST-SKU',
+          }
+        ]
+      }
+    })
+
+    const mapping = {
+      userIdentities: {'channels.email.address': 'contact@example.com'},
+      orderID: { '@path': '$.properties.order_id' },
+      purchaseDate: { '@path': '$.timestamp' },
+      status: { '@path': '$.event' },
+      totalAmount: { '@path': '$.properties.total' },
+      discountApplication: {
+        type: 'fixed',
+        amount: { '@path': '$.properties.discount' }
+      },
+      items: {
+        '@arrayPath': [
+          '$.properties.products',
+          {
+            productID: {'@path': '$.product_id'},
+            sku: {'@path': '$.sku'},
+            name: {'@path': '$.name'}
+          }
+        ]
+      }
+    }
+
+    const settings = {
+      apiKey: 'cordialApiKey',
+      endpoint: 'https://api.cordial.io' as const
+    }
+
+    const responses = await testDestination.testAction('upsertOrder', {
+      event,
+      mapping,
+      settings,
+      useDefaultMappings: false
+    })
+
+    expect(responses[0].status).toBe(202);
+    expect(responses[0].data).toMatchObject({success: 'success'});
+    expect(responses[0].options.json).toMatchObject({
+      userIdentities: { 'channels.email.address': 'contact@example.com' },
+      orderID: 'test-order',
+      purchaseDate: '1631210000',
+      status: 'Order Completed',
+      totalAmount: 546.05,
+      discountApplication: {
+        type: 'fixed',
+        amount: 11.43
+      },
+      properties: undefined,
+      items: [
+        {
+          productID: '51easf12',
+          sku: 'TEST-SKU',
+          name: 'TEST-SKU'
+        },
+        {
+          productID: 'gserq3eas',
+          sku: 'TEST-SKU2',
+          name: 'TEST-SKU'
+        }
+      ]
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
@@ -32,6 +32,19 @@ export interface Payload {
    */
   totalAmount: number
   /**
+   * Discount application data
+   */
+  discountApplication?: {
+    /**
+     * Type of discount applied to the order (e.g. fixed)
+     */
+    type?: string
+    /**
+     * Amount of the discount applied to the order
+     */
+    amount?: number
+  }
+  /**
    * Additional order properties (e.g. affiliation/tax/revenue)
    */
   properties?: {

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
@@ -32,7 +32,7 @@ export interface Payload {
    */
   totalAmount: number
   /**
-   * Discount application data
+   * Discount application data, allowed fields: type (only 'fixed' as of now), amount (float discount amount, e.g. 10.45)
    */
   discountApplication?: {
     /**

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
@@ -38,11 +38,11 @@ export interface Payload {
     /**
      * Type of discount applied to the order (e.g. fixed)
      */
-    type?: string
+    type: string
     /**
      * Amount of the discount applied to the order
      */
-    amount?: number
+    amount: number
   }
   /**
    * Additional order properties (e.g. affiliation/tax/revenue)

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/generated-types.ts
@@ -38,11 +38,11 @@ export interface Payload {
     /**
      * Type of discount applied to the order (e.g. fixed)
      */
-    type: string
+    type?: string
     /**
      * Amount of the discount applied to the order
      */
-    amount: number
+    amount?: number
   }
   /**
    * Additional order properties (e.g. affiliation/tax/revenue)

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
@@ -48,9 +48,13 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     discountApplication: {
       label: 'Discount application',
-      description: 'Discount application data',
+      description: 'Discount application data, allowed fields: type (only \'fixed\' as of now), amount (float discount amount, e.g. 10.45)',
       type: 'object',
       required: false,
+      default: {
+        type: 'fixed',
+        amount: { '@path': '$.properties.discount' }
+      },
       properties: {
         type: {
           label: 'Type',

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
@@ -60,14 +60,17 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Type',
           description: 'Type of discount applied to the order (e.g. fixed)',
           type: 'string',
-          required: true,
-          placeholder: 'fixed'
+          required: false,
+          placeholder: 'fixed',
+          choices: [
+            {value: 'fixed', label: 'fixed'}
+          ]
         },
         amount: {
           label: 'Amount',
           description: 'Amount of the discount applied to the order',
           type: 'number',
-          required: true,
+          required: false,
           placeholder: '0.0'
         }
       }

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
@@ -46,6 +46,28 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties.total'
       }
     },
+    discountApplication: {
+      label: 'Discount application',
+      description: 'Discount application data',
+      type: 'object',
+      required: false,
+      properties: {
+        type: {
+          label: 'Type',
+          description: 'Type of discount applied to the order (e.g. fixed)',
+          type: 'string',
+          required: false,
+          placeholder: 'fixed'
+        },
+        amount: {
+          label: 'Amount',
+          description: 'Amount of the discount applied to the order',
+          type: 'number',
+          required: false,
+          placeholder: '0.0'
+        }
+      }
+    },
     properties: {
       label: 'Order properties',
       description: 'Additional order properties (e.g. affiliation/tax/revenue)',

--- a/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
+++ b/packages/destination-actions/src/destinations/cordial/upsertOrder/index.ts
@@ -60,14 +60,14 @@ const action: ActionDefinition<Settings, Payload> = {
           label: 'Type',
           description: 'Type of discount applied to the order (e.g. fixed)',
           type: 'string',
-          required: false,
+          required: true,
           placeholder: 'fixed'
         },
         amount: {
           label: 'Amount',
           description: 'Amount of the discount applied to the order',
           type: 'number',
-          required: false,
+          required: true,
           placeholder: '0.0'
         }
       }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Added new optional object property `discountApplication` to Cordial's upsertOrder action.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
