### PR TITLE
[GA 4 web] - handling when domain is an empty string

### DIFF
--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/index.ts
@@ -239,7 +239,7 @@ export const destination: BrowserDestinationDefinition<Settings, Function> = {
       }
       gtag('consent', 'default', consent)
     }
-    const script = `https://${settings.domain ?? 'www.googletagmanager.com'}/gtag/js?id=${settings.measurementID}`
+    const script = `https://${settings.domain || 'www.googletagmanager.com'}/gtag/js?id=${settings.measurementID}`
     await deps.loadScript(script)
     return window.gtag
   },


### PR DESCRIPTION
Minor change from ?? to || for optional domain field in GA 4 web. 

## Testing

Tested locally and in stage