### PR TITLE
[TOPSORT] Add skipZeroPricePurchases setting to Topsort destination

### DIFF
--- a/packages/destination-actions/src/destinations/topsort/generated-types.ts
+++ b/packages/destination-actions/src/destinations/topsort/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * Created under Settings > API Integration in the Topsort Manager Platform.
    */
   api_key: string
+  /**
+   * When enabled, purchase events with items that have zero or missing unit price will be filtered out.
+   */
+  skipZeroPricePurchases?: boolean
 }

--- a/packages/destination-actions/src/destinations/topsort/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/index.ts
@@ -24,6 +24,14 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Created under Settings > API Integration in the Topsort Manager Platform.',
         type: 'password',
         required: true
+      },
+      skipZeroPricePurchases: {
+        label: 'Skip Zero Price Purchases',
+        description:
+          'When enabled, purchase events with items that have zero or missing unit price will be filtered out.',
+        type: 'boolean',
+        required: false,
+        default: false
       }
     }
   },

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/index.test.ts
@@ -157,4 +157,141 @@ describe('Topsort.purchase', () => {
       })
     ).rejects.toThrowError(AggregateAjvError)
   })
+
+  it('should filter out items with zero price when skipZeroPricePurchases is enabled', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: {
+        products: [
+          {
+            product_id: '123',
+            price: 100,
+            quantity: 1
+          },
+          {
+            product_id: '456',
+            price: 0,
+            quantity: 2
+          },
+          {
+            product_id: '789',
+            price: 50,
+            quantity: 1
+          }
+        ]
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar',
+        skipZeroPricePurchases: true
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1
+            },
+            {
+              productId: '789',
+              unitPrice: 50,
+              quantity: 1
+            }
+          ]
+        })
+      ])
+    })
+  })
+
+  it('should skip entire purchase when all items have zero price and skipZeroPricePurchases is enabled', async () => {
+    const event = createTestEvent({
+      properties: {
+        products: [
+          {
+            product_id: '123',
+            price: 0,
+            quantity: 1
+          },
+          {
+            product_id: '456',
+            price: 0,
+            quantity: 2
+          }
+        ]
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar',
+        skipZeroPricePurchases: true
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(0)
+  })
+
+  it('should send all items including zero price when skipZeroPricePurchases is disabled', async () => {
+    nock(/.*/).persist().post(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: {
+        products: [
+          {
+            product_id: '123',
+            price: 100,
+            quantity: 1
+          },
+          {
+            product_id: '456',
+            price: 0,
+            quantity: 2
+          }
+        ]
+      }
+    })
+
+    const responses = await testDestination.testAction('purchase', {
+      event,
+      settings: {
+        api_key: 'bar',
+        skipZeroPricePurchases: false
+      },
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      purchases: expect.arrayContaining([
+        expect.objectContaining({
+          items: [
+            {
+              productId: '123',
+              unitPrice: 100,
+              quantity: 1
+            },
+            {
+              productId: '456',
+              unitPrice: 0,
+              quantity: 2
+            }
+          ]
+        })
+      ])
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/topsort/purchase/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/__tests__/snapshot.test.ts
@@ -24,9 +24,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, skipZeroPricePurchases: false },
       auth: undefined
     })
+
+    if (!responses[0].request) {
+      expect(responses[0].options.json).toMatchSnapshot()
+      return
+    }
 
     const request = responses[0].request
     const rawBody = await request.text()
@@ -57,9 +62,14 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
     const responses = await testDestination.testAction(actionSlug, {
       event: event,
       mapping: event.properties,
-      settings: settingsData,
+      settings: { ...settingsData, skipZeroPricePurchases: false },
       auth: undefined
     })
+
+    if (!responses[0].request) {
+      expect(responses[0].options.json).toMatchSnapshot()
+      return
+    }
 
     const request = responses[0].request
     const rawBody = await request.text()

--- a/packages/destination-actions/src/destinations/topsort/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/topsort/purchase/index.ts
@@ -90,6 +90,17 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, { payload, settings }) => {
     const client = new TopsortAPIClient(request, settings)
+
+    if (settings.skipZeroPricePurchases) {
+      const filteredItems = payload.items.filter((item) => item.unitPrice != null && item.unitPrice > 0)
+
+      if (filteredItems.length === 0) {
+        return
+      }
+
+      payload.items = filteredItems
+    }
+
     return client.sendEvent({
       purchases: [payload]
     })


### PR DESCRIPTION
- Introduced a new optional setting `skipZeroPricePurchases` to filter out purchase events with items that have zero or missing unit price.
- Updated the `Settings` interface and corresponding destination definition.
- Implemented filtering logic in the purchase action.
- Added unit tests to verify the new functionality, including scenarios for enabling and disabling the setting.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [x] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
