### PR TITLE
Ortto: Make message ID optional

### DIFF
--- a/packages/destination-actions/src/destinations/ortto-audiences/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/ortto-audiences/syncAudience/index.ts
@@ -48,6 +48,8 @@ const action: ActionDefinition<Settings, Payload> = {
       description: 'Message ID',
       type: 'string',
       readOnly: true,
+      required: false,
+      unsafe_hidden: true,
       default: {
         '@path': '$.messageId'
       }

--- a/packages/destination-actions/src/destinations/ortto/common-fields.ts
+++ b/packages/destination-actions/src/destinations/ortto/common-fields.ts
@@ -1,27 +1,6 @@
 import { InputField } from '@segment/actions-core'
 
 export const commonFields: Record<string, InputField> = {
-  timestamp: {
-    label: 'Timestamp',
-    description: 'Event timestamp (ISO 8601)',
-    type: 'string',
-    readOnly: true,
-    format: 'date-time',
-    required: true,
-    default: {
-      '@path': '$.timestamp'
-    }
-  },
-  message_id: {
-    label: 'Message ID',
-    description: 'Message ID',
-    type: 'string',
-    readOnly: true,
-    required: true,
-    default: {
-      '@path': '$.messageId'
-    }
-  },
   enable_batching: {
     type: 'boolean',
     label: 'Batch data',
@@ -136,7 +115,7 @@ export const commonFields: Record<string, InputField> = {
     description: 'An object containing key-value pairs representing custom properties assigned to Contact profile',
     type: 'object',
     defaultObjectUI: 'keyvalue',
-    default:  {
+    default: {
       '@if': {
         exists: { '@path': '$.traits' },
         then: { '@path': '$.traits' },

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/__tests__/index.test.ts
@@ -20,12 +20,10 @@ const settings: Settings = {
 }
 
 const validPayload = {
-  timestamp: '2024-01-08T13:52:50.212Z',
   type: 'track',
   userId: 'user_id',
   anonymousId: 'anonymous_id',
   event: 'event',
-  messageId: 'message_id',
   properties: {
     arrtibute1: 'value1',
     arrtibute2: 'value2'

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/generated-types.ts
@@ -2,13 +2,13 @@
 
 export interface Payload {
   /**
-   * Event timestamp (ISO 8601)
+   * Event timestamp in ISO 8601 format. Used with the Message ID to uniquely identify an activity in Ortto. If not provided, duplicate activities may occur.
    */
-  timestamp: string
+  timestamp?: string
   /**
-   * Message ID
+   * Message ID. Combined with the event timestamp to uniquely identify an activity in Ortto. If omitted, duplicate activities may occur.
    */
-  message_id: string
+  message_id?: string
   /**
    * The unique user identifier
    */

--- a/packages/destination-actions/src/destinations/ortto/trackActivity/index.ts
+++ b/packages/destination-actions/src/destinations/ortto/trackActivity/index.ts
@@ -8,8 +8,29 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Track user activity',
   defaultSubscription: 'type = "track"',
   fields: {
-    timestamp: commonFields.timestamp,
-    message_id: commonFields.message_id,
+    timestamp: {
+      label: 'Timestamp',
+      description:
+        'Event timestamp in ISO 8601 format. Used with the Message ID to uniquely identify an activity in Ortto. If not provided, duplicate activities may occur.',
+      type: 'string',
+      readOnly: false,
+      format: 'date-time',
+      required: false,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    message_id: {
+      label: 'Message ID',
+      description:
+        'Message ID. Combined with the event timestamp to uniquely identify an activity in Ortto. If omitted, duplicate activities may occur.',
+      type: 'string',
+      readOnly: false,
+      required: false,
+      default: {
+        '@path': '$.messageId'
+      }
+    },
     user_id: commonFields.user_id,
     anonymous_id: commonFields.anonymous_id,
     enable_batching: commonFields.enable_batching,
@@ -23,8 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     traits: {
       ...commonFields.traits,
-      description:
-        "key-value custom property pairs to be assigned to the Contact's profile"
+      description: "key-value custom property pairs to be assigned to the Contact's profile"
     },
     audience_update_mode: commonFields.audience_update_mode,
     batch_size: commonFields.batch_size,
@@ -51,7 +71,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Activity properties',
       description: 'An object containing key-value pairs representing activity attributes',
       type: 'object',
-      defaultObjectUI: 'keyvalue',    
+      defaultObjectUI: 'keyvalue',
       default: {
         '@path': '$.properties'
       }

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/__tests__/index.test.ts
@@ -14,11 +14,9 @@ const settings: Settings = {
 }
 
 const validPayload = {
-  timestamp: '2024-01-08T13:52:50.212Z',
   type: 'identify',
   userId: 'user_id',
   anonymousId: 'anonymous_id',
-  messageId: 'message_id',
   traits: {
     first_name: 'John',
     last_name: 'Smith'

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/generated-types.ts
@@ -4,11 +4,11 @@ export interface Payload {
   /**
    * Event timestamp (ISO 8601)
    */
-  timestamp: string
+  timestamp?: string
   /**
    * Message ID
    */
-  message_id: string
+  message_id?: string
   /**
    * The unique user identifier
    */

--- a/packages/destination-actions/src/destinations/ortto/upsertContactProfile/index.ts
+++ b/packages/destination-actions/src/destinations/ortto/upsertContactProfile/index.ts
@@ -9,8 +9,29 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Create or update a Contact in Ortto',
   defaultSubscription: 'type = "identify"',
   fields: {
-    timestamp: commonFields.timestamp,
-    message_id: commonFields.message_id,
+    timestamp: {
+      label: 'Timestamp',
+      description: 'Event timestamp (ISO 8601)',
+      type: 'string',
+      readOnly: true,
+      format: 'date-time',
+      required: false,
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    message_id: {
+      label: 'Message ID',
+      description: 'Message ID',
+      type: 'string',
+      readOnly: true,
+      required: false,
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.messageId'
+      }
+    },
     user_id: commonFields.user_id,
     anonymous_id: commonFields.anonymous_id,
     enable_batching: commonFields.enable_batching,


### PR DESCRIPTION
Make Message ID and Timestamp optional to support rETL, which cannot provide a Message ID. Without a Message ID, activities from rETL cannot be deduplicated using the usual key, so this change allows the integration to accept events while acknowledging that duplicates may occur.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [X] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
