### PR TITLE
Remove kafka destination logs

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/__tests__/index.test.ts
@@ -308,8 +308,6 @@ describe('Kafka.send', () => {
       expect((error as Error).message).toBe('Kafka Connection Error: some settings error')
       expect((error as IntegrationError).status).toBe(400)
     }
-
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error:'))
   })
 
   it('wraps producer connect errors and logs with critical level', async () => {
@@ -329,8 +327,6 @@ describe('Kafka.send', () => {
       expect((error as Error).message).toBe('Kafka Connection Error - KafkaJSError: connect failed')
       expect((error as IntegrationError).status).toBe(500)
     }
-
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Connection Error'))
   })
 
   it('wraps producer send errors and logs with critical level', async () => {
@@ -351,8 +347,6 @@ describe('Kafka.send', () => {
       expect((error as Error).message).toBe('Kafka Producer Error - KafkaJSError: broker unavailable')
       expect((error as IntegrationError).status).toBe(500)
     }
-
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('Kafka Send Error'))
   })
 
   it('extracts nested Kafka cause for connect errors', async () => {
@@ -375,8 +369,6 @@ describe('Kafka.send', () => {
       expect((error as IntegrationError).message).toBe('Kafka Connection Error - BrokerNotAvailable: brokers down')
       expect((error as IntegrationError).status).toBe(500)
     }
-
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('BrokerNotAvailable'))
   })
 
   it('extracts nested Kafka cause for send errors', async () => {
@@ -401,8 +393,6 @@ describe('Kafka.send', () => {
       expect((error as IntegrationError).message).toBe('Kafka Producer Error - MessageSizeTooLarge: message too large')
       expect((error as IntegrationError).status).toBe(500)
     }
-
-    expect(logger.crit).toHaveBeenCalledWith(expect.stringContaining('MessageSizeTooLarge'))
   })
 })
 

--- a/packages/destination-actions/src/destinations/kafka/send/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/send/index.ts
@@ -65,11 +65,11 @@ const action: ActionDefinition<Settings, Payload> = {
       return getTopics(settings)
     }
   },
-  perform: async (_request, { settings, payload, features, statsContext, logger }) => {
-    await sendData(settings, [payload], features, statsContext, logger)
+  perform: async (_request, { settings, payload, features, statsContext }) => {
+    await sendData(settings, [payload], features, statsContext)
   },
-  performBatch: async (_request, { settings, payload, features, statsContext, logger }) => {
-    await sendData(settings, payload, features, statsContext, logger)
+  performBatch: async (_request, { settings, payload, features, statsContext }) => {
+    await sendData(settings, payload, features, statsContext)
   }
 }
 

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -4,7 +4,7 @@ import type { Settings } from './generated-types'
 import type { Payload } from './send/generated-types'
 import { DEFAULT_PARTITIONER, Message, TopicMessages, SSLConfig, CachedProducer } from './types'
 import { PRODUCER_REQUEST_TIMEOUT_MS, PRODUCER_TTL_MS, FLAGON_NAME } from './constants'
-import { Logger, StatsContext } from '@segment/actions-core/destination-kit'
+import { StatsContext } from '@segment/actions-core/destination-kit'
 
 export const producersByConfig: Record<string, CachedProducer> = {}
 
@@ -192,8 +192,7 @@ export const sendData = async (
   settings: Settings,
   payload: Payload[],
   features: Features | undefined,
-  statsContext: StatsContext | undefined,
-  logger: Logger | undefined
+  statsContext: StatsContext | undefined
 ) => {
   validate(settings)
 
@@ -239,14 +238,12 @@ export const sendData = async (
   } catch (error) {
     if ((error as Error).name !== 'IntegrationError') {
       const kafkaError = getKafkaError(error as Error)
-      logger?.crit(`Kafka Connection Error - ${kafkaError.name} | ${JSON.stringify(kafkaError)}`)
       throw new IntegrationError(
         `Kafka Connection Error - ${kafkaError.name}: ${kafkaError.message}`,
         kafkaError.name,
         500
       )
     } else {
-      logger?.crit(`Kafka Connection Error - ${error.name}: ${error as Error}`)
       throw error
     }
   }
@@ -256,7 +253,6 @@ export const sendData = async (
       await producer.send(data as ProducerRecord)
     } catch (error) {
       const kafkaError = getKafkaError(error as Error)
-      logger?.crit(`Kafka Send Error - ${kafkaError.name} | ${JSON.stringify(kafkaError)}`)
       throw new IntegrationError(
         `Kafka Producer Error - ${kafkaError.name}: ${kafkaError.message}`,
         kafkaError.name,


### PR DESCRIPTION
This pull request refactors the Kafka destination action to remove the use of the `logger` for critical error logging in both the implementation and its associated tests. The main goal is to simplify the code by no longer passing or invoking the `logger` for error handling, instead relying solely on error throwing. This change improves is done to potentially resolve the memory issue recorded in [this datadog alert](https://twilio.slack.com/archives/C04J657D268/p1758526723850809).


Testing completed successfully on stage: No logs are now found in [stage](https://segment.grafana.net/goto/eeyx9v28hy22od?orgId=1) for kafka destination

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
