### PR TITLE
new braze web sdk

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/packages/browser-destinations/destinations/braze/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -85,7 +85,7 @@ exports[`loads different versions from CDN undefined version:
      1`] = `
 NodeList [
   <script
-    src="https://js.appboycdn.com/web-sdk/5.9/braze.no-module.min.js"
+    src="https://js.appboycdn.com/web-sdk/6.1/braze.no-module.min.js"
     status="loaded"
     type="text/javascript"
   />,

--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -18,7 +18,7 @@ declare global {
   }
 }
 
-const defaultVersion = '5.9'
+const defaultVersion = '6.1'
 
 const presets: DestinationDefinition['presets'] = [
   {
@@ -105,6 +105,10 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         {
           value: '5.9',
           label: '5.9'
+        },
+        {
+          value: '6.1',
+          label: '6.1'
         }
       ],
       default: defaultVersion,


### PR DESCRIPTION
Adding Braze Web SDK v6.1.0

Original [PR](https://github.com/segmentio/action-destinations/pull/3292) raised by Braze - but snapshot failing - so I copied code here.