### PR TITLE
[MS Bing Ads Audiences] Fix multistatus bug

### DIFF
--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/__tests__/utils.test.ts
@@ -148,6 +148,52 @@ describe('handleHttpError', () => {
 })
 
 describe('handleMultistatusResponse', () => {
+  it('uses default Code (400) when error.Code is missing', () => {
+    const msResponse = createMockMsResponse()
+    const items = ['item1']
+    const listItemsMap = new Map<string, number[]>([['item1', [0]]])
+    const payload: Payload[] = [
+      {
+        audience_id: 'a1',
+        identifier_type: 'Email',
+        email: 'test@example.com',
+        enable_batching: true,
+        batch_size: 1000,
+        traits_or_props: {},
+        audience_key: 'a1',
+        computation_class: 'Default'
+      }
+    ]
+
+    const response = {
+      data: {
+        PartialErrors: [
+          {
+            FieldPath: null,
+            ErrorCode: 'InvalidInput',
+            Message: 'The input is invalid',
+            Code: undefined, // Missing Code
+            Details: null,
+            Index: 0,
+            Type: 'Error',
+            ForwardCompatibilityMap: null
+          }
+        ]
+      }
+    }
+
+    handleMultistatusResponse(msResponse, response as unknown as ModifiedResponse, items, listItemsMap, payload, true)
+
+    // Should use default 400 status code
+    expect(msResponse.setErrorResponseAtIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        status: 400, // Default value
+        errormessage: 'InvalidInput: The input is invalid'
+      })
+    )
+  })
+
   it('throws IntegrationError when not in batch mode and there are partial errors', () => {
     const msResponse = createMockMsResponse()
     const items = ['item1']
@@ -368,6 +414,144 @@ describe('handleMultistatusResponse', () => {
       0,
       expect.objectContaining({
         status: 200
+      })
+    )
+  })
+
+  it('uses default Message ("No error message provided") when Message is missing in partial errors', () => {
+    const msResponse = createMockMsResponse()
+    const items = ['item1']
+    const listItemsMap = new Map<string, number[]>([['item1', [0]]])
+    const payload: Payload[] = [
+      {
+        audience_id: 'a1',
+        identifier_type: 'Email',
+        email: 'test@example.com',
+        enable_batching: true,
+        batch_size: 1000,
+        traits_or_props: {},
+        audience_key: 'a1',
+        computation_class: 'Default'
+      }
+    ]
+
+    const response = {
+      data: {
+        PartialErrors: [
+          {
+            FieldPath: null,
+            ErrorCode: 'InvalidInput',
+            // Message is missing
+            Code: 403,
+            Details: null,
+            Index: 0,
+            Type: 'Error',
+            ForwardCompatibilityMap: null
+          }
+        ]
+      }
+    }
+
+    handleMultistatusResponse(msResponse, response as unknown as ModifiedResponse, items, listItemsMap, payload, true)
+
+    // Check that the default Message "No error message provided" is used
+    expect(msResponse.setErrorResponseAtIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        status: 403,
+        errormessage: 'InvalidInput: No error message provided'
+      })
+    )
+  })
+
+  it('uses default ErrorCode ("UnknownError") when ErrorCode is missing in partial errors', () => {
+    const msResponse = createMockMsResponse()
+    const items = ['item1']
+    const listItemsMap = new Map<string, number[]>([['item1', [0]]])
+    const payload: Payload[] = [
+      {
+        audience_id: 'a1',
+        identifier_type: 'Email',
+        email: 'test@example.com',
+        enable_batching: true,
+        batch_size: 1000,
+        traits_or_props: {},
+        audience_key: 'a1',
+        computation_class: 'Default'
+      }
+    ]
+
+    const response = {
+      data: {
+        PartialErrors: [
+          {
+            FieldPath: null,
+            // ErrorCode is missing
+            Message: 'The input is invalid',
+            Code: 403,
+            Details: null,
+            Index: 0,
+            Type: 'Error',
+            ForwardCompatibilityMap: null
+          }
+        ]
+      }
+    }
+
+    handleMultistatusResponse(msResponse, response as unknown as ModifiedResponse, items, listItemsMap, payload, true)
+
+    // Check that the default ErrorCode "UnknownError" is used
+    expect(msResponse.setErrorResponseAtIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        status: 403,
+        errormessage: 'UnknownError: The input is invalid'
+      })
+    )
+  })
+
+  it('uses default status code (400) when Code is missing in partial errors', () => {
+    const msResponse = createMockMsResponse()
+    const items = ['item1']
+    const listItemsMap = new Map<string, number[]>([['item1', [0]]])
+    const payload: Payload[] = [
+      {
+        audience_id: 'a1',
+        identifier_type: 'Email',
+        email: 'test@example.com',
+        enable_batching: true,
+        batch_size: 1000,
+        traits_or_props: {},
+        audience_key: 'a1',
+        computation_class: 'Default'
+      }
+    ]
+
+    const response = {
+      data: {
+        PartialErrors: [
+          {
+            FieldPath: null,
+            ErrorCode: 'InvalidInput',
+            Message: 'The input is invalid',
+            // Code is missing
+            Details: null,
+            Index: 0,
+            Type: 'Error',
+            ForwardCompatibilityMap: null
+          }
+        ]
+      }
+    }
+
+    handleMultistatusResponse(msResponse, response as unknown as ModifiedResponse, items, listItemsMap, payload, true)
+
+    // Check that the default status code 400 is used
+    expect(msResponse.setErrorResponseAtIndex).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        status: 400, // Default value
+        errormessage: 'InvalidInput: The input is invalid'
       })
     )
   })

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/fields.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/fields.ts
@@ -56,8 +56,7 @@ export const email: InputField = {
       else: { '@path': '$.properties.email' }
     }
   },
-  category: 'hashedPII',
-  format: 'email'
+  category: 'hashedPII'
 }
 
 export const crm_id: InputField = {

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/index.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/index.ts
@@ -71,8 +71,8 @@ const syncUser = async (request: RequestClient, payload: Payload[], isBatch: boo
   // Audience ID value is static for every batch as it's set in the batch keys array
   const audienceId = payload[0]?.audience_id
 
-  const addMap: Map<string, number> = new Map()
-  const removeMap: Map<string, number> = new Map()
+  const addMap: Map<string, number[]> = new Map()
+  const removeMap: Map<string, number[]> = new Map()
 
   categorizePayloadByAction(payload, addMap, removeMap)
 
@@ -98,7 +98,7 @@ const syncUser = async (request: RequestClient, payload: Payload[], isBatch: boo
       throw error
     }
     if (error instanceof HTTPError) {
-      await handleHttpError(msResponse, error, new Map([...addMap, ...removeMap]), payload)
+      await handleHttpError(msResponse, error, new Map([...addMap.entries(), ...removeMap.entries()]), payload)
     } else {
       throw error
     }


### PR DESCRIPTION
I found a bug while testing Ms Bing ads audiences, I was getting `MultiStatusResponse is missing a response at the specified index`. The error was because duplicate identifiers were not handled properly in multi status response.

- Fixed the multi status response by storing array of index when preparing identifier payload.

- Removed the `format: email` from mapping since we can have both hashed email and normal email in the email field.

- Updated unit tests.

## Testing
Test Doc: https://docs.google.com/document/d/1nwKG4u1abEK-fUqumAir0VSf0fkY_ytzxa87aSH3sqQ/edit?tab=t.qt1qlrkg4zbg

Testing completed locally.
_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
