### PR TITLE
Add 'unsafe_hidden' property to table name field

### DIFF
--- a/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/sendCustomEvent/index.ts
@@ -11,7 +11,8 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'The name of the table.',
       type: 'string',
       required: true,
-      default: { '@path': '$.event' }
+      default: { '@path': '$.event' },
+      unsafe_hidden: true
     },
     // note that this must be `properties` to be processed by the warehouse pipeline
     properties: {


### PR DESCRIPTION
We'd like to hide this particular field since it is a redundant with a newer UI that already allows users to configure the table name. However, the field itself is still needed in the mapping for normal warehouse pipeline processing.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
