### PR TITLE
[Action Tester] - Clearing responses after action incovation for actions tester

### DIFF
--- a/packages/cli/src/lib/server.ts
+++ b/packages/cli/src/lib/server.ts
@@ -311,6 +311,7 @@ function setupRoutes(def: DestinationDefinition | null): void {
           }
 
           const debug = await getExchanges(destination.responses)
+          destination.responses.splice(0, destination.responses.length)  
           return res.status(200).json(debug)
         } catch (err) {
           const output = marshalError(err as ResponseError)


### PR DESCRIPTION
Action Tester tool retains all responses after every Action invocation, when it should be clearing them. 
This results in an ever expanding list of responses which make debugging more difficult. 

## Testing

Tested locally.

