### PR TITLE
[Amazon DSP] - Support AMC audiences

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 import { HTTPError } from '@segment/actions-core/*'
-import { AUTHORIZATION_URL, TTL_MAX_VALUE } from '../utils'
+import { AUTHORIZATION_URL, TTL_MAX_VALUE } from '../constants'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -68,32 +68,53 @@ describe('Amazon-Ads (actions)', () => {
     })
 
     it("should fail if advertiserId is missing in audienceSettings and sync_to = 'DSP'", async () => {
+      
+      const audienceSettings2 = {
+        ...audienceSettings,
+        advertiserId: undefined,
+        sync_to: 'dsp'
+      }
+      
       const createAudienceInput = {
         ...createAudienceInputTemp,
-        audienceSettings: {
-          ...audienceSettings,
-          advertiserId: '',
-          sync_to: 'dsp'
-        }
+        audienceSettings: audienceSettings2
       }
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        'Missing advertiserId Value when syncing audience to DSP'
+        "The root value is missing the required field 'advertiserId'. The root value must match \"then\" schema."
       )
     })
 
-    it("should fail if amcInstanceId && amcAccountId && amcAccountMarketplaceId are missing in audienceSettings and sync_to = 'AMC'", async () => {
+    it("should fail if advertiserId is missing in audienceSettings and sync_to = undefined or null", async () => {
+      
+      const audienceSettings2 = {
+        ...audienceSettings,
+        advertiserId: undefined,
+        sync_to: undefined
+      }
+      
+      const createAudienceInput = {
+        ...createAudienceInputTemp,
+        audienceSettings: audienceSettings2
+      }
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
+        "Advertiser Id value is required when syncing an audience to DSP"
+      )
+    })
+
+    it("should fail if any of amcInstanceId, amcAccountId or amcAccountMarketplaceId are missing in audienceSettings and sync_to = 'AMC'", async () => {
+      
       const createAudienceInput = {
         ...createAudienceInputTemp,
         audienceSettings: {
           ...audienceSettings,
-          amcInstanceId: '',
-          amcAccountId: '',
-          amcAccountMarketplaceId: '',
+          amcInstanceId: undefined,
+          amcAccountId: undefined,
+          amcAccountMarketplaceId: undefined,
           sync_to: 'amc'
         }
       }
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        'Missing required fields amcInstanceId, amcAccountId, and amcAccountMarketplaceId Value when syncing audience to AMC'
+        "The root value is missing the required field 'amcInstanceId'. The root value must match \"then\" schema. The root value is missing the required field 'amcAccountId'. The root value must match \"then\" schema. The root value is missing the required field 'amcAccountMarketplaceId'. The root value must match \"then\" schema."
       )
     })
 

--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -79,6 +79,21 @@ describe('Amazon-Ads (actions)', () => {
         'Missing advertiserId Value'
       )
     })
+    it('should fail if advertiserId  and amcInstanceId && amcAccountId && amcAccountMarketplaceId are missing in audienceSettings', async () => {
+      const createAudienceInput = {
+        ...createAudienceInputTemp,
+        audienceSettings: {
+          ...audienceSettings,
+          advertiserId: '',
+          amcInstanceId: '',
+          amcAccountId: '',
+          amcAccountMarketplaceId: ''
+        }
+      }
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
+        'Missing advertiserId, amcInstanceId , amcAccountId , amcAccountMarketplaceId Value'
+      )
+    })
     it('should fail if externalAudienceId is missing in audienceSettings', async () => {
       const createAudienceInput = {
         ...createAudienceInputTemp,

--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -79,7 +79,7 @@ describe('Amazon-Ads (actions)', () => {
         audienceSettings: audienceSettings2
       }
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        "The root value is missing the required field 'advertiserId'. The root value must match \"then\" schema."
+        "Advertiser Id value is required when syncing an audience to DSP"
       )
     })
 
@@ -109,11 +109,11 @@ describe('Amazon-Ads (actions)', () => {
           amcInstanceId: undefined,
           amcAccountId: undefined,
           amcAccountMarketplaceId: undefined,
-          sync_to: 'amc'
+          syncTo: 'amc'
         }
       }
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        "The root value is missing the required field 'amcInstanceId'. The root value must match \"then\" schema. The root value is missing the required field 'amcAccountId'. The root value must match \"then\" schema. The root value is missing the required field 'amcAccountMarketplaceId'. The root value must match \"then\" schema."
+        "AMC Instance Id, AMC Account Id and AMC Account Marketplace Id value are required when syncing audience to AMC"
       )
     })
 

