### PR TITLE
shift producer.disconnect() to finally block to disconnect kafka producer gracefully on errors

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -271,7 +271,7 @@ export const sendData = async (
           producersByConfig[key].lastUsed = Date.now()
         }
       } else {
-        await producer.disconnect()
+        await producer?.disconnect()
       }
     }
   }

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -264,15 +264,15 @@ export const sendData = async (
         kafkaError.name,
         500
       )
+    } finally {
+      if (features && features[FLAGON_NAME]) {
+        const key = serializeKafkaConfig(settings)
+        if (producersByConfig[key]) {
+          producersByConfig[key].lastUsed = Date.now()
+        }
+      } else {
+        await producer.disconnect()
+      }
     }
-  }
-
-  if (features && features[FLAGON_NAME]) {
-    const key = serializeKafkaConfig(settings)
-    if (producersByConfig[key]) {
-      producersByConfig[key].lastUsed = Date.now()
-    }
-  } else {
-    await producer.disconnect()
   }
 }


### PR DESCRIPTION
This pull request makes a small but important change to the Kafka utility function, ensuring proper cleanup of resources. The main update is moving the Kafka producer disconnection logic into a `finally` block, which guarantees that the producer is disconnected regardless of whether an error occurs during data sending.

<img width="2992" height="6665" alt="image" src="https://github.com/user-attachments/assets/bcc3c154-1ccd-418b-8942-8fe3c9de1e49" />


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
