### PR TITLE
Removing IAM authentication from kafka settings

### DIFF
--- a/packages/destination-actions/src/destinations/kafka/generated-types.ts
+++ b/packages/destination-actions/src/destinations/kafka/generated-types.ts
@@ -22,18 +22,6 @@ export interface Settings {
    */
   password?: string
   /**
-   * The Access Key ID for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.
-   */
-  accessKeyId?: string
-  /**
-   * The Secret Key for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.
-   */
-  secretAccessKey?: string
-  /**
-   * AWS IAM role ARN used for authorization. This field is optional, and should only be populated if using the AWS IAM Authentication Mechanism.
-   */
-  authorizationIdentity?: string
-  /**
    * Indicates if SSL should be enabled.
    */
   ssl_enabled?: boolean

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -36,7 +36,6 @@ const destination: DestinationDefinition<Settings> = {
           { label: 'Plain', value: 'plain' },
           { label: 'SCRAM-SHA-256', value: 'scram-sha-256' },
           { label: 'SCRAM-SHA-512', value: 'scram-sha-512' },
-          //  { label: 'AWS IAM', value: 'aws' },
           { label: 'Client Certificate', value: 'client-cert-auth' }
         ],
         default: 'plain'
@@ -56,30 +55,6 @@ const destination: DestinationDefinition<Settings> = {
         type: 'password',
         required: false,
         depends_on: DEPENDS_ON_PLAIN_OR_SCRAM
-      },
-      accessKeyId: {
-        label: 'AWS Access Key ID',
-        description:
-          'The Access Key ID for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.',
-        type: 'string',
-        required: false,
-        depends_on: DEPEONDS_ON_AWS
-      },
-      secretAccessKey: {
-        label: 'AWS Secret Key',
-        description:
-          'The Secret Key for your AWS IAM instance. Must be populated if using AWS IAM Authentication Mechanism.',
-        type: 'password',
-        required: false,
-        depends_on: DEPEONDS_ON_AWS
-      },
-      authorizationIdentity: {
-        label: 'AWS Authorization Identity',
-        description:
-          'AWS IAM role ARN used for authorization. This field is optional, and should only be populated if using the AWS IAM Authentication Mechanism.',
-        type: 'string',
-        required: false,
-        depends_on: DEPEONDS_ON_AWS
       },
       ssl_enabled: {
         label: 'SSL Enabled',

--- a/packages/destination-actions/src/destinations/kafka/index.ts
+++ b/packages/destination-actions/src/destinations/kafka/index.ts
@@ -1,7 +1,7 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { validate, getTopics } from './utils'
-import { DEPENDS_ON_CLIENT_CERT, DEPEONDS_ON_AWS, DEPENDS_ON_PLAIN_OR_SCRAM } from './depends-on'
+import { DEPENDS_ON_CLIENT_CERT, DEPENDS_ON_PLAIN_OR_SCRAM } from './depends-on'
 import send from './send'
 
 const destination: DestinationDefinition<Settings> = {

--- a/packages/destination-actions/src/destinations/kafka/utils.ts
+++ b/packages/destination-actions/src/destinations/kafka/utils.ts
@@ -19,9 +19,6 @@ export const serializeKafkaConfig = (settings: Settings): string => {
     mechanism: settings.mechanism,
     username: settings.username,
     password: settings.password,
-    accessKeyId: settings.accessKeyId,
-    secretAccessKey: settings.secretAccessKey,
-    authorizationIdentity: settings.authorizationIdentity,
     ssl_ca: settings.ssl_ca,
     ssl_cert: settings.ssl_cert,
     ssl_key: settings.ssl_key,
@@ -62,13 +59,6 @@ const getKafka = (settings: Settings) => {
           return {
             username: settings.username,
             password: settings.password,
-            mechanism: settings.mechanism
-          } as SASLOptions
-        case 'aws':
-          return {
-            accessKeyId: settings.accessKeyId,
-            secretAccessKey: settings.secretAccessKey,
-            authorizationIdentity: settings.authorizationIdentity,
             mechanism: settings.mechanism
           } as SASLOptions
         default:
@@ -115,13 +105,6 @@ export const validate = (settings: Settings) => {
     throw new IntegrationError(
       'Username and Password are required for PLAIN and SCRAM authentication mechanisms',
       'SASL_PARAMS_MISSING',
-      400
-    )
-  }
-  if (['aws'].includes(settings.mechanism) && (!settings.accessKeyId || !settings.secretAccessKey)) {
-    throw new IntegrationError(
-      'AWS Access Key ID and AWS Secret Key are required for AWS authentication mechanism',
-      'SASL_AWS_PARAMS_MISSING',
       400
     )
   }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->



<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Removing iam settings from kafka destination docs because we don't support IAM authentication for Kafka.

https://twilio-engineering.atlassian.net/browse/STRATCONN-6172

## Testing

Performed cloud stage deploy https://github.com/segmentio/action-destinations/actions/runs/18278506656, verification pending. 

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