--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
+import { HTTPError, createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
-import { HTTPError } from '@segment/actions-core/*'
 import { AUTHORIZATION_URL, TTL_MAX_VALUE } from '../constants'
 
 const testDestination = createTestIntegration(Definition)

--- a/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/__tests__/index.test.ts
@@ -67,33 +67,36 @@ describe('Amazon-Ads (actions)', () => {
       )
     })
 
-    it('should fail if advertiserId is missing in audienceSettings', async () => {
-      const createAudienceInput = {
-        ...createAudienceInputTemp,
-        audienceSettings: {
-          ...audienceSettings,
-          advertiserId: ''
-        }
-      }
-      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        'Missing advertiserId Value'
-      )
-    })
-    it('should fail if advertiserId  and amcInstanceId && amcAccountId && amcAccountMarketplaceId are missing in audienceSettings', async () => {
+    it("should fail if advertiserId is missing in audienceSettings and sync_to = 'DSP'", async () => {
       const createAudienceInput = {
         ...createAudienceInputTemp,
         audienceSettings: {
           ...audienceSettings,
           advertiserId: '',
-          amcInstanceId: '',
-          amcAccountId: '',
-          amcAccountMarketplaceId: ''
+          sync_to: 'dsp'
         }
       }
       await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
-        'Missing advertiserId, amcInstanceId , amcAccountId , amcAccountMarketplaceId Value'
+        'Missing advertiserId Value when syncing audience to DSP'
       )
     })
+
+    it("should fail if amcInstanceId && amcAccountId && amcAccountMarketplaceId are missing in audienceSettings and sync_to = 'AMC'", async () => {
+      const createAudienceInput = {
+        ...createAudienceInputTemp,
+        audienceSettings: {
+          ...audienceSettings,
+          amcInstanceId: '',
+          amcAccountId: '',
+          amcAccountMarketplaceId: '',
+          sync_to: 'amc'
+        }
+      }
+      await expect(testDestination.createAudience(createAudienceInput)).rejects.toThrowError(
+        'Missing required fields amcInstanceId, amcAccountId, and amcAccountMarketplaceId Value when syncing audience to AMC'
+      )
+    })
+
     it('should fail if externalAudienceId is missing in audienceSettings', async () => {
       const createAudienceInput = {
         ...createAudienceInputTemp,

--- a/packages/destination-actions/src/destinations/amazon-amc/constants.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/constants.ts
@@ -1,0 +1,31 @@
+export const SYNC_TO = {
+  DSP: 'dsp',
+  AMC: 'amc'
+}
+
+export const AUTHORIZATION_URL: Record<string, string> = {
+  'https://advertising-api.amazon.com': 'https://api.amazon.com',
+  'https://advertising-api-eu.amazon.com': 'https://api.amazon.co.uk',
+  'https://advertising-api-fe.amazon.com': 'https://api.amazon.co.jp'
+}
+
+export const CONSTANTS = {
+  CREATE: 'CREATE',
+  DELETE: 'DELETE'
+}
+
+export const CURRENCY = ['USD', 'CAD', 'JPY', 'GBP', 'EUR', 'SAR', 'AUD', 'AED', 'CNY', 'MXN', 'INR', 'SEK', 'TRY']
+
+export const REGEX_AUDIENCEID = /"audienceId":(\d+)/
+
+export const REGEX_ADVERTISERID = /"advertiserId":"(\d+)"/
+
+export const REGEX_EXTERNALUSERID = /^[0-9a-zA-Z-_]{1,128}$/
+
+export const TTL_MAX_VALUE = 34300800
+
+export const ALPHA_NUMERIC = /[^a-z0-9]/g
+
+export const EMAIL_ALLOWED = /[^a-z0-9.@-]/g
+
+export const NON_DIGIT = /[^\d]/g

--- a/packages/destination-actions/src/destinations/amazon-amc/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/generated-types.ts
@@ -12,7 +12,7 @@ export interface AudienceSettings {
   /**
    * Chose whether to sync audience to DSP or AMC. Defaults to DSP.
    */
-  sync_to?: string
+  syncTo?: string
   /**
    * The audience description. Must be an alphanumeric, non-null string between 0 to 1000 characters in length.
    */
@@ -38,19 +38,19 @@ export interface AudienceSettings {
    */
   ttl?: number
   /**
-   * Use for Amazon Ads DSP integration
+   * Advertiser ID when when syncing an Audience to Amazon Ads DSP
    */
   advertiserId?: string
   /**
-   * Use for  Amazon Marketing Cloud (AMC) integration
+   * AMC Instance ID used when syncing an audience to Amazon Marketing Cloud (AMC)
    */
   amcInstanceId?: string
   /**
-   * Use for  Amazon Marketing Cloud (AMC) integration
+   * AMC Account ID used when syncing an audience to Amazon Marketing Cloud (AMC)
    */
   amcAccountId?: string
   /**
-   * Use for  Amazon Marketing Cloud (AMC) integration
+   * AMC Account Marketplace ID used when syncing an audience to Amazon Marketing Cloud (AMC)
    */
   amcAccountMarketplaceId?: string
 }

--- a/packages/destination-actions/src/destinations/amazon-amc/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/generated-types.ts
@@ -10,6 +10,10 @@ export interface Settings {
 
 export interface AudienceSettings {
   /**
+   * Chose whether to sync audience to DSP or AMC. Defaults to DSP.
+   */
+  sync_to?: string
+  /**
    * The audience description. Must be an alphanumeric, non-null string between 0 to 1000 characters in length.
    */
   description: string
@@ -34,7 +38,19 @@ export interface AudienceSettings {
    */
   ttl?: number
   /**
-   * Advertiser Id
+   * Use for Amazon Ads DSP integration
    */
-  advertiserId: string
+  advertiserId?: string
+  /**
+   * Use for  Amazon Marketing Cloud (AMC) integration
+   */
+  amcInstanceId?: string
+  /**
+   * Use for  Amazon Marketing Cloud (AMC) integration
+   */
+  amcAccountId?: string
+  /**
+   * Use for  Amazon Marketing Cloud (AMC) integration
+   */
+  amcAccountMarketplaceId?: string
 }

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -131,102 +131,22 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     advertiserId: {
       label: 'Advertiser ID',
       description: 'Advertiser ID when when syncing an Audience to Amazon Ads DSP',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is_not',
-            value: SYNC_TO.AMC
-          }
-        ]
-      },
-      depends_on: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is_not',
-            value: SYNC_TO.AMC
-          }
-        ]
-      }
+      type: 'string'
     },
     amcInstanceId: {
       label: 'AMC Instance ID',
       description: 'AMC Instance ID used when syncing an audience to Amazon Marketing Cloud (AMC)',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      },
-      depends_on: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      }
+      type: 'string'
     },
     amcAccountId: {
       label: 'AMC Account ID',
       description: 'AMC Account ID used when syncing an audience to Amazon Marketing Cloud (AMC)',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      },
