### PR TITLE
STRATCONN-6177 - [GA4 Web] - domain setting

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { destination } from '../index'
+import type { Settings } from '../generated-types'
+describe('Set Configuration Fields action', () => {
+  const defaultSettings: Settings = {
+    enableConsentMode: false,
+    measurementID: 'G-XXXXXXXXXX',
+    allowAdPersonalizationSignals: false,
+    allowGoogleSignals: false,
+    cookieDomain: 'auto',
+    cookieExpirationInSeconds: 63072000,
+    cookieUpdate: true,
+    pageView: true
+  }
+  beforeEach(async () => {
+    jest.restoreAllMocks()
+  })
+
+  it('should load script from default domain when no domain setting is provided', async () => {
+    const mockLoadScript = jest.fn().mockResolvedValue(undefined)
+    const mockDeps = { loadScript: mockLoadScript }
+    await destination.initialize({ settings: { ...defaultSettings } }, mockDeps)
+    expect(mockLoadScript).toHaveBeenCalledWith('https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX')
+  })
+
+  it('should load script from custom domain when domain setting is provided', async () => {
+    const mockLoadScript = jest.fn().mockResolvedValue(undefined)
+    const mockDeps = { loadScript: mockLoadScript }
+    await destination.initialize({ settings: { ...defaultSettings, domain: 'www.example.com' } }, mockDeps)
+    expect(mockLoadScript).toHaveBeenCalledWith('https://www.example.com/gtag/js?id=G-XXXXXXXXXX')
+  })
+})

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/generated-types.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/generated-types.ts
@@ -65,4 +65,8 @@ export interface Settings {
    * Set to false to prevent the default snippet from sending page views. Enabled by default.
    */
   pageView?: boolean
+  /**
+   * A custom domain to load the Google Analytics script from.
+   */
+  domain?: string
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
@@ -202,6 +202,12 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       label: 'Page Views',
       type: 'boolean',
       default: true
+    },
+    domain: {
+      description: 'A custom domain to load the Google Analytics script from.',
+      label: 'Domain',
+      type: 'string',
+      default: 'www.googletagmanager.com'
     }
   },
 
@@ -233,7 +239,7 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       }
       gtag('consent', 'default', consent)
     }
-    const script = `https://www.googletagmanager.com/gtag/js?id=${settings.measurementID}`
+    const script = `https://${settings.domain ?? 'www.googletagmanager.com'}/gtag/js?id=${settings.measurementID}`
     await deps.loadScript(script)
     return window.gtag
   },


### PR DESCRIPTION
GA4 Web Destination - adding new global setting to allow for the domain to be changed. 

## Testing

Unit tests added. Tested locally. 

**Default domain:** 
<img width="1701" height="612" alt="image" src="https://github.com/user-attachments/assets/55da2302-db45-4cfd-abdc-facec7c7f08d" />


**Custom domain:** 
<img width="1786" height="698" alt="image" src="https://github.com/user-attachments/assets/fed77e18-4fe6-4709-a7cc-2f771440ed3e" />
