### PR TITLE
SECOPS-16392 Fix: update @aws-sdk/client-sts dependency version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     }
   },
   "dependencies": {
-    "@aws-sdk/client-sts": "3.614.0",
     "chance": "^1.1.8",
     "liquidjs": "^10.21.0",
     "xml-js": "^1.6.11"

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -80,7 +80,6 @@
       "@bufbuild/protobuf/codegenv1": "<rootDir>/../../node_modules/@bufbuild/protobuf/dist/cjs/codegenv1"
     },
     "setupFilesAfterEnv": [
-      "<rootDir>/jest.setup.js",
       "<rootDir>/test/setup-after-env.ts"
     ],
     "coverageReporters": [

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -43,6 +43,7 @@
     "@amplitude/ua-parser-js": "^0.7.25",
     "@aws-sdk/client-eventbridge": "^3.741.0",
     "@aws-sdk/client-s3": "^3.600.0",
+    "@aws-sdk/client-sts": "3.614.0",
     "@bufbuild/protobuf": "^2.2.3",
     "@segment/a1-notation": "^2.1.4",
     "@segment/actions-core": "^3.159.0",
@@ -79,6 +80,7 @@
       "@bufbuild/protobuf/codegenv1": "<rootDir>/../../node_modules/@bufbuild/protobuf/dist/cjs/codegenv1"
     },
     "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js",
       "<rootDir>/test/setup-after-env.ts"
     ],
     "coverageReporters": [


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


This pull request primarily reorganizes how the `@aws-sdk/client-sts` dependency is managed, ensuring it is only included where needed. 

Dependency management improvements:

* Removed `@aws-sdk/client-sts` from the top-level `package.json` to avoid unnecessary inclusion in all packages.
* Added `@aws-sdk/client-sts` as a dependency specifically to `packages/destination-actions/package.json`, ensuring it is only installed where required.

Currently when I am running the tests after upgrading dependencies in integrations I am facing below error

```
  ✖ No tests found in Service/service.test.js

  ─

  Uncaught exception in Service/service.test.js

  Error: Cannot find module '@aws-sdk/client-sts'
  Require stack:
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/@segment/action-destinations/dist/destinations/aws-s3/syncAudienceToCSV/s3.js
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/@segment/action-destinations/dist/destinations/aws-s3/syncAudienceToCSV/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/@segment/action-destinations/dist/destinations/aws-s3/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/@segment/action-destinations/dist/destinations/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/@segment/action-destinations/dist/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/integrations/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/Service/index.js
  - /Users/abhandage/GitHub/segmentio/integrations/Service/service.test.js
  - /Users/abhandage/GitHub/segmentio/integrations/node_modules/ava/lib/worker/subprocess.js
```
Because @aws-sdk/client-sts has not been added as a directly dependency in actions-destinations.

Hence adding it here.


## Testing

not required 

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
