### PR TITLE
[MS Bing Ads Audiences] Create and Get Audience 

### DIFF
--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/constants.ts
@@ -1,0 +1,3 @@
+const API_VERSION = 'v13'
+export const BASE_URL = `https://campaign.api.bingads.microsoft.com/CampaignManagement/${API_VERSION}`
+export const TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/generated-types.ts
@@ -1,3 +1,16 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
-export interface Settings {}
+export interface Settings {
+  /**
+   * The developer token for authenticating API requests. You can find it in the Microsoft Advertising UI under Settings → Developer Settings.
+   */
+  developerToken: string
+  /**
+   * The account ID of the Microsoft Advertising account you want to manage. You can find it in the URL when viewing the account in the Microsoft Ads UI.
+   */
+  customerAccountId: string
+  /**
+   * The customer (parent) ID associated with your Microsoft Advertising account. You can also find this in the URL when viewing your account in the Microsoft Ads UI.
+   */
+  customerId: string
+}

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/index.ts
@@ -1,8 +1,9 @@
-import type { AudienceDestinationDefinition } from '@segment/actions-core'
+import { IntegrationError, PayloadValidationError, AudienceDestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import syncAudiences from './syncAudiences'
+import { CreateAudienceResponse, GetAudienceResponse, RefreshTokenResponse } from './types'
+import { BASE_URL, TOKEN_URL } from './constants'
 
-// For an example audience destination, refer to webhook-audiences. The Readme section is under 'Audience Support'
 const destination: AudienceDestinationDefinition<Settings> = {
   name: 'Ms Bing Ads Audiences',
   slug: 'actions-ms-bing-ads-audiences',
@@ -10,31 +11,57 @@ const destination: AudienceDestinationDefinition<Settings> = {
 
   authentication: {
     scheme: 'oauth2',
-    fields: {}
-    // testAuthentication: (request) => {
-    //   // Return a request that tests/validates the user's credentials.
-    //   // If you do not have a way to validate the authentication fields safely,
-    //   // you can remove the `testAuthentication` function, though discouraged.
-    // },
-    // refreshAccessToken: async (request, { auth }) => {
-    //   // Return a request that refreshes the access_token if the API supports it
-    //   const res = await request('https://www.example.com/oauth/refresh', {
-    //     method: 'POST',
-    //     body: new URLSearchParams({
-    //       refresh_token: auth.refreshToken,
-    //       client_id: auth.clientId,
-    //       client_secret: auth.clientSecret,
-    //       grant_type: 'refresh_token'
-    //     })
-    //   })
+    fields: {
+      developerToken: {
+        label: 'Developer Token',
+        description:
+          'The developer token for authenticating API requests. You can find it in the Microsoft Advertising UI under Settings → Developer Settings.',
+        type: 'string',
+        required: true
+      },
+      customerAccountId: {
+        label: 'Customer Account ID',
+        description:
+          'The account ID of the Microsoft Advertising account you want to manage. You can find it in the URL when viewing the account in the Microsoft Ads UI.',
+        type: 'string',
+        required: true
+      },
+      customerId: {
+        label: 'Customer ID',
+        description:
+          'The customer (parent) ID associated with your Microsoft Advertising account. You can also find this in the URL when viewing your account in the Microsoft Ads UI.',
+        type: 'string',
+        required: true
+      }
+    },
+    refreshAccessToken: async (request, { auth }) => {
+      // API Docs
+      // https://learn.microsoft.com/en-us/advertising/guides/authentication-oauth-get-tokens?view=bingads-13#refresh-accesstoken
+      const res = await request<RefreshTokenResponse>(TOKEN_URL, {
+        method: 'POST',
+        body: new URLSearchParams({
+          refresh_token: auth.refreshToken,
+          client_id: auth.clientId,
+          client_secret: auth.clientSecret,
+          grant_type: 'refresh_token',
+          scope: 'https://ads.microsoft.com/msads.manage offline_access'
+        })
+      })
 
-    //   return { accessToken: res?.data?.access_token }
-    // }
+      return {
+        accessToken: res?.data?.access_token,
+        refreshToken: res?.data?.refresh_token
+      }
+    }
   },
-  extendRequest({ auth }) {
+
+  extendRequest({ auth, settings }) {
     return {
       headers: {
-        authorization: `Bearer ${auth?.accessToken}`
+        Authorization: `Bearer ${auth?.accessToken}`,
+        DeveloperToken: settings?.developerToken,
+        CustomerAccountId: settings?.customerAccountId,
+        CustomerId: settings?.customerId
       }
     }
   },
@@ -43,28 +70,66 @@ const destination: AudienceDestinationDefinition<Settings> = {
 
   audienceConfig: {
     mode: {
-      type: 'synced', // Indicates that the audience is synced on some schedule; update as necessary
-      full_audience_sync: false // If true, we send the entire audience. If false, we just send the delta.
+      type: 'synced',
+      full_audience_sync: false
+    },
+    createAudience: async (request, createAudienceInput) => {
+      // API Docs
+      // Add Audience: https://learn.microsoft.com/en-us/advertising/campaign-management-service/addaudiences?view=bingads-13&tabs=prod&pivots=rest
+      // Customer List: https://learn.microsoft.com/en-us/advertising/campaign-management-service/customerlist?view=bingads-13&tabs=json
+      const audienceName = createAudienceInput?.audienceName
+
+      if (!audienceName) {
+        throw new PayloadValidationError('Missing audience name value')
+      }
+
+      const response: CreateAudienceResponse = await request(`${BASE_URL}/Audiences`, {
+        method: 'POST',
+        json: {
+          Audiences: [
+            {
+              Name: audienceName,
+              Type: 'CustomerList'
+            }
+          ]
+        }
+      })
+
+      // Handle Terms and Conditions error from Bing Ads API
+      if (response?.data?.PartialErrors?.length) {
+        const errorObj = response.data.PartialErrors[0]
+        if (errorObj?.ErrorCode === 'CustomerListTermsAndConditionsNotAccepted') {
+          throw new IntegrationError(
+            "The Customer Match 'Terms And Conditions' are not yet Accepted in the Microsoft Advertising web UI. Please create a Customer List in the Microsoft Advertising UI to accept the terms.",
+            'TERMS_NOT_ACCEPTED',
+            400
+          )
+        }
+      }
+
+      // Extract the created audience ID
+      const audienceId = response?.data?.AudienceIds?.[0]
+      if (!audienceId) {
+        throw new IntegrationError('Failed to create audience: No AudienceId returned', 'NO_AUDIENCE_ID', 400)
+      }
+
+      return { externalId: audienceId }
+    },
+    getAudience: async (request, getAudienceInput) => {
+      // API Docs
+      // https://learn.microsoft.com/en-us/advertising/campaign-management-service/getaudiencesbyids?view=bingads-13&tabs=prod&pivots=rest
+      const audienceId = getAudienceInput?.externalId
+      const response: GetAudienceResponse = await request(`${BASE_URL}/Audiences/QueryByIds`, {
+        method: 'POST',
+        json: {
+          AudienceIds: [audienceId],
+          Type: 'CustomerList'
+        }
+      })
+
+      return { externalId: response?.data?.Audiences?.[0]?.Id }
     }
-
-    // Get/Create are optional and only needed if you need to create an audience before sending events/users.
-    // createAudience: async (request, createAudienceInput) => {
-    //   // Create an audience through the destination's API
-    //   // Segment will save this externalId for subsequent calls; the externalId is used to keep track of the audience in our database
-    //   return {externalId: ''}
-    // },
-
-    // getAudience: async (request, getAudienceInput) => {
-    //   // Right now, `getAudience` will mostly serve as a check to ensure the audience still exists in the destination
-    //   return {externalId: ''}
-    // }
   },
-
-  // onDelete: async (request, { settings, payload }) => {
-  //   // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
-  //   // provided in the payload. If your destination does not support GDPR deletion you should not
-  //   // implement this function and should remove it completely.
-  // },
 
   actions: {
     syncAudiences

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/types.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/types.ts
@@ -1,0 +1,31 @@
+export interface RefreshTokenResponse {
+  access_token: string
+  refresh_token?: string
+}
+
+export interface CreateAudienceResponse {
+  data: {
+    AudienceIds: string[]
+    PartialErrors: {
+      FieldPath: string | null
+      ErrorCode: string
+      Message: string
+      Code: number
+      Details: string | null
+      Index: number
+      Type: string
+      ForwardCompatibilityMap: null
+    }[]
+  }
+}
+
+export interface GetAudienceResponse {
+  data: {
+    Audiences: [
+      {
+        Id: string
+      }
+    ]
+    PartialErrors: []
+  }
+}


### PR DESCRIPTION
Add the following for the new Bing Ads Audiences destination.
- Add Refresh Access Token Flow
- Add Create Audience
- Add Get Audience
- Add Unit Tests

JIRA: https://twilio-engineering.atlassian.net/browse/STRATCONN-6125

## Testing

Stage testing: https://docs.google.com/document/d/1nwKG4u1abEK-fUqumAir0VSf0fkY_ytzxa87aSH3sqQ/edit?usp=sharing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
