### PR TITLE
[Twilio messaging destination] - Enable free-text input for Messaging Service SID And Content Template SID

### DIFF
--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/fields.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/fields.ts
@@ -135,7 +135,6 @@ export const fields: Record<string, InputField> = {
     },
     default: undefined,
     allowNull: false,
-    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
     depends_on: {
       match: 'all',
       conditions: [
@@ -159,7 +158,6 @@ export const fields: Record<string, InputField> = {
     dynamic: true,
     required: false,
     allowNull: false,
-    disabledInputMethods: ['variable', 'function'],
     depends_on: {
       match: 'all',
       conditions: [


### PR DESCRIPTION
Requested by a customer - losening the Messaging Service SID And Content Template SID fields to allow freeform and mappings. 

## Testing
Not needed. 