-      depends_on: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      }
+      type: 'string'
     },
     amcAccountMarketplaceId: {
       label: 'AMC Account Marketplace ID',
       description: 'AMC Account Marketplace ID used when syncing an audience to Amazon Marketing Cloud (AMC)',
-      type: 'string',
-      required: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      },
-      depends_on: {
-        match: 'all',
-        conditions: [
-          {
-            fieldKey: 'sync_to',
-            operator: 'is',
-            value: SYNC_TO.AMC
-          }
-        ]
-      }
+      type: 'string'
     }
   },
 
@@ -253,8 +173,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         amcAccountMarketplaceId
       } = audienceSettings || {}
 
-
-      if (syncTo === SYNC_TO.DSP && !advertiserId) {
+      if ((syncTo === SYNC_TO.DSP) && !advertiserId) {
         throw new PayloadValidationError('Advertiser Id value is required when syncing an audience to DSP')
       }
 

--- a/packages/destination-actions/src/destinations/amazon-amc/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/index.ts
@@ -226,9 +226,17 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
       const amcAccountMarketplaceId = audienceSettings?.amcAccountMarketplaceId
       const syncTo = audienceSettings?.sync_to || 'dsp'
 
-      if (!advertiser_id && !(amcInstanceId && amcAccountId && amcAccountMarketplaceId)) {
+      if (syncTo === 'dsp' && !advertiser_id) {
         throw new IntegrationError(
-          'One of Advertiser ID or a combination of AMC Instance ID, AMC Account ID, and AMC Account Marketplace ID must be provided',
+          'Missing advertiserId Value when syncing audience to DSP',
+          'MISSING_REQUIRED_FIELD',
+          400
+        )
+      }
+
+      if (syncTo === 'amc' && !amcInstanceId && !amcAccountId && !amcAccountMarketplaceId) {
+        throw new IntegrationError(
+          'Missing required fields amcInstanceId, amcAccountId, and amcAccountMarketplaceId Value when syncing audience to AMC',
           'MISSING_REQUIRED_FIELD',
           400
         )

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/__tests__/functions.test.ts
@@ -1,0 +1,41 @@
+import { createPayloadToUploadRecords } from '../../function'
+import { AudienceSettings } from '../../generated-types'
+import { Payload } from '../../syncAudiencesToDSP/generated-types'
+
+describe('AmazonAds.syncAudiencesToDSP functions', () => {
+    it('createPayloadToUploadRecords should reject when audienceSettings are incorrect (DSP)', async () => {
+        const payloads = [
+            {
+                audienceId: 'blah',
+            }
+        ]
+
+        const audienceSettings1 = {
+            syncTo: 'dsp',
+            advertiserId: undefined
+        }
+
+        expect(() =>
+        createPayloadToUploadRecords(payloads as Payload[], audienceSettings1 as AudienceSettings)
+        ).toThrow("Advertiser Id value is required when syncing an audience to DSP")
+    })
+
+    it('createPayloadToUploadRecords should reject when audienceSettings are incorrect (AMC)', async () => {
+        const payloads = [
+            {
+                audienceId: 'blah',
+            }
+        ]
+
+        const audienceSettings1 = {
+            syncTo: 'amc',
+            amcInstanceId: undefined,
+            amcAccountId: undefined,
+            amcAccountMarketplaceId: undefined
+        }
+
+        expect(() =>
+        createPayloadToUploadRecords(payloads as Payload[], audienceSettings1 as AudienceSettings)
+        ).toThrow("AMC Instance Id, AMC Account Id and AMC Account Marketplace Id value are required when syncing audience to AMC")
+    })
+})

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import { processBatchPayload, processPayload } from '../function'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Sync Audiences to DSP',
+  title: 'Sync Audiences to DSP and AMC',
   description: 'Sync audiences from Segment to Amazon Ads Audience.',
   defaultSubscription: 'event = "Audience Entered" or event = "Audience Exited"',
   fields: {

--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/index.ts
@@ -1,5 +1,5 @@
 import { ActionDefinition } from '@segment/actions-core'
-import type { Settings } from '../generated-types'
+import type { Settings, AudienceSettings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { processBatchPayload, processPayload } from '../function'
 
@@ -124,10 +124,10 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { settings, payload, audienceSettings }) => {
-    return processPayload(request, settings, [payload], audienceSettings)
+    return processPayload(request, settings, [payload], audienceSettings as AudienceSettings)
   },
   performBatch: async (request, { settings, payload: payloads, audienceSettings }) => {
-    return await processBatchPayload(request, settings, payloads, audienceSettings)
+    return await processBatchPayload(request, settings, payloads, audienceSettings as AudienceSettings)
   }
 }
 

--- a/packages/destination-actions/src/destinations/amazon-amc/types.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/types.ts
@@ -1,5 +1,5 @@
 import { HTTPError } from '@segment/actions-core'
-
+import { Settings } from './generated-types'
 export interface RefreshTokenResponse {
   access_token: string
   scope: string
@@ -50,3 +50,46 @@ export interface AudienceRecordPayload {
   targetResource: TargetResourceRecords
   audienceId: number
 }
+
+export class AmazonAdsError extends HTTPError {
+  response: Response & {
+    data: {
+      status: string
+      message: string
+    }
+  }
+}
+
+export interface AudiencePayload {
+  name: string
+  description: string
+  countryCode: string
+  targetResource: AMCTargetResource | DSPTargetResource
+  metadata: {
+    externalAudienceId: string
+    ttl?: number
+    audienceFees?: {
+      cpmCents: number
+      currency: string
+    }[]
+  }
+}
+
+export interface AMCTargetResource {
+  amcInstanceId: String
+  amcAccountId: string
+  amcAccountMarketplaceId: string
+  connectionId: string
+}
+
+export interface DSPTargetResource {
+  advertiserId: string
+}
+
+export interface RecordsResponseType {
+  jobRequestId: string
+}
+
+export type AmazonAMCCredentials = { refresh_token: string; access_token: string; client_id: string; client_secret: string }
+
+export type SettingsWithOauth = Settings & { oauth: AmazonAMCCredentials }

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -22,7 +22,11 @@ export interface AudiencePayload {
   description: string
   countryCode: string
   targetResource: {
-    advertiserId: string
+    advertiserId?: string
+    amcInstanceId?: String
+    amcAccountId?: string
+    amcAccountMarketplaceId?: string
+    connectionId?: string
   }
   metadata: {
     externalAudienceId: string
@@ -50,6 +54,7 @@ export const CURRENCY = ['USD', 'CAD', 'JPY', 'GBP', 'EUR', 'SAR', 'AUD', 'AED',
 
 export const REGEX_AUDIENCEID = /"audienceId":(\d+)/
 export const REGEX_ADVERTISERID = /"advertiserId":"(\d+)"/
+export const REGEX_CONNECTIONID = /"connectionId":"(\d+)"/
 type AmazonAMCCredentials = { refresh_token: string; access_token: string; client_id: string; client_secret: string }
 
 export function extractNumberAndSubstituteWithStringValue(responseString: string, regex: any, substituteWith: string) {

--- a/packages/destination-actions/src/destinations/amazon-amc/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/utils.ts
@@ -1,71 +1,17 @@
-import {
-  ErrorCodes,
-  HTTPError,
-  OAuth2ClientCredentials,
-  InvalidAuthenticationError,
-  RequestClient
-} from '@segment/actions-core'
+import { ErrorCodes, OAuth2ClientCredentials, InvalidAuthenticationError, RequestClient } from '@segment/actions-core'
 import { Settings } from './generated-types'
-import { AmazonRefreshTokenError, RefreshTokenResponse } from './types'
+import { SettingsWithOauth, AmazonRefreshTokenError, RefreshTokenResponse } from './types'
+import { AUTHORIZATION_URL } from './constants'  
 
-export class AmazonAdsError extends HTTPError {
-  response: Response & {
-    data: {
-      status: string
-      message: string
-    }
-  }
-}
-
-export interface AudiencePayload {
-  name: string
-  description: string
-  countryCode: string
-  targetResource: {
-    advertiserId?: string
-    amcInstanceId?: String
-    amcAccountId?: string
-    amcAccountMarketplaceId?: string
-    connectionId?: string
-  }
-  metadata: {
-    externalAudienceId: string
-    ttl?: number
-    audienceFees?: {
-      cpmCents: number
-      currency: string
-    }[]
-  }
-}
-export interface RecordsResponseType {
-  jobRequestId: string
-}
-
-export const AUTHORIZATION_URL: any = {
-  'https://advertising-api.amazon.com': 'https://api.amazon.com',
-  'https://advertising-api-eu.amazon.com': 'https://api.amazon.co.uk',
-  'https://advertising-api-fe.amazon.com': 'https://api.amazon.co.jp'
-}
-export const CONSTANTS = {
-  CREATE: 'CREATE',
-  DELETE: 'DELETE'
-}
-export const CURRENCY = ['USD', 'CAD', 'JPY', 'GBP', 'EUR', 'SAR', 'AUD', 'AED', 'CNY', 'MXN', 'INR', 'SEK', 'TRY']
-
-export const REGEX_AUDIENCEID = /"audienceId":(\d+)/
-export const REGEX_ADVERTISERID = /"advertiserId":"(\d+)"/
-export const REGEX_CONNECTIONID = /"connectionId":"(\d+)"/
-type AmazonAMCCredentials = { refresh_token: string; access_token: string; client_id: string; client_secret: string }
-
-export function extractNumberAndSubstituteWithStringValue(responseString: string, regex: any, substituteWith: string) {
+export function extractNumberAndSubstituteWithStringValue(responseString: string, regex: RegExp, substituteWith: string) {
   const resString = responseString.replace(regex, substituteWith)
   return JSON.parse(resString)
 }
-type SettingsWithOauth = Settings & { oauth: AmazonAMCCredentials }
+
 // Use the refresh token to get a new access token.
 // Refresh tokens, Client_id and secret are long-lived and belong to the DMP.
 // Given the short expiration time of access tokens, we need to refresh them periodically.
-export const getAuthToken = async (request: RequestClient, settings: Settings, auth: OAuth2ClientCredentials) => {
+export const getAuthToken = async (request: RequestClient, settings: Settings, auth: OAuth2ClientCredentials): Promise<string> => {
   const endpoint = AUTHORIZATION_URL[`${settings.region}`]
   try {
     const { data } = await request<RefreshTokenResponse>(`${endpoint}/auth/o2/token`, {
@@ -83,7 +29,7 @@ export const getAuthToken = async (request: RequestClient, settings: Settings, a
       timeout: 15000
     })
     return data.access_token
-  } catch (e: any) {
+  } catch (e: unknown) {
     const error = e as AmazonRefreshTokenError
     if (error.response?.data?.error === 'invalid_grant') {
       throw new InvalidAuthenticationError(
@@ -100,12 +46,20 @@ export const getAuthToken = async (request: RequestClient, settings: Settings, a
 }
 
 export const getAuthSettings = (settings: SettingsWithOauth): OAuth2ClientCredentials => {
-  return {
-    refreshToken: settings.oauth?.refresh_token,
-    accessToken: settings.oauth?.access_token,
-    clientId: process.env.ACTIONS_AMAZON_AMC_CLIENT_ID,
-    clientSecret: process.env.ACTIONS_AMAZON_AMC_CLIENT_SECRET
-  } as OAuth2ClientCredentials
+  
+  const { 
+    refresh_token: refreshToken, 
+    access_token: accessToken, 
+    client_id: clientId, 
+    client_secret: clientSecret 
+  } = settings.oauth || {}
+
+  const oauth2ClientCredentials: OAuth2ClientCredentials = {
+    refreshToken,
+    accessToken,
+    clientId,
+    clientSecret
+  }
+
+  return oauth2ClientCredentials
 }
-export const REGEX_EXTERNALUSERID = /^[0-9a-zA-Z-_]{1,128}$/
-export const TTL_MAX_VALUE = 34300800


### PR DESCRIPTION
This pull request publishes changes to Amazon AMC/DSP destination to start supporting audience upload to the AMC platform. Currently the destination only supports DSP.

This PR introduces 4 new fields in the audience config:
- Sync to (DSP/AMC)
- amcInstanceId
- amcAccountId
- amcAccountMarketplaceId

This is required to create audiences in AMC . The sync_to field will enable the user to decide whether the audience should be uploaded to DSP (as it's working today) or AMC.
Current users should not be affected if they don't have sync_to value populated, as we're applying condition to only sync to DSP if sync_to is not AMC

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`
