### PR TITLE
Disable kafka retries

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import { Kafka, KafkaConfig, Partitioners } from 'kafkajs'
 import { producersByConfig, serializeKafkaConfig, getOrCreateProducer } from '../../utils'
 import { Settings } from '../../generated-types'
 import { Producer } from 'kafkajs'
+import { IntegrationError } from '@segment/actions-core/*'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -290,6 +291,68 @@ describe('Kafka.send', () => {
     expect(key).toBe(
       '{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}'
     )
+  })
+
+  it('logs and rethrows IntegrationError when Kafka constructor fails', async () => {
+    // Make Kafka constructor throw
+    ;(Kafka as unknown as jest.Mock).mockImplementationOnce(() => {
+      throw new IntegrationError('some settings error', 'Kafka Connection Error', 400)
+    })
+
+    const logger = { crit: jest.fn() } as any
+
+    try {
+      await testDestination.testAction('send', { ...(testData as any), logger })
+    } catch (error) {
+      expect(error).toBeInstanceOf(IntegrationError)
+      expect((error as Error).message).toBe('Kafka Connection Error: some settings error')
+      expect((error as IntegrationError).status).toBe(400)
+    }
+
+    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error:'))
+  })
+
+  it('wraps producer connect errors and logs with critical level', async () => {
+    const err = new Error('connect failed')
+    err.name = 'KafkaJSError'
+
+    // Make connect reject for the next call
+    const producer = new (Kafka as unknown as jest.Mock)({} as KafkaConfig).producer()
+    ;(producer.connect as unknown as jest.Mock).mockRejectedValueOnce(err)
+
+    const logger = { crit: jest.fn() } as any
+
+    try {
+      await testDestination.testAction('send', { ...(testData as any), logger })
+    } catch (error) {
+      expect(error).toBeInstanceOf(IntegrationError)
+      expect((error as Error).message).toBe('Kafka Connection Error - KafkaJSError: connect failed')
+      expect((error as IntegrationError).status).toBe(500)
+    }
+
+    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error:'))
+  })
+
+  it('wraps producer send errors and logs with critical level', async () => {
+    // Ensure connect resolves
+    const producer = new (Kafka as unknown as jest.Mock)({} as KafkaConfig).producer()
+    ;(producer.connect as unknown as jest.Mock).mockResolvedValueOnce(undefined)
+
+    const err = new Error('broker unavailable')
+    err.name = 'KafkaJSError'
+    ;(producer.send as unknown as jest.Mock).mockRejectedValueOnce(err)
+
+    const logger = { crit: jest.fn() } as any
+
+    try {
+      await testDestination.testAction('send', { ...(testData as any), logger })
+    } catch (error) {
+      expect(error).toBeInstanceOf(IntegrationError)
+      expect((error as Error).message).toBe('Kafka Producer Error - KafkaJSError: broker unavailable')
+      expect((error as IntegrationError).status).toBe(500)
+    }
+
+    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Send Error:'))
   })
 })
 

