### PR TITLE
feat: add the missing presets to pipedrive destination defined in actions prop

### DIFF
--- a/packages/destination-actions/src/destinations/pipedrive/index.ts
+++ b/packages/destination-actions/src/destinations/pipedrive/index.ts
@@ -100,6 +100,27 @@ const destination: DestinationDefinition<Settings> = {
       partnerAction: 'createUpdateActivity',
       mapping: defaultValues(createUpdateActivity.fields),
       type: 'automatic'
+    },
+    {
+      name: 'Create or Update a Deal',
+      subscribe: 'type = "identify"',
+      partnerAction: 'createUpdateDeal',
+      mapping: defaultValues(createUpdateDeal.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Create or Update a Note',
+      subscribe: 'type = "track" and event = "Note Upserted"',
+      partnerAction: 'createUpdateNote',
+      mapping: defaultValues(createUpdateNote.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Create or Update a Lead',
+      subscribe: 'type = "track" and event = "Lead Upserted"',
+      partnerAction: 'createUpdateLead',
+      mapping: defaultValues(createUpdateLead.fields),
+      type: 'automatic'
     }
   ]
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR intends to add the missing presets to the Pipedrive destination that are already available in the `actions` property

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
