### PR TITLE
Add error name in logs

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -330,7 +330,7 @@ describe('Kafka.send', () => {
       expect((error as IntegrationError).status).toBe(500)
     }
 
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error:'))
+    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error'))
   })
 
   it('wraps producer send errors and logs with critical level', async () => {
@@ -352,7 +352,7 @@ describe('Kafka.send', () => {
       expect((error as IntegrationError).status).toBe(500)
     }
 
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Send Error:'))
+    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Send Error'))
   })
 })
 

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -229,7 +229,7 @@ export const sendData = async (
       await producer.connect()
     }
   } catch (error) {
-    logger?.crit(`Kafka Connection Error: ${(error as Error).stack}`)
+    logger?.crit(`Kafka Connection Error - ${(error as Error).name}: ${(error as Error).stack}`)
     if ((error as Error).name !== 'IntegrationError') {
       throw new IntegrationError(
         `Kafka Connection Error - ${(error as Error).name}: ${(error as Error).message}`,
@@ -245,7 +245,7 @@ export const sendData = async (
     try {
       await producer.send(data as ProducerRecord)
     } catch (error) {
-      logger?.crit(`Kafka Send Error: ${(error as Error).stack}`)
+      logger?.crit(`Kafka Send Error - ${(error as Error).name}: ${(error as Error).stack}`)
       throw new IntegrationError(
         `Kafka Producer Error - ${(error as Error).name}: ${(error as Error).message}`,
         (error as Error)?.name,


### PR DESCRIPTION
The changes involve including the error name in critical log messages for both Kafka connection and send errors, and updating test assertions accordingly.

This will help us identify the exact error log for the error type received in datadog stats.


## Testing
<img width="1496" height="967" alt="Screenshot 2025-09-17 at 1 23 09 PM" src="https://github.com/user-attachments/assets/63d5127c-a919-4147-b779-9cdea8016fa1" />


Test logs on local:
```
2025-09-17T06:09:52.937Z - INFO - integrations - listening at http://:3000
{"level":"ERROR","timestamp":"2025-09-17T06:10:11.096Z","logger":"kafkajs","message":"[Connection] Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com","broker":"kafka-240f0580-actions-kafka.c.aivencloud.com:27263","clientId":"segment-actions-kafka-producer","stack":"Error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)\n    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17)"}
{"level":"ERROR","timestamp":"2025-09-17T06:10:11.098Z","logger":"kafkajs","message":"[BrokerPool] Failed to connect to seed broker, trying another broker from the list: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com","retryCount":0,"retryTime":308}
2025-09-17T06:10:11.099Z - CRIT - integrations-kafka - Kafka Connection Error - KafkaJSNumberOfRetriesExceeded: KafkaJSNonRetriableError
  Caused by: KafkaJSConnectionError: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
    at TLSSocket.onError (/Users/array/dev/src/github.com/segmentio/action-destinations/node_modules/kafkajs/src/network/connection.js:210:23)
    at TLSSocket.emit (node:events:524:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
2025-09-17T06:10:11.100Z - ERROR - integrations - actions-kafka - 1234567890 - Kafka Connection Error - KafkaJSNumberOfRetriesExceeded: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
 IntegrationError: Kafka Connection Error - KafkaJSNumberOfRetriesExceeded: Connection error: getaddrinfo ENOTFOUND kafka-240f0580-actions-kafka.c.aivencloud.com
```

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