--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -64,19 +64,18 @@ describe('Kafka.send', () => {
   it('kafka library is initialized correctly for SASL plain auth', async () => {
     await testDestination.testAction('send', testData as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: true,
-        sasl: {
-          mechanism: 'plain',
-          username: 'yourUsername',
-          password: 'yourPassword'
-        }
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: true,
+      retry: { retries: 0 },
+      sasl: {
+        mechanism: 'plain',
+        username: 'yourUsername',
+        password: 'yourPassword'
       }
-    )
+    })
   })
 
   it('kafka library is initialized correctly for SASL scram-sha-256 auth', async () => {
@@ -87,22 +86,21 @@ describe('Kafka.send', () => {
         mechanism: 'scram-sha-256'
       }
     }
-    
+
     await testDestination.testAction('send', testData1 as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: true,
-        sasl: {
-          mechanism: 'scram-sha-256',
-          username: 'yourUsername',
-          password: 'yourPassword'
-        }
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: true,
+      retry: { retries: 0 },
+      sasl: {
+        mechanism: 'scram-sha-256',
+        username: 'yourUsername',
+        password: 'yourPassword'
       }
-    )
+    })
   })
 
   it('kafka library is initialized correctly for SASL scram-sha-512 auth', async () => {
@@ -113,22 +111,21 @@ describe('Kafka.send', () => {
         mechanism: 'scram-sha-512'
       }
     }
-    
+
     await testDestination.testAction('send', testData1 as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: true,
-        sasl: {
-          mechanism: 'scram-sha-512',
-          username: 'yourUsername',
-          password: 'yourPassword'
-        }
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: true,
+      retry: { retries: 0 },
+      sasl: {
+        mechanism: 'scram-sha-512',
+        username: 'yourUsername',
+        password: 'yourPassword'
       }
-    )
+    })
   })
 
   it('kafka library is initialized correctly for SASL aws auth', async () => {
@@ -142,23 +139,22 @@ describe('Kafka.send', () => {
         authorizationIdentity: 'testAuthorizationIdentity'
       }
     }
-    
+
     await testDestination.testAction('send', testData3 as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: true,
-        sasl: {
-          mechanism: 'aws',
-          accessKeyId: 'testAccessKeyId',
-          secretAccessKey: 'testSecretAccessKey',
-          authorizationIdentity: 'testAuthorizationIdentity'
-        }
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: true,
+      retry: { retries: 0 },
+      sasl: {
+        mechanism: 'aws',
+        accessKeyId: 'testAccessKeyId',
+        secretAccessKey: 'testSecretAccessKey',
+        authorizationIdentity: 'testAuthorizationIdentity'
       }
-    )
+    })
   })
 
   it('kafka library is initialized correctly when SSL_CA provided', async () => {
@@ -170,25 +166,24 @@ describe('Kafka.send', () => {
         ssl_reject_unauthorized_ca: true
       }
     }
-    
+
     await testDestination.testAction('send', testData4 as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: {
-          ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
-          rejectUnauthorized: true
-        },
-        sasl: {
-          mechanism: 'plain',
-          username: 'yourUsername',
-          password: 'yourPassword'
-        }
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: {
+        ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
+        rejectUnauthorized: true
+      },
+      retry: { retries: 0 },
+      sasl: {
+        mechanism: 'plain',
+        username: 'yourUsername',
+        password: 'yourPassword'
       }
-    )
+    })
   })
 
   it('kafka library is initialized correctly when SSL_CA provided and mechanism is client-cert-auth', async () => {
@@ -203,25 +198,24 @@ describe('Kafka.send', () => {
         ssl_ca: 'yourCACert',
         ssl_reject_unauthorized_ca: true,
         ssl_key: 'yourKey',
-        ssl_cert: 'yourCert',
+        ssl_cert: 'yourCert'
       }
     }
-    
+
     await testDestination.testAction('send', testData5 as any)
 
-    expect(Kafka).toHaveBeenCalledWith(
-     {
-        clientId: 'yourClientId',
-        brokers: ['yourBroker'],
-        requestTimeout: 10000,
-        ssl: {
-          ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
-          rejectUnauthorized: true,
-          key: '-----BEGIN PRIVATE KEY-----\nyourKey\n-----END PRIVATE KEY-----',
-          cert: '-----BEGIN CERTIFICATE-----\nyourCert\n-----END CERTIFICATE-----'
-        }
-      }
-    )
+    expect(Kafka).toHaveBeenCalledWith({
+      clientId: 'yourClientId',
+      brokers: ['yourBroker'],
+      requestTimeout: 10000,
+      ssl: {
+        ca: ['-----BEGIN CERTIFICATE-----\nyourCACert\n-----END CERTIFICATE-----'],
+        rejectUnauthorized: true,
+        key: '-----BEGIN PRIVATE KEY-----\nyourKey\n-----END PRIVATE KEY-----',
+        cert: '-----BEGIN CERTIFICATE-----\nyourCert\n-----END CERTIFICATE-----'
+      },
+      retry: { retries: 0 }
+    })
   })
 
   it('kafka producer is initialized correctly', async () => {
@@ -269,7 +263,9 @@ describe('Kafka.send', () => {
 
     const key = serializeKafkaConfig(settings)
     expect(typeof key).toBe('string')
-    expect(key).toBe('{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}')
+    expect(key).toBe(
+      '{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}'
+    )
   })
 
   it('serializeKafkaConfig generates the correct producer connection cache key', async () => {
@@ -291,7 +287,9 @@ describe('Kafka.send', () => {
 
     const key = serializeKafkaConfig(settings)
     expect(typeof key).toBe('string')
-    expect(key).toBe('{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}')
+    expect(key).toBe(
+      '{"clientId":"testClientId","brokers":["https://broker1:9092","https://broker2:9092"],"mechanism":"plain","username":"testUsername","password":"testPassword","accessKeyId":"testAccessKeyId","secretAccessKey":"testSecretAccessKey","authorizationIdentity":"testAuthorizationIdentity","ssl_ca":"testCACert","ssl_cert":"testCert","ssl_key":"testKey","ssl_reject_unauthorized_ca":true,"ssl_enabled":true}'
+    )
   })
 })
 
@@ -348,7 +346,7 @@ describe('getOrCreateProducer', () => {
 
   it('getOrCreateProducer replaces expired connections and creates a new connection', async () => {
     const now = Date.now()
-    const expiredTime = now - (31 * 60 * 1000) // 31 minutes ago
+    const expiredTime = now - 31 * 60 * 1000 // 31 minutes ago
     const key = serializeKafkaConfig(settings)
 
     const oldProducer = {

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -234,8 +234,9 @@ export const sendData = async (
     logger?.crit(`Kafka Connection Error: ${(error as Error).stack}`)
     if ((error as Error).name !== 'IntegrationError') {
       throw new RetryableError(`${(error as Error).name}: ${(error as Error).message}`)
+    } else {
+      throw error
     }
-    throw error
   }
 
   for (const data of topicMessages) {

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -91,7 +91,9 @@ const getKafka = (settings: Settings) => {
       }
       return undefined
     })(),
-    retries: 0
+    retry: {
+      retries: 0
+    }
   } as unknown as KafkaConfig
 
   try {

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -233,7 +233,7 @@ export const sendData = async (
     statsContext?.statsClient.incr('kafka_connection_error', 1, tags)
     logger?.crit(`Kafka Connection Error: ${(error as Error).stack}`)
     if ((error as Error).name !== 'IntegrationError') {
-      throw new RetryableError(`${(error as Error).name}: ${(error as Error).message}`)
+      throw new RetryableError(`Kafka Connection Error - ${(error as Error).name}: ${(error as Error).message}`)
     } else {
       throw error
     }
@@ -246,7 +246,7 @@ export const sendData = async (
       const tags = [...(statsContext?.tags ?? []), `kafka_error:${error.name}`]
       statsContext?.statsClient.incr('kafka_send_error', 1, tags)
       logger?.crit(`Kafka Send Error: ${(error as Error).stack}`)
-      throw new RetryableError(`Kafka Producer Error - ${(error as Error).name}: ${(error as KafkaJSError).message}`)
+      throw new RetryableError(`Kafka Producer Error - ${(error as Error).name}: ${(error as Error).message}`)
     }
   }
 

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -1,5 +1,5 @@
 import { Kafka, ProducerRecord, Partitioners, SASLOptions, KafkaConfig, KafkaJSError, Producer } from 'kafkajs'
-import { DynamicFieldResponse, IntegrationError, Features, RetryableError } from '@segment/actions-core'
+import { DynamicFieldResponse, IntegrationError, Features } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import type { Payload } from './send/generated-types'
 import { DEFAULT_PARTITIONER, Message, TopicMessages, SSLConfig, CachedProducer } from './types'
@@ -229,11 +229,13 @@ export const sendData = async (
       await producer.connect()
     }
   } catch (error) {
-    const tags = [...(statsContext?.tags ?? []), `kafka_error:${error.name}`]
-    statsContext?.statsClient.incr('kafka_connection_error', 1, tags)
     logger?.crit(`Kafka Connection Error: ${(error as Error).stack}`)
     if ((error as Error).name !== 'IntegrationError') {
-      throw new RetryableError(`Kafka Connection Error - ${(error as Error).name}: ${(error as Error).message}`)
+      throw new IntegrationError(
+        `Kafka Connection Error - ${(error as Error).name}: ${(error as Error).message}`,
+        (error as Error)?.name,
+        500
+      )
     } else {
       throw error
     }
@@ -243,10 +245,12 @@ export const sendData = async (
     try {
       await producer.send(data as ProducerRecord)
     } catch (error) {
-      const tags = [...(statsContext?.tags ?? []), `kafka_error:${error.name}`]
-      statsContext?.statsClient.incr('kafka_send_error', 1, tags)
       logger?.crit(`Kafka Send Error: ${(error as Error).stack}`)
-      throw new RetryableError(`Kafka Producer Error - ${(error as Error).name}: ${(error as Error).message}`)
+      throw new IntegrationError(
+        `Kafka Producer Error - ${(error as Error).name}: ${(error as Error).message}`,
+        (error as Error)?.name,
+        500
+      )
     }
   }
 


### PR DESCRIPTION
- Added a `retry` configuration with `retries: 0` to the Kafka client, explicitly controlling retry behavior at the client level.
- Marked KafkaJSError as `500` errors to prevent data loss due to turning off retries and send the actual Kafka error names as error codes.


## Testing

Example logs. As it can be seen, the `retryCount` is now 0. 
```
{"level":"ERROR","timestamp":"2025-09-16T05:08:21.413Z","logger":"kafkajs","message":"[Connection] Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com","broker":"kafka-240f0580-actions-kafka.c.aivencloud.com:27263","clientId":"segment-actions-kafka-producer","stack":"Error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)"}
{"level":"ERROR","timestamp":"2025-09-16T05:08:21.414Z","logger":"kafkajs","message":"[BrokerPool] Failed to connect to seed broker, trying another broker from the list: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com","retryCount":0,"retryTime":281}
2025-09-16T05:08:23.486Z - CRIT - integrations-kafka - Kafka Connection Error: KafkaJSNonRetriableError
  Caused by: KafkaJSConnectionError: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
    at TLSSocket.onError (/Users/array/dev/src/github.com/segmentio/action-destinations/node_modules/kafkajs/src/network/connection.js:210:23)
    at TLSSocket.emit (node:events:524:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
2025-09-16T05:08:23.488Z - ERROR - integrations - actions-kafka - 1234567890 - Kafka Connection Error - KafkaJSNumberOfRetriesExceeded: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
 IntegrationError: Kafka Connection Error - KafkaJSNumberOfRetriesExceeded: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
    at sendData (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/destination-actions/dist/destinations/kafka/utils.js:196:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.performBatch (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/destination-actions/dist/destinations/kafka/send/index.js:70:9)
    at async Action.executeBatch (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/destination-kit/action.js:184:42)
    at async Destination.executeBatch (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/destination-kit/index.js:194:16)
    at async Destination.onSubscription (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/destination-kit/index.js:303:46)
    at async Promise.all (index 0)
    at async run (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/destination-kit/index.js:383:29)
    at async retry (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/retry.js:9:30)
    at async Destination.onSubscriptions (/Users/array/dev/src/github.com/segmentio/action-destinations/packages/core/dist/cjs/destination-kit/index.js:402:16)
    at async ActionDestination.send (/Users/array/dev/src/github.com/segmentio/integrations/createActionDestination/index.js:385:20)
    at async ActionDestination.batch (/Users/array/dev/src/github.com/segmentio/integrations/createActionDestination/index.js:194:24)
```


Stage Instance for testing: https://app.segment.build/arijit-dev/destinations/actions-kafka/sources/http_api/instances/6880c59b62bcbb1aabdd3887/event-delivery?period=past-hour

<img width="1496" height="967" alt="Screenshot 2025-09-16 at 12 23 06 PM" src="https://github.com/user-attachments/assets/4f06a0b7-e872-4ccc-9dea-1d83adda2e4f" />
<img width="1496" height="967" alt="Screenshot 2025-09-16 at 12 23 15 PM" src="https://github.com/user-attachments/assets/225c4c3e-78d9-4bac-95c1-d049230fd788" />
<img width="1496" height="967" alt="Screenshot 2025-09-16 at 12 23 35 PM" src="https://github.com/user-attachments/assets/aa752430-1425-4c44-a3a6-376b9be8fe85" />



Datadog Notebook Analysis: https://segment.datadoghq.com/notebook/12973425/kafka-analyisis?range=1245859&start=1758002484241&live=false
<img width="915" height="569" alt="Screenshot 2025-09-16 at 12 27 43 PM" src="https://github.com/user-attachments/assets/c6367b34-c2be-4844-85b9-53f420b2e4fd" />




_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
