### PR TITLE
[MS BING ADS AUDIENCES] Add Developer Token as an environment variable

### DIFF
--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/generated-types.ts
@@ -2,10 +2,6 @@
 
 export interface Settings {
   /**
-   * The developer token for authenticating API requests. You can find it in the Microsoft Advertising User Interface under Settings → Developer Settings.
-   */
-  developerToken: string
-  /**
    * The account ID of the Microsoft Advertising account you want to manage. You can find it in the URL when viewing the account in the Microsoft Ads User Interface.
    */
   customerAccountId: string

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/index.ts
@@ -18,13 +18,6 @@ const destination: AudienceDestinationDefinition<Settings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {
-      developerToken: {
-        label: 'Developer Token',
-        description:
-          'The developer token for authenticating API requests. You can find it in the Microsoft Advertising User Interface under Settings → Developer Settings.',
-        type: 'password',
-        required: true
-      },
       customerAccountId: {
         label: 'Customer Account ID',
         description:
@@ -69,7 +62,7 @@ const destination: AudienceDestinationDefinition<Settings> = {
     return {
       headers: {
         Authorization: `Bearer ${auth?.accessToken}`,
-        DeveloperToken: settings?.developerToken,
+        DeveloperToken: process.env.ACTIONS_MS_BING_ADS_AUDIENCES_DEVELOPER_TOKEN || '',
         CustomerAccountId: settings?.customerAccountId,
         CustomerId: settings?.customerId
       }

--- a/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/ms-bing-ads-audiences/syncAudiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -29,7 +29,7 @@ Headers {
       "7%%34jFY!]ma!EVbG",
     ],
     "developertoken": Array [
-      "7%%34jFY!]ma!EVbG",
+      "",
     ],
     "user-agent": Array [
       "Segment (Actions)",
@@ -67,7 +67,7 @@ Headers {
       "7%%34jFY!]ma!EVbG",
     ],
     "developertoken": Array [
-      "7%%34jFY!]ma!EVbG",
+      "",
     ],
     "user-agent": Array [
       "Segment (Actions)",


### PR DESCRIPTION
This change makes the Microsoft Ads developer token configurable through an environment variable.
The token is intended to be a shared Segment-level credential, rather than a separate token generated by each user.

Added the environment variable in chamber.

[Document with steps to access the Microsoft account.
](https://docs.google.com/document/d/1lE5XFhmNWoYaU-iGBS8XbunCubE0GlMNWe8xgiFLOvA/edit?usp=sharing)

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
