### PR TITLE
[MAIN][STRATCONN-6153] : [DV360] added feature flag for first party dv360 destination  for version upgrade to v4 from v3 

### DIFF
--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
@@ -106,6 +106,64 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
     // Optionally, check that the emails are correctly hashed and correspond to the input
   })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag ON, v4)', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag OFF, v3)', async () => {
+    nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
 })
 
 export type BatchContactListItem = {

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/index.ts
@@ -31,13 +31,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editContactInfo(request, [payload], 'add', statsContext)
+    return editContactInfo(request, [payload], 'add', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editContactInfo(request, payload, 'add', statsContext)
+    return editContactInfo(request, payload, 'add', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/index.ts
@@ -15,13 +15,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, [payload], 'add', statsContext)
+    return editDeviceMobileIds(request, [payload], 'add', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, payload, 'add', statsContext)
+    return editDeviceMobileIds(request, payload, 'add', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/functions.ts
@@ -1,10 +1,11 @@
-import { IntegrationError, RequestClient, StatsContext } from '@segment/actions-core'
+import { Features, IntegrationError, RequestClient, StatsContext } from '@segment/actions-core'
 import { Payload } from './addToAudContactInfo/generated-types'
 import { Payload as DeviceIdPayload } from './addToAudMobileDeviceId/generated-types'
 import { processHashing } from '../../lib/hashing-utils'
 
-const DV360API = `https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences`
+const DV360API = `https://displayvideo.googleapis.com/`
 const CONSENT_STATUS_GRANTED = 'CONSENT_STATUS_GRANTED' // Define consent status
+export const FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE = 'actions-first-party-dv360-version-update'
 
 interface createAudienceRequestParams {
   advertiserId: string
@@ -14,16 +15,19 @@ interface createAudienceRequestParams {
   audienceType: string
   appId?: string
   token?: string
+  features?: Features
 }
 
 interface getAudienceParams {
   advertiserId: string
   audienceId: string
   token?: string
+  features?: Features
 }
 
 interface DV360editCustomerMatchResponse {
-  firstAndThirdPartyAudienceId: string
+  firstAndThirdPartyAudienceId?: string
+  firstPartyAndPartnerAudienceId?: string
   error: [
     {
       code: string
@@ -37,9 +41,15 @@ export const createAudienceRequest = (
   request: RequestClient,
   params: createAudienceRequestParams
 ): Promise<Response> => {
-  const { advertiserId, audienceName, description, membershipDurationDays, audienceType, appId, token } = params
+  const { advertiserId, audienceName, description, membershipDurationDays, audienceType, appId, token, features } =
+    params
 
-  const endpoint = DV360API + `?advertiserId=${advertiserId}`
+  let endpoint
+  if (features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]) {
+    endpoint = DV360API + 'v4/firstPartyAndPartnerAudiences' + `?advertiserId=${advertiserId}`
+  } else {
+    endpoint = DV360API + 'v3/firstAndThirdPartyAudiences' + `?advertiserId=${advertiserId}`
+  }
 
   return request(endpoint, {
     method: 'POST',
@@ -53,16 +63,25 @@ export const createAudienceRequest = (
       membershipDurationDays: membershipDurationDays,
       description: description,
       audienceSource: 'AUDIENCE_SOURCE_UNSPECIFIED',
-      firstAndThirdPartyAudienceType: 'FIRST_AND_THIRD_PARTY_AUDIENCE_TYPE_FIRST_PARTY',
+      firstAndThirdPartyAudienceType:
+        features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]
+          ? undefined
+          : 'FIRST_AND_THIRD_PARTY_AUDIENCE_TYPE_FIRST_PARTY',
+      firstPartyAndPartnerAudienceType:
+        features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE] ? 'TYPE_FIRST_PARTY' : undefined,
       appId: appId
     }
   })
 }
 
 export const getAudienceRequest = (request: RequestClient, params: getAudienceParams): Promise<Response> => {
-  const { advertiserId, audienceId, token } = params
-
-  const endpoint = DV360API + `/${audienceId}?advertiserId=${advertiserId}`
+  const { advertiserId, audienceId, token, features } = params
+  let endpoint
+  if (features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]) {
+    endpoint = DV360API + 'v4/firstPartyAndPartnerAudiences' + `/${audienceId}?advertiserId=${advertiserId}`
+  } else {
+    endpoint = DV360API + 'v3/firstAndThirdPartyAudiences' + `/${audienceId}?advertiserId=${advertiserId}`
+  }
 
   return request(endpoint, {
     method: 'GET',
@@ -77,7 +96,8 @@ export async function editDeviceMobileIds(
   request: RequestClient,
   payloads: DeviceIdPayload[],
   operation: 'add' | 'remove',
-  statsContext?: StatsContext // Adjust type based on actual stats context
+  statsContext?: StatsContext, // Adjust type based on actual stats context,
+  features?: Features
 ) {
   const payload = payloads[0]
   const audienceId = payload.external_id
@@ -86,9 +106,13 @@ export async function editDeviceMobileIds(
   if (payload.mobileDeviceIds === undefined) {
     return
   }
-
-  //Format the endpoint
-  const endpoint = DV360API + '/' + audienceId + ':editCustomerMatchMembers'
+  let endpoint
+  if (features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]) {
+    // Handle version update logic
+    endpoint = DV360API + 'v4/firstPartyAndPartnerAudiences/' + audienceId + ':editCustomerMatchMembers'
+  } else {
+    endpoint = DV360API + 'v3/firstAndThirdPartyAudiences/' + audienceId + ':editCustomerMatchMembers'
+  }
 
   // Prepare the request payload
   const mobileDeviceIdList = {
@@ -112,7 +136,11 @@ export async function editDeviceMobileIds(
     },
     body: requestPayload
   })
-  if (!response.data || !response.data.firstAndThirdPartyAudienceId) {
+  const responseAudienceId =
+    features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]
+      ? response.data.firstPartyAndPartnerAudienceId
+      : response.data.firstAndThirdPartyAudienceId
+  if (!response.data || !responseAudienceId) {
     statsContext?.statsClient?.incr('addCustomerMatchMembers.error', 1, statsContext?.tags)
     throw new IntegrationError(
       `API returned error: ${response.data?.error || 'Unknown error'}`,
@@ -159,7 +187,8 @@ export async function editContactInfo(
   request: RequestClient,
   payloads: Payload[],
   operation: 'add' | 'remove',
-  statsContext?: StatsContext
+  statsContext?: StatsContext,
+  features?: Features
 ) {
   if (!payloads || payloads.length === 0) return
 
@@ -181,7 +210,12 @@ export async function editContactInfo(
   const contactInfos = validPayloads.map(processPayload)
   const contactInfoList = buildContactInfoList(contactInfos)
   const requestPayload = buildRequestPayload(advertiserId, contactInfoList, operation)
-  const endpoint = DV360API + '/' + audienceId + ':editCustomerMatchMembers'
+  let endpoint
+  if (features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]) {
+    endpoint = DV360API + 'v4/firstPartyAndPartnerAudiences/' + audienceId + ':editCustomerMatchMembers'
+  } else {
+    endpoint = DV360API + 'v3/firstAndThirdPartyAudiences/' + audienceId + ':editCustomerMatchMembers'
+  }
   const response = await request<DV360editCustomerMatchResponse>(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json; charset=utf-8' },

--- a/packages/destination-actions/src/destinations/first-party-dv360/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/index.ts
@@ -11,6 +11,7 @@ import removeFromAudMobileDeviceId from './removeFromAudMobileDeviceId'
 import addToAudContactInfo from './addToAudContactInfo'
 import addToAudMobileDeviceId from './addToAudMobileDeviceId'
 import { _CreateAudienceInput, _GetAudienceInput } from './types'
+import { FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE } from './functions'
 
 export interface RefreshTokenResponse {
   access_token: string
@@ -98,7 +99,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
 
     createAudience: async (_request, _CreateAudienceInput: _CreateAudienceInput) => {
       // Extract values from input
-      const { audienceName, audienceSettings, statsContext } = _CreateAudienceInput
+      const { audienceName, audienceSettings, statsContext, features } = _CreateAudienceInput
       const auth = _CreateAudienceInput.settings.oauth
       const advertiserId = audienceSettings?.advertiserId?.trim()
       const description = audienceSettings?.description
@@ -165,20 +166,24 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         membershipDurationDays,
         audienceType,
         appId,
-        token
+        token,
+        features
       })
 
       // Parse and return the externalId
       const r = await response.json()
       statsClient?.incr(`${statsName}.success`, 1, statsTags)
       return {
-        externalId: r.firstAndThirdPartyAudienceId
+        externalId:
+          features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]
+            ? r.firstPartyAndPartnerAudienceId
+            : r.firstAndThirdPartyAudienceId
       }
     },
 
     getAudience: async (_request, _GetAudienceInput: _GetAudienceInput) => {
       // Extract values from input
-      const { audienceSettings, statsContext } = _GetAudienceInput
+      const { audienceSettings, statsContext, features } = _GetAudienceInput
       const auth = _GetAudienceInput.settings.oauth
       const audienceId = _GetAudienceInput.externalId
       const advertiserId = audienceSettings?.advertiserId?.trim()
@@ -223,7 +228,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       }
 
       // Make API request to get audience details
-      const response = await getAudienceRequest(_request, { advertiserId, audienceId, token })
+      const response = await getAudienceRequest(_request, { advertiserId, audienceId, token, features })
 
       if (!response.ok) {
         // Handle non-OK responses
@@ -236,7 +241,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const audienceData = await response.json()
       statsClient?.incr(`${statsName}.success`, 1, statsTags)
       return {
-        externalId: audienceData.firstAndThirdPartyAudienceId
+        externalId:
+          features && features[FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE]
+            ? audienceData.firstPartyAndPartnerAudienceId
+            : audienceData.firstAndThirdPartyAudienceId
       }
     }
   },

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
@@ -26,7 +26,51 @@ const event = createTestEvent({
 })
 
 describe('First-Party-dv360.removeToAudContactInfo', () => {
-  it('should hash pii data if not already hashed', async () => {
+  it('should hash pii data if not already hashed (feature flag ON, v4)', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const responses = await testDestination.testAction('removeFromAudContactInfo', {
+      event,
+      mapping: {
+        emails: ['testing@testing.com'],
+        phoneNumbers: ['+1234567890'],
+        zipCodes: ['12345'],
+        firstName: 'John',
+        lastName: 'Doe',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: false,
+        batch_size: 1
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+    expect(JSON.parse(responses[0].options.body as string)).toMatchInlineSnapshot(`
+      Object {
+        "advertiserId": "1234567890",
+        "removedContactInfoList": Object {
+          "consent": Object {
+            "adPersonalization": "CONSENT_STATUS_GRANTED",
+            "adUserData": "CONSENT_STATUS_GRANTED",
+          },
+          "contactInfos": Array [
+            Object {
+              "countryCode": "US",
+              "hashedEmails": "584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777",
+              "hashedFirstName": "96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a",
+              "hashedLastName": "799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f",
+              "hashedPhoneNumbers": "422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8",
+              "zipCodes": "12345",
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  it('should hash pii data if not already hashed (feature flag OFF, v3)', async () => {
     nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
@@ -44,15 +88,59 @@ describe('First-Party-dv360.removeToAudContactInfo', () => {
         advertiser_id: '1234567890',
         enable_batching: false,
         batch_size: 1
-      }
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
     })
+    expect(JSON.parse(responses[0].options.body as string)).toMatchInlineSnapshot(`
+      Object {
+        "advertiserId": "1234567890",
+        "removedContactInfoList": Object {
+          "consent": Object {
+            "adPersonalization": "CONSENT_STATUS_GRANTED",
+            "adUserData": "CONSENT_STATUS_GRANTED",
+          },
+          "contactInfos": Array [
+            Object {
+              "countryCode": "US",
+              "hashedEmails": "584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777",
+              "hashedFirstName": "96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a",
+              "hashedLastName": "799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f",
+              "hashedPhoneNumbers": "422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8",
+              "zipCodes": "12345",
+            },
+          ],
+        },
+      }
+    `)
+  })
 
-    expect(responses[0].options.body).toMatchInlineSnapshot(
-      '"{\\"advertiserId\\":\\"1234567890\\",\\"removedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
+  it('should not hash pii data if already hashed (feature flag ON, v4)', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const responses = await testDestination.testAction('removeFromAudContactInfo', {
+      event,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: false,
+        batch_size: 1
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+    expect(responses[0].options.body).toBe(
+      '{"advertiserId":"1234567890","removedContactInfoList":{"contactInfos":[{"hashedEmails":"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777","hashedPhoneNumbers":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","zipCodes":"12345","hashedFirstName":"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a","hashedLastName":"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f","countryCode":"US"}],"consent":{"adUserData":"CONSENT_STATUS_GRANTED","adPersonalization":"CONSENT_STATUS_GRANTED"}}}'
     )
   })
 
-  it('should not hash pii data if already hashed', async () => {
+  it('should not hash pii data if already hashed (feature flag OFF, v3)', async () => {
     nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
@@ -70,9 +158,9 @@ describe('First-Party-dv360.removeToAudContactInfo', () => {
         advertiser_id: '1234567890',
         enable_batching: false,
         batch_size: 1
-      }
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
     })
-
     expect(responses[0].options.body).toBe(
       '{"advertiserId":"1234567890","removedContactInfoList":{"contactInfos":[{"hashedEmails":"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777","hashedPhoneNumbers":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","zipCodes":"12345","hashedFirstName":"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a","hashedLastName":"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f","countryCode":"US"}],"consent":{"adUserData":"CONSENT_STATUS_GRANTED","adPersonalization":"CONSENT_STATUS_GRANTED"}}}'
     )

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/index.ts
@@ -31,13 +31,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editContactInfo(request, [payload], 'remove', statsContext)
+    return editContactInfo(request, [payload], 'remove', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editContactInfo(request, payload, 'remove', statsContext)
+    return editContactInfo(request, payload, 'remove', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudMobileDeviceId/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudMobileDeviceId/index.ts
@@ -15,13 +15,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, [payload], 'remove', statsContext)
+    return editDeviceMobileIds(request, [payload], 'remove', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, payload, 'remove', statsContext)
+    return editDeviceMobileIds(request, payload, 'remove', statsContext, features)
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->
 ## JIRA 
 
https://twilio-engineering.atlassian.net/browse/STRATCONN-6153

<!-- Hello and thank you for contributing to Segment action-destinations! -->

_A summary of your pull request, including the what change you're making and why._

## Description 
1. This PR includes changes for migration from v3 to v4 for first party DV360 action destination with feature flag .
2. Updated the unit test cases to v4 from v3 in first party action destination with feature flag .
3. Google is depreciating the v3  version of dv360 hence the changes are done .
<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing
Please find the testing document attached here .
https://docs.google.com/document/d/1W8CsIjAtOyP27YrgfyHMLXSz5V2QvffG7t91wo05-QY/edit?tab=t.0

## Flag created on production - 
https://flagon.segment.com/families/centrifuge-destinations/gates/actions-first-party-dv360-version-update

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
