### PR TITLE
[MAIN][STRATCONN-6153] : [DV360] added feature flag for first party dv360 destination for upgrade version from v3 to v4 

### DIFF
--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
@@ -106,6 +106,64 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
     // Optionally, check that the emails are correctly hashed and correspond to the input
   })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag ON, v4)', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag OFF, v3)', async () => {
+    nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
 })
 
 export type BatchContactListItem = {

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/index.ts
@@ -31,13 +31,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editContactInfo(request, [payload], 'add', statsContext)
+    return editContactInfo(request, [payload], 'add', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editContactInfo(request, payload, 'add', statsContext)
+    return editContactInfo(request, payload, 'add', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/_tests_/index.test.ts
@@ -21,6 +21,71 @@ const event = createTestEvent({
 })
 
 describe('First-Party-dv360.addToAudMobileDeviceId', () => {
+  it('should use v4 endpoint when feature flag is ON', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { firstPartyAndPartnerAudienceId: '1234567890' })
+
+    const responses = await testDestination.testAction('addToAudMobileDeviceId', {
+      event,
+      mapping: {
+        mobileDeviceIds: ['test-id'],
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: false,
+        batch_size: 1
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+
+    expect(JSON.parse(responses[0].options.body as string)).toMatchInlineSnapshot(`
+      Object {
+        "addedMobileDeviceIdList": Object {
+          "consent": Object {
+            "adPersonalization": "CONSENT_STATUS_GRANTED",
+            "adUserData": "CONSENT_STATUS_GRANTED",
+          },
+          "mobileDeviceIds": Array [
+            "test-id",
+          ],
+        },
+        "advertiserId": "1234567890",
+      }
+    `)
+  })
+
+  it('should use v3 endpoint when feature flag is OFF', async () => {
+    nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { firstAndThirdPartyAudienceId: '1234567890' })
+
+    const responses = await testDestination.testAction('addToAudMobileDeviceId', {
+      event,
+      mapping: {
+        mobileDeviceIds: ['test-id'],
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: false,
+        batch_size: 1
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
+    })
+
+    expect(JSON.parse(responses[0].options.body as string)).toMatchInlineSnapshot(`
+      Object {
+        "addedMobileDeviceIdList": Object {
+          "consent": Object {
+            "adPersonalization": "CONSENT_STATUS_GRANTED",
+            "adUserData": "CONSENT_STATUS_GRANTED",
+          },
+          "mobileDeviceIds": Array [
+            "test-id",
+          ],
+        },
+        "advertiserId": "1234567890",
+      }
+    `)
+  })
   it('should addToAudMobileDeviceId', async () => {
     nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
       .post('/1234567890:editCustomerMatchMembers')

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudMobileDeviceId/index.ts
@@ -15,13 +15,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, [payload], 'add', statsContext)
+    return editDeviceMobileIds(request, [payload], 'add', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, payload, 'add', statsContext)
+    return editDeviceMobileIds(request, payload, 'add', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/properties.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/properties.ts
@@ -1,5 +1,7 @@
 import { InputField } from '@segment/actions-core/index'
 
+export const FLAGON_NAME_FIRST_PARTY_DV360_VERSION_UPDATE = 'actions-first-party-dv360-version-update'
+
 export const external_id: InputField = {
   label: 'External ID',
   description: 'The ID of the DV360 Audience.',

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
@@ -25,13 +25,13 @@ const event = createTestEvent({
   }
 })
 
-describe('First-Party-dv360.removeToAudContactInfo', () => {
+describe('First-Party-dv360.addToAudContactInfo', () => {
   it('should hash pii data if not already hashed', async () => {
     nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
 
-    const responses = await testDestination.testAction('removeFromAudContactInfo', {
+    const responses = await testDestination.testAction('addToAudContactInfo', {
       event,
       mapping: {
         emails: ['testing@testing.com'],
@@ -48,7 +48,7 @@ describe('First-Party-dv360.removeToAudContactInfo', () => {
     })
 
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      '"{\\"advertiserId\\":\\"1234567890\\",\\"removedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
+      '"{\\"advertiserId\\":\\"1234567890\\",\\"addedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
     )
   })
 
@@ -57,7 +57,7 @@ describe('First-Party-dv360.removeToAudContactInfo', () => {
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
 
-    const responses = await testDestination.testAction('removeFromAudContactInfo', {
+    const responses = await testDestination.testAction('addToAudContactInfo', {
       event,
       mapping: {
         emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
@@ -73,8 +73,138 @@ describe('First-Party-dv360.removeToAudContactInfo', () => {
       }
     })
 
-    expect(responses[0].options.body).toBe(
-      '{"advertiserId":"1234567890","removedContactInfoList":{"contactInfos":[{"hashedEmails":"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777","hashedPhoneNumbers":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8","zipCodes":"12345","hashedFirstName":"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a","hashedLastName":"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f","countryCode":"US"}],"consent":{"adUserData":"CONSENT_STATUS_GRANTED","adPersonalization":"CONSENT_STATUS_GRANTED"}}}'
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      '"{\\"advertiserId\\":\\"1234567890\\",\\"addedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
     )
   })
+
+  it('should batch multiple payloads into a single request when enable_batching is true', async () => {
+    nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+    // Optionally, check that the emails are correctly hashed and correspond to the input
+  })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag ON, v4)', async () => {
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': true }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
+
+  it('should batch multiple payloads into a single request when enable_batching is true (feature flag OFF, v3)', async () => {
+    nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const events = createBatchTestEvents(createContactList)
+    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+      events: events,
+      mapping: {
+        emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
+        phoneNumbers: ['422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8'],
+        zipCodes: ['12345'],
+        firstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+        lastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: true,
+        batch_size: 2
+      },
+      features: { 'actions-first-party-dv360-version-update': false }
+    })
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
 })
+
+export type BatchContactListItem = {
+  id?: string
+  email: string
+  firstname: string
+  lastname: string
+}
+
+export const createBatchTestEvents = (batchContactList: BatchContactListItem[]) =>
+  batchContactList.map((contact) =>
+    createTestEvent({
+      type: 'identify',
+      traits: {
+        email: contact.email,
+        firstname: contact.firstname,
+        lastname: contact.lastname,
+        address: {
+          city: 'San Francisco',
+          country: 'USA',
+          postal_code: '600001',
+          state: 'California',
+          street: 'Vancover st'
+        },
+        graduation_date: 1664533942262,
+        company: 'Some Company',
+        phone: '+13134561129',
+        website: 'somecompany.com'
+      }
+    })
+  )
+
+const createContactList: BatchContactListItem[] = [
+  {
+    email: 'userone@somecompany.com',
+    firstname: 'User',
+    lastname: 'One'
+  },
+  {
+    email: 'usertwo@somecompany.com',
+    firstname: 'User',
+    lastname: 'Two'
+  }
+]

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
@@ -25,13 +25,13 @@ const event = createTestEvent({
   }
 })
 
-describe('First-Party-dv360.addToAudContactInfo', () => {
+describe('First-Party-dv360.removeFromAudContactInfo', () => {
   it('should hash pii data if not already hashed', async () => {
     nock('https://displayvideo.googleapis.com/v3/firstAndThirdPartyAudiences')
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
 
-    const responses = await testDestination.testAction('addToAudContactInfo', {
+    const responses = await testDestination.testAction('removeFromAudContactInfo', {
       event,
       mapping: {
         emails: ['testing@testing.com'],
@@ -48,7 +48,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     })
 
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      '"{\\"advertiserId\\":\\"1234567890\\",\\"addedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
+      '"{\\"advertiserId\\":\\"1234567890\\",\\"removedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
     )
   })
 
@@ -57,7 +57,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
       .post('/1234567890:editCustomerMatchMembers')
       .reply(200, { success: true })
 
-    const responses = await testDestination.testAction('addToAudContactInfo', {
+    const responses = await testDestination.testAction('removeFromAudContactInfo', {
       event,
       mapping: {
         emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
@@ -74,7 +74,8 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     })
 
     expect(responses[0].options.body).toMatchInlineSnapshot(
-      '"{\\"advertiserId\\":\\"1234567890\\",\\"addedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
+      '"{\\"advertiserId\\":\\"1234567890\\",\\"removeFromAudContactInfo\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"',
+      `"{\\"advertiserId\\":\\"1234567890\\",\\"removedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"`
     )
   })
 
@@ -84,7 +85,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
       .reply(200, { success: true })
 
     const events = createBatchTestEvents(createContactList)
-    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+    const responses = await testDestination.testBatchAction('removeFromAudContactInfo', {
       events: events,
       mapping: {
         emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
@@ -101,9 +102,9 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     })
 
     const requestBody = JSON.parse(String(responses[0].options.body))
-    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
-    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
-    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.removedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
     // Optionally, check that the emails are correctly hashed and correspond to the input
   })
 
@@ -113,7 +114,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
       .reply(200, { success: true })
 
     const events = createBatchTestEvents(createContactList)
-    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+    const responses = await testDestination.testBatchAction('removeFromAudContactInfo', {
       events: events,
       mapping: {
         emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
@@ -131,9 +132,9 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     })
 
     const requestBody = JSON.parse(String(responses[0].options.body))
-    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
-    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
-    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.removedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
   })
 
   it('should batch multiple payloads into a single request when enable_batching is true (feature flag OFF, v3)', async () => {
@@ -142,7 +143,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
       .reply(200, { success: true })
 
     const events = createBatchTestEvents(createContactList)
-    const responses = await testDestination.testBatchAction('addToAudContactInfo', {
+    const responses = await testDestination.testBatchAction('removeFromAudContactInfo', {
       events: events,
       mapping: {
         emails: ['584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'],
@@ -160,9 +161,9 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     })
 
     const requestBody = JSON.parse(String(responses[0].options.body))
-    expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
-    expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
-    expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos.length).toBe(2)
+    expect(requestBody.removedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
+    expect(requestBody.removedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
   })
 })
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/_tests_/index.test.ts
@@ -73,10 +73,27 @@ describe('First-Party-dv360.removeFromAudContactInfo', () => {
       }
     })
 
-    expect(responses[0].options.body).toMatchInlineSnapshot(
-      '"{\\"advertiserId\\":\\"1234567890\\",\\"removeFromAudContactInfo\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"',
-      `"{\\"advertiserId\\":\\"1234567890\\",\\"removedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"`
-    )
+    expect(JSON.parse(responses[0].options.body as string)).toMatchInlineSnapshot(`
+      Object {
+        "advertiserId": "1234567890",
+        "removedContactInfoList": Object {
+          "consent": Object {
+            "adPersonalization": "CONSENT_STATUS_GRANTED",
+            "adUserData": "CONSENT_STATUS_GRANTED",
+          },
+          "contactInfos": Array [
+            Object {
+              "countryCode": "US",
+              "hashedEmails": "584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777",
+              "hashedFirstName": "96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a",
+              "hashedLastName": "799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f",
+              "hashedPhoneNumbers": "422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8",
+              "zipCodes": "12345",
+            },
+          ],
+        },
+      }
+    `)
   })
 
   it('should batch multiple payloads into a single request when enable_batching is true', async () => {

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudContactInfo/index.ts
@@ -31,13 +31,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editContactInfo(request, [payload], 'remove', statsContext)
+    return editContactInfo(request, [payload], 'remove', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editContactInfo(request, payload, 'remove', statsContext)
+    return editContactInfo(request, payload, 'remove', statsContext, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudMobileDeviceId/index.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/removeFromAudMobileDeviceId/index.ts
@@ -15,13 +15,13 @@ const action: ActionDefinition<Settings, Payload, AudienceSettings> = {
     enable_batching: { ...enable_batching },
     batch_size: { ...batch_size }
   },
-  perform: async (request, { payload, statsContext }) => {
+  perform: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, [payload], 'remove', statsContext)
+    return editDeviceMobileIds(request, [payload], 'remove', statsContext, features)
   },
-  performBatch: async (request, { payload, statsContext }) => {
+  performBatch: async (request, { payload, statsContext, features }) => {
     statsContext?.statsClient?.incr('editCustomerMatchMembers.batch', 1, statsContext?.tags)
-    return editDeviceMobileIds(request, payload, 'remove', statsContext)
+    return editDeviceMobileIds(request, payload, 'remove', statsContext, features)
   }
 }
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->
 ## JIRA 
 
https://twilio-engineering.atlassian.net/browse/STRATCONN-6153

<!-- Hello and thank you for contributing to Segment action-destinations! -->

_A summary of your pull request, including the what change you're making and why._

## Description 
1. This PR includes changes for migration from v3 to v4 for first party DV360 action destination with feature flag .
2. Updated the unit test cases to v4 from v3 in first party action destination with feature flag .
3. Google is depreciating the v3  version of dv360 hence the changes are done .
<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

## Testing
Please find the testing document attached here .
https://docs.google.com/document/d/1W8CsIjAtOyP27YrgfyHMLXSz5V2QvffG7t91wo05-QY/edit?tab=t.0

## Flag created on production - 
https://flagon.segment.com/families/centrifuge-destinations/gates/actions-first-party-dv360-version-update

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 