### PR TITLE
[Twilio Messaging] - relaxing input method types

### DIFF
--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/fields.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/fields.ts
@@ -124,6 +124,7 @@ export const fields: Record<string, InputField> = {
     description: 'The SID of the messaging service to use. If not in the dropdown, enter it directly.',
     type: 'string',
     dynamic: true,
+    disabledInputMethods: [],
     required: {
       conditions: [
         { 
@@ -156,6 +157,7 @@ export const fields: Record<string, InputField> = {
     description: 'The SID of the Content Template to use.',
     type: 'string',
     dynamic: true,
+    disabledInputMethods: [],
     required: false,
     allowNull: false,
     depends_on: {


### PR DESCRIPTION
Correcting the input method types for Twilio messaging. 

## Testing

Not in use by customers yet. 
