### PR TITLE
[MAIN][MS-BING-CAPI] default value changes

### DIFF
--- a/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/fields.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/fields.ts
@@ -78,7 +78,7 @@ export const userData: InputField = {
       '@if': {
         exists: { '@path': '$.properties.msclkid' },
         then: { '@path': '$.properties.msclkid' },
-        else: { '@path': '$.integrations.Microsoft Bing CAPI.msclkid' }
+        else: { '@path': '$.integrations.Ms Bing Capi.msclkid' }
       }
     }
   }


### PR DESCRIPTION
This PR updates the destination path for Microsoft Bing CAPI to use a consistent naming convention. The change updates the integration key from "Microsoft Bing CAPI" to "Ms Bing Capi" and simplifies import formatting.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
