### PR TITLE
[MAIN] [STRATCONN-6427] Removed hidden key from enable batching

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/common-fields.ts
@@ -173,7 +173,8 @@ export const commonFields: Record<string, InputField> = {
   },
   list_details: {
     label: 'List Details (BETA)',
-    description: 'Details of the list to add or remove the record from. This feature is currently in Beta and should not be used with production data.',
+    description:
+      'Details of the list to add or remove the record from. This feature is currently in Beta and should not be used with production data.',
     type: 'object',
     required: false,
     defaultObjectUI: 'keyvalue:only',
@@ -220,8 +221,7 @@ export const commonFields: Record<string, InputField> = {
     type: 'boolean',
     label: 'Batch Data to Hubspot by default',
     description: 'By default Segment batches events to Hubspot.',
-    default: true,
-    unsafe_hidden: true
+    default: true
   },
   batch_size: {
     label: 'Batch Size',


### PR DESCRIPTION
In this ticket, the unsafe_hidden parameter was removed from enable batching in HubSpot, allowing users to enable or disable it based on their use case.

JIRA TICKET: https://twilio-engineering.atlassian.net/browse/STRATCONN-6427

_A summary of your pull request, including the what change you're making and why._ 

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`
