### PR TITLE
[NTTS-447] Add optional schemaOverride setting for Snowflake destination

### DIFF
--- a/packages/warehouse-destinations/src/destinations/snowflake/generated-types.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * The ID of the existing Snowflake warehouse instance to use.
    */
   warehouseId: string
+  /**
+   * The name of an existing Snowflake Schema to use.
+   */
+  schemaOverride?: string
 }

--- a/packages/warehouse-destinations/src/destinations/snowflake/index.ts
+++ b/packages/warehouse-destinations/src/destinations/snowflake/index.ts
@@ -17,6 +17,12 @@ const destination: WarehouseDestinationDefinition<Settings> = {
       description: 'The ID of the existing Snowflake warehouse instance to use.',
       type: 'string',
       required: true
+    },
+    schemaOverride: {
+      label: 'Schema Override',
+      description: 'The name of an existing Snowflake Schema to use.',
+      type: 'string',
+      required: false
     }
   },
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

# Description

> As a User, I want the ability to override which Snowflake SCHEMA is used when loading data to my Snowflake Destination.

This PR adds an optional `schemaOverride` setting in the Snowflake Destination Settings metadata.

This change does not add any new destinations, and only updates the "warehouse-destinations" Snowflake definition (which is for internal use only).

### Additional Context
[RFC: Warehouse Action Destinations - Schema Overrides](https://docs.google.com/document/d/1oqi2MFMEbZIx9wGm1qkxQhDdDbJK6rhKL8bnLQ6hgAc/edit?tab=t.wxrif5g5lxeo#heading=h.8q0oljvi6xtu)

The Snowflake destination is used as a relay to Segment Warehouse Destinations. It requires an existing Warehouse ID, validated via control-plane. 
Transformations are applied to events based on the event trigger's customized mappings, and event Archives are inserted into the Warehouses' Pipeline.

The service responsible for transforming the data and inserting the Warehouse Archives will read this setting if it is present in control-plane / ctlstore, and add the schema override setting to the Archive metadata.

This archive metadata for the SchemaOverride will then be used when loading the data to Snowflake.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 

* Applied changes to staging via internal tooling `actions-cli push`
* Setting visible via Destination Settings modal:
<img width="609" height="481" alt="Screenshot 2025-09-26 at 2 20 21 PM" src="https://github.com/user-attachments/assets/3b303e86-6114-42cc-ae74-d93cd89da518" />

