### PR TITLE
[MS Bing Ads Audiences] Registering MS Bing Ads Audiences

### DIFF
--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -213,6 +213,7 @@ register('6891fb45c0068b7fad1e80a5', './batch')
 register('6891e1a284d96219f601647b', './sftp')
 register('689b6590095a4d2957bc50ca', './yonoma')
 register('68b6ddcd033b3f6d006d8e1f', './taguchi')
+register('68bff47aa7bba4dd200b450a', './ms-bing-ads-audiences')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
Registering new destination MS Bing audiences.

## Testing
N/R

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
