### PR TITLE
[MAIN] [MS-BING-CAPI] Updated Destination path

### DIFF
--- a/packages/browser-destinations/destinations/ms-bing-capi/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ms-bing-capi/src/__tests__/index.test.ts
@@ -54,7 +54,7 @@ describe('ajs-integration', () => {
 
     const updatedCtx = await msclkidPlugin.track?.(ctx)
 
-    const msBingCAPIIntegrationsObj = updatedCtx?.event?.integrations['Microsoft Bing CAPI']
+    const msBingCAPIIntegrationsObj = updatedCtx?.event?.integrations['Ms Bing Capi']
 
     expect(msBingCAPIIntegrationsObj[clickIdIntegrationFieldName]).toEqual('dummyQuerystringValue')
   })

--- a/packages/browser-destinations/destinations/ms-bing-capi/src/msclkidPlugin/index.ts
+++ b/packages/browser-destinations/destinations/ms-bing-capi/src/msclkidPlugin/index.ts
@@ -1,11 +1,7 @@
 import type { BrowserActionDefinition } from '@segment/browser-destination-runtime/types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import {
-  storageClickIdKey,
-  clickIdIntegrationFieldName,
-  storageFallback
-} from '../utils'
+import { storageClickIdKey, clickIdIntegrationFieldName, storageFallback } from '../utils'
 import { UniversalStorage } from '@segment/analytics-next'
 
 const action: BrowserActionDefinition<Settings, {}, Payload> = {
@@ -22,8 +18,8 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
     const integrationsData: Record<string, string> = {}
     if (msclkid) {
       integrationsData[clickIdIntegrationFieldName] = msclkid
-      if (context.event.integrations?.All !== false || context.event.integrations['Snap Conversions Api']) {
-        context.updateEvent(`integrations.Microsoft Bing CAPI`, integrationsData)
+      if (context.event.integrations?.All !== false || context.event.integrations['Ms Bing Capi']) {
+        context.updateEvent(`integrations.Ms Bing Capi`, integrationsData)
       }
     }
     return


### PR DESCRIPTION
Updated Destination Path to capture msclkId

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
