### PR TITLE
[MS-BING-CAPI] [STRATCONN-6069] Changed actions name

### DIFF
--- a/packages/browser-destinations/destinations/ms-bing-capi/src/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/ms-bing-capi/src/__tests__/index.test.ts
@@ -54,7 +54,7 @@ describe('ajs-integration', () => {
 
     const updatedCtx = await msclkidPlugin.track?.(ctx)
 
-    const msBingCAPIIntegrationsObj = updatedCtx?.event?.integrations['Ms Bing Capi']
+    const msBingCAPIIntegrationsObj = updatedCtx?.event?.integrations['Microsoft Bing CAPI (Actions)']
 
     expect(msBingCAPIIntegrationsObj[clickIdIntegrationFieldName]).toEqual('dummyQuerystringValue')
   })

--- a/packages/browser-destinations/destinations/ms-bing-capi/src/msclkidPlugin/index.ts
+++ b/packages/browser-destinations/destinations/ms-bing-capi/src/msclkidPlugin/index.ts
@@ -18,8 +18,8 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
     const integrationsData: Record<string, string> = {}
     if (msclkid) {
       integrationsData[clickIdIntegrationFieldName] = msclkid
-      if (context.event.integrations?.All !== false || context.event.integrations['Ms Bing Capi']) {
-        context.updateEvent(`integrations.Ms Bing Capi`, integrationsData)
+      if (context.event.integrations?.All !== false || context.event.integrations['Microsoft Bing CAPI (Actions)']) {
+        context.updateEvent(`integrations.Microsoft Bing CAPI (Actions)`, integrationsData)
       }
     }
     return

--- a/packages/destination-actions/src/destinations/ms-bing-capi/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-capi/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   UetTag: string
   /**
-   * Your Bing API Token.
+   * Your Bing API Token. API token generation is not generally available. To obtain one, you’ll need to contact Microsoft Support, or alternatively, you can [fill out this form](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbRwMZAe0PcMxHmZ0AjDaNRmxUM0o5UURRVktCRkxHNEFLTVNYQjI3NDNBUS4u) to request access.
    */
   ApiToken: string
   /**

--- a/packages/destination-actions/src/destinations/ms-bing-capi/index.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-capi/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from './generated-types'
 import sendEvent from './sendEvent'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Ms Bing Capi',
+  name: 'Microsoft Bing CAPI (Actions)',
   slug: 'actions-ms-bing-capi',
   mode: 'cloud',
   authentication: {
@@ -17,7 +17,8 @@ const destination: DestinationDefinition<Settings> = {
       },
       ApiToken: {
         label: 'Bing ApiToken',
-        description: 'Your Bing API Token.',
+        description:
+          'Your Bing API Token. API token generation is not generally available. To obtain one, you’ll need to contact Microsoft Support, or alternatively, you can [fill out this form](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbRwMZAe0PcMxHmZ0AjDaNRmxUM0o5UURRVktCRkxHNEFLTVNYQjI3NDNBUS4u) to request access.',
         type: 'password',
         required: true
       },
@@ -99,7 +100,8 @@ const destination: DestinationDefinition<Settings> = {
     },
     {
       name: 'Send Custom Event',
-      subscribe: 'type = "track" and event != "Order Completed" and event != "Add to Cart" and event != "Products Searched"',
+      subscribe:
+        'type = "track" and event != "Order Completed" and event != "Add to Cart" and event != "Products Searched"',
       partnerAction: 'sendEvent',
       mapping: defaultValues(sendEvent.fields),
       type: 'automatic'

--- a/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/__tests__/sendEvent.test.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/__tests__/sendEvent.test.ts
@@ -37,7 +37,7 @@ function buildTrackEvent(overrides: Record<string, any> = {}) {
 
 const settings: Settings = { UetTag: 'uet-123', ApiToken: 'token-abc', adStorageConsent: 'G' }
 
-describe('Ms Bing Capi - sendEvent (updated)', () => {
+describe('Microsoft Bing CAPI (Actions) - sendEvent (updated)', () => {
   const testDestination = createTestIntegration(destination)
   afterEach(() => nock.cleanAll())
 
@@ -112,10 +112,10 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
     await testDestination.testAction('sendEvent', {
       event,
       settings,
-      mapping: { 
-        data: { eventType: 'custom', eventTime: isoEventTime }, 
+      mapping: {
+        data: { eventType: 'custom', eventTime: isoEventTime },
         userData: { anonymousId: 'anon-1' },
-        timestamp: { '@path': '$.timestamp' } 
+        timestamp: { '@path': '$.timestamp' }
       }
     })
     expect(scope.isDone()).toBe(true)
@@ -131,9 +131,9 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
       settings,
       mapping: {
         enable_batching: true,
-        data: { eventType: 'custom'},
+        data: { eventType: 'custom' },
         userData: { anonymousId: 'anon-1' },
-        timestamp: { '@path': '$.timestamp'}
+        timestamp: { '@path': '$.timestamp' }
       }
     })
     expect(responses.length).toBe(2)
@@ -156,9 +156,9 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
       settings,
       mapping: {
         enable_batching: true,
-        data: { eventType: 'custom'},
+        data: { eventType: 'custom' },
         userData: { anonymousId: 'anon-1' },
-        timestamp: { '@path': '$.timestamp'}
+        timestamp: { '@path': '$.timestamp' }
       }
     })
     expect(responses.length).toBe(2)
@@ -181,7 +181,7 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
       event,
       settings,
       mapping: {
-        data: { eventType: 'custom'},
+        data: { eventType: 'custom' },
         userData: { anonymousId: 'anon-1', em: 'only@example.com' },
         timestamp: { '@path': '$.timestamp' }
       }
@@ -204,7 +204,7 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
         data: { eventType: 'custom', eventTime: new Date('2024-01-01T00:00:00.000Z').toISOString() },
         customData: { value: 10 },
         userData: { anonymousId: 'anon-1' },
-        timestamp: { '@path': '$.timestamp'}
+        timestamp: { '@path': '$.timestamp' }
       }
     })
     expect(scope.isDone()).toBe(true)
@@ -250,7 +250,7 @@ describe('Ms Bing Capi - sendEvent (updated)', () => {
       mapping: {
         data: { eventType: 'custom', eventTime: '2024-01-01T00:00:00.000Z' },
         userData: { anonymousId: 'anon-1', ph: rawPhone },
-        timestamp: { '@path': '$.timestamp'}
+        timestamp: { '@path': '$.timestamp' }
       }
     })
     expect(scope.isDone()).toBe(true)

--- a/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/fields.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-capi/sendEvent/fields.ts
@@ -78,7 +78,7 @@ export const userData: InputField = {
       '@if': {
         exists: { '@path': '$.properties.msclkid' },
         then: { '@path': '$.properties.msclkid' },
-        else: { '@path': '$.integrations.Ms Bing Capi.msclkid' }
+        else: { '@path': '$.integrations.Microsoft Bing CAPI (Actions).msclkid' }
       }
     }
   }


### PR DESCRIPTION
This PR updates the action name from “Ms Bing Capi” to “Microsoft Bing CAPI (Actions)”. It also adds the form link for obtaining an API token, since the API token is not yet generally available from Microsoft.

<img width="647" height="570" alt="Screenshot 2025-09-30 at 12 29 14 PM" src="https://github.com/user-attachments/assets/fb5de738-4449-44f9-80bc-25965ac8db0b" />

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
