### PR TITLE
[Async Batch Pipeline] Add support for onPoll method

### DIFF
--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -671,9 +671,6 @@ export class Action<
 
     // Construct the request client and perform the poll operation
     const requestClient = this.createRequestClient(dataBundle)
-    if (!this.definition.pollStatus) {
-      throw new IntegrationError('Poll method is not defined.', 'NotImplemented', 501)
-    }
     const pollResponse = await this.definition.pollStatus(requestClient, dataBundle)
 
     return pollResponse
@@ -813,17 +810,19 @@ export class Action<
      * Try to use the parsed response `.data` or `.content` string
      * @see {@link ../middleware/after-response/prepare-response.ts}
      */
-
-    // Handle async action responses by returning them as it is
-    if (response && typeof response === 'object' && (response as any).isAsync === true) {
-      return response
-    }
+    console.log('[parseResponse] response type:', typeof response)
+    console.log('[parseResponse] response instanceof Response:', response instanceof Response)
+    console.log('[parseResponse] response value:', JSON.stringify(response))
+    console.log('[parseResponse] response.data:', (response as ModifiedResponse).data)
 
     if (response instanceof Response) {
-      return (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
+      const result = (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
+      console.log('[parseResponse] extracted from Response — .data/.content:', JSON.stringify(result))
+      return result
     }
 
     // otherwise, we don't really know what this is, so return as-is
+    console.log('[parseResponse] returning as-is (not a Response instance)')
     return response
   }
 

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -17,7 +17,8 @@ import type {
   ActionDestinationSuccessResponseType,
   ActionDestinationErrorResponseType,
   ResultMultiStatusNode,
-  AudienceMembership
+  AudienceMembership,
+  AsyncPollResponseType
 } from './types'
 import { syncModeTypes } from './types'
 import { HTTPError, NormalizedOptions } from '../request-client'
@@ -41,7 +42,14 @@ type MaybePromise<T> = T | Promise<T>
 type RequestClient = ReturnType<typeof createRequestClient>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RequestFn<Settings, Payload, Return = any, AudienceSettings = any, ActionHookInputs = any, AudienceMembershipType = AudienceMembership | AudienceMembership[]> = (
+export type RequestFn<
+  Settings,
+  Payload,
+  Return = any,
+  AudienceSettings = any,
+  ActionHookInputs = any,
+  AudienceMembershipType = AudienceMembership | AudienceMembership[]
+> = (
   request: RequestClient,
   data: ExecuteInput<Settings, Payload, AudienceSettings, ActionHookInputs, any, AudienceMembershipType>
 ) => MaybePromise<Return>
@@ -84,6 +92,13 @@ export interface BaseActionDefinition {
    * The fields used to perform the action. These fields should match what the partner API expects.
    */
   fields: ActionFields
+
+  /**
+   * The fields used specifically for polling async operations. These are typically minimal fields
+   * containing only identifiers needed to check operation status (e.g., operationId).
+   * REQUIRED when defining a poll method - ensures security and performance by validating only essential polling data.
+   */
+  pollFields?: ActionFields
 }
 
 type HookValueTypes = string | boolean | number | Array<string | boolean | number>
@@ -105,7 +120,9 @@ export interface ActionDefinition<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   GeneratedActionHookInputs = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  GeneratedActionHookOutputs = any
+  GeneratedActionHookOutputs = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PollPayload = any
 > extends BaseActionDefinition {
   /**
    * A way to "register" dynamic fields.
@@ -140,6 +157,9 @@ export interface ActionDefinition<
 
   /** The operation to perform when this action is triggered for a batch of events */
   performBatch?: RequestFn<Settings, Payload[], PerformBatchResponse, AudienceSettings, any, AudienceMembership[]>
+
+  /** The operation to poll the status of asynchronous actions */
+  pollStatus?: RequestFn<Settings, PollPayload, AsyncPollResponseType, AudienceSettings>
 
   /** Hooks are triggered at some point in a mappings lifecycle. They may perform a request with the
    * destination using the provided inputs and return a response. The response may then optionally be stored
@@ -255,20 +275,27 @@ const isSyncMode = (value: unknown): value is SyncMode => {
  * Action is the beginning step for all partner actions. Entrypoints always start with the
  * MapAndValidateInput step.
  */
-export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings = any> extends EventEmitter {
-  readonly definition: ActionDefinition<Settings, Payload, AudienceSettings>
+export class Action<
+  Settings,
+  Payload extends JSONLikeObject,
+  AudienceSettings = any,
+  PollPayload = unknown
+> extends EventEmitter {
+  readonly definition: ActionDefinition<Settings, Payload, AudienceSettings, unknown, unknown, PollPayload>
   readonly destinationName: string
   readonly schema?: JSONSchema4
+  readonly pollSchema?: JSONSchema4
   readonly hookSchemas?: Record<string, JSONSchema4>
   readonly hasBatchSupport: boolean
   readonly hasHookSupport: boolean
+  readonly hasPollSupport: boolean
   // Payloads may be any type so we use `any` explicitly here.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private extendRequest: RequestExtension<Settings, any> | undefined
 
   constructor(
     destinationName: string,
-    definition: ActionDefinition<Settings, Payload, AudienceSettings>,
+    definition: ActionDefinition<Settings, Payload, AudienceSettings, unknown, unknown, PollPayload>,
     // Payloads may be any type so we use `any` explicitly here.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extendRequest?: RequestExtension<Settings, any>
@@ -279,10 +306,17 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     this.extendRequest = extendRequest
     this.hasBatchSupport = typeof definition.performBatch === 'function'
     this.hasHookSupport = definition.hooks !== undefined
+    this.hasPollSupport = typeof definition.pollStatus === 'function'
     // Generate json schema based on the field definitions
     if (Object.keys(definition.fields ?? {}).length) {
       this.schema = fieldsToJsonSchema(definition.fields)
     }
+
+    // Generate json schema for poll fields if they are defined
+    if (Object.keys(definition.pollFields ?? {}).length) {
+      this.pollSchema = fieldsToJsonSchema(definition.pollFields)
+    }
+
     // Generate a json schema for each defined hook based on the field definitions
     if (definition.hooks) {
       for (const hookName in definition.hooks) {
@@ -362,7 +396,7 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
       rawMapping: bundle.mapping,
       settings: bundle.settings,
       payload,
-      ...( typeof audienceMembership === 'boolean' ? { audienceMembership } : {}),
+      ...(typeof audienceMembership === 'boolean' ? { audienceMembership } : {}),
       auth: bundle.auth,
       features: bundle.features,
       statsContext: bundle.statsContext,
@@ -593,6 +627,58 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     return multiStatusResponse
   }
 
+  async executePoll(
+    bundle: ExecuteBundle<Settings, InputData | undefined, AudienceSettings>
+  ): Promise<AsyncPollResponseType> {
+    if (!this.hasPollSupport || !this.definition.pollStatus) {
+      throw new IntegrationError('This action does not support polling.', 'NotImplemented', 501)
+    }
+
+    const payload = bundle.data as PollPayload
+    // Remove empty values and validate using poll schema (required for polling operations)
+    if (!this.pollSchema) {
+      throw new IntegrationError('Poll fields must be defined for polling operations.', 'NotImplemented', 501)
+    }
+    const validationSchema = this.pollSchema
+    // Cast to PollPayload as the removeEmptyValues pipeline produces a valid poll payload
+    // This represents the PollPayload type defined in the ActionDefinition (e.g., { operationId: string })
+    const pollPayload = removeEmptyValues(payload, validationSchema, true) as PollPayload
+    // Validate the resolved payload against the poll schema
+    const schemaKey = `${this.destinationName}:${this.definition.title}:poll`
+    validateSchema(pollPayload, validationSchema, {
+      schemaKey,
+      statsContext: bundle.statsContext,
+      exempt: ['dynamicAuthSettings']
+    })
+
+    // Construct the data bundle to send to the poll action
+    const dataBundle = {
+      rawData: bundle.data,
+      rawMapping: bundle.mapping,
+      settings: bundle.settings,
+      payload: pollPayload,
+      auth: bundle.auth,
+      features: bundle.features,
+      statsContext: bundle.statsContext,
+      logger: bundle.logger,
+      engageDestinationCache: bundle.engageDestinationCache,
+      transactionContext: bundle.transactionContext,
+      stateContext: bundle.stateContext,
+      audienceSettings: bundle.audienceSettings,
+      subscriptionMetadata: bundle.subscriptionMetadata,
+      signal: bundle?.signal
+    }
+
+    // Construct the request client and perform the poll operation
+    const requestClient = this.createRequestClient(dataBundle)
+    if (!this.definition.pollStatus) {
+      throw new IntegrationError('Poll method is not defined.', 'NotImplemented', 501)
+    }
+    const pollResponse = await this.definition.pollStatus(requestClient, dataBundle)
+
+    return pollResponse
+  }
+
   /*
    * Extract the dynamic field context and handler path from a field string. Examples:
    * - "structured.first_name" => { dynamicHandlerPath: "structured.first_name" }
@@ -727,6 +813,12 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
      * Try to use the parsed response `.data` or `.content` string
      * @see {@link ../middleware/after-response/prepare-response.ts}
      */
+
+    // Handle async action responses by returning them as it is
+    if (response && typeof response === 'object' && (response as any).isAsync === true) {
+      return response
+    }
+
     if (response instanceof Response) {
       return (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
     }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -17,7 +17,8 @@ import type {
   ActionDestinationSuccessResponseType,
   ActionDestinationErrorResponseType,
   ResultMultiStatusNode,
-  AudienceMembership
+  AudienceMembership,
+  AsyncPollResponseType
 } from './types'
 import { syncModeTypes } from './types'
 import { HTTPError, NormalizedOptions } from '../request-client'
@@ -92,6 +93,13 @@ export interface BaseActionDefinition {
    * The fields used to perform the action. These fields should match what the partner API expects.
    */
   fields: ActionFields
+
+  /**
+   * The fields used specifically for polling async operations. These are typically minimal fields
+   * containing only identifiers needed to check operation status (e.g., operationId).
+   * REQUIRED when defining a poll method - ensures security and performance by validating only essential polling data.
+   */
+  pollFields?: ActionFields
 }
 
 type HookValueTypes = string | boolean | number | Array<string | boolean | number>
@@ -113,7 +121,9 @@ export interface ActionDefinition<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   GeneratedActionHookInputs = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  GeneratedActionHookOutputs = any
+  GeneratedActionHookOutputs = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PollPayload = any
 > extends BaseActionDefinition {
   /**
    * A way to "register" dynamic fields.
@@ -148,6 +158,9 @@ export interface ActionDefinition<
 
   /** The operation to perform when this action is triggered for a batch of events */
   performBatch?: RequestFn<Settings, Payload[], PerformBatchResponse, AudienceSettings, any, AudienceMembership[]>
+
+  /** The operation to poll the status of asynchronous actions */
+  pollStatus?: RequestFn<Settings, PollPayload, AsyncPollResponseType, AudienceSettings>
 
   /** Hooks are triggered at some point in a mappings lifecycle. They may perform a request with the
    * destination using the provided inputs and return a response. The response may then optionally be stored
@@ -264,20 +277,27 @@ const isSyncMode = (value: unknown): value is SyncMode => {
  * Action is the beginning step for all partner actions. Entrypoints always start with the
  * MapAndValidateInput step.
  */
-export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings = any> extends EventEmitter {
-  readonly definition: ActionDefinition<Settings, Payload, AudienceSettings>
+export class Action<
+  Settings,
+  Payload extends JSONLikeObject,
+  AudienceSettings = any,
+  PollPayload = unknown
+> extends EventEmitter {
+  readonly definition: ActionDefinition<Settings, Payload, AudienceSettings, unknown, unknown, PollPayload>
   readonly destinationName: string
   readonly schema?: JSONSchema4
+  readonly pollSchema?: JSONSchema4
   readonly hookSchemas?: Record<string, JSONSchema4>
   readonly hasBatchSupport: boolean
   readonly hasHookSupport: boolean
+  readonly hasPollSupport: boolean
   // Payloads may be any type so we use `any` explicitly here.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private extendRequest: RequestExtension<Settings, any> | undefined
 
   constructor(
     destinationName: string,
-    definition: ActionDefinition<Settings, Payload, AudienceSettings>,
+    definition: ActionDefinition<Settings, Payload, AudienceSettings, unknown, unknown, PollPayload>,
     // Payloads may be any type so we use `any` explicitly here.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extendRequest?: RequestExtension<Settings, any>
@@ -288,10 +308,17 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     this.extendRequest = extendRequest
     this.hasBatchSupport = typeof definition.performBatch === 'function'
     this.hasHookSupport = definition.hooks !== undefined
+    this.hasPollSupport = typeof definition.pollStatus === 'function'
     // Generate json schema based on the field definitions
     if (Object.keys(definition.fields ?? {}).length) {
       this.schema = fieldsToJsonSchema(definition.fields)
     }
+
+    // Generate json schema for poll fields if they are defined
+    if (Object.keys(definition.pollFields ?? {}).length) {
+      this.pollSchema = fieldsToJsonSchema(definition.pollFields)
+    }
+
     // Generate a json schema for each defined hook based on the field definitions
     if (definition.hooks) {
       for (const hookName in definition.hooks) {
@@ -604,6 +631,58 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
     return multiStatusResponse
   }
 
+  async executePoll(
+    bundle: ExecuteBundle<Settings, InputData | undefined, AudienceSettings>
+  ): Promise<AsyncPollResponseType> {
+    if (!this.hasPollSupport || !this.definition.pollStatus) {
+      throw new IntegrationError('This action does not support polling.', 'NotImplemented', 501)
+    }
+
+    const payload = bundle.data as PollPayload
+    // Remove empty values and validate using poll schema (required for polling operations)
+    if (!this.pollSchema) {
+      throw new IntegrationError('Poll fields must be defined for polling operations.', 'NotImplemented', 501)
+    }
+    const validationSchema = this.pollSchema
+    // Cast to PollPayload as the removeEmptyValues pipeline produces a valid poll payload
+    // This represents the PollPayload type defined in the ActionDefinition (e.g., { operationId: string })
+    const pollPayload = removeEmptyValues(payload, validationSchema, true) as PollPayload
+    // Validate the resolved payload against the poll schema
+    const schemaKey = `${this.destinationName}:${this.definition.title}:poll`
+    validateSchema(pollPayload, validationSchema, {
+      schemaKey,
+      statsContext: bundle.statsContext,
+      exempt: ['dynamicAuthSettings']
+    })
+
+    // Construct the data bundle to send to the poll action
+    const dataBundle = {
+      rawData: bundle.data,
+      rawMapping: bundle.mapping,
+      settings: bundle.settings,
+      payload: pollPayload,
+      auth: bundle.auth,
+      features: bundle.features,
+      statsContext: bundle.statsContext,
+      logger: bundle.logger,
+      engageDestinationCache: bundle.engageDestinationCache,
+      transactionContext: bundle.transactionContext,
+      stateContext: bundle.stateContext,
+      audienceSettings: bundle.audienceSettings,
+      subscriptionMetadata: bundle.subscriptionMetadata,
+      signal: bundle?.signal
+    }
+
+    // Construct the request client and perform the poll operation
+    const requestClient = this.createRequestClient(dataBundle)
+    if (!this.definition.pollStatus) {
+      throw new IntegrationError('Poll method is not defined.', 'NotImplemented', 501)
+    }
+    const pollResponse = await this.definition.pollStatus(requestClient, dataBundle)
+
+    return pollResponse
+  }
+
   /*
    * Extract the dynamic field context and handler path from a field string. Examples:
    * - "structured.first_name" => { dynamicHandlerPath: "structured.first_name" }
@@ -738,6 +817,12 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
      * Try to use the parsed response `.data` or `.content` string
      * @see {@link ../middleware/after-response/prepare-response.ts}
      */
+
+    // Handle async action responses by returning them as it is
+    if (response && typeof response === 'object' && (response as any).isAsync === true) {
+      return response
+    }
+
     if (response instanceof Response) {
       return (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
     }

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -675,9 +675,6 @@ export class Action<
 
     // Construct the request client and perform the poll operation
     const requestClient = this.createRequestClient(dataBundle)
-    if (!this.definition.pollStatus) {
-      throw new IntegrationError('Poll method is not defined.', 'NotImplemented', 501)
-    }
     const pollResponse = await this.definition.pollStatus(requestClient, dataBundle)
 
     return pollResponse
@@ -817,17 +814,19 @@ export class Action<
      * Try to use the parsed response `.data` or `.content` string
      * @see {@link ../middleware/after-response/prepare-response.ts}
      */
-
-    // Handle async action responses by returning them as it is
-    if (response && typeof response === 'object' && (response as any).isAsync === true) {
-      return response
-    }
+    console.log('[parseResponse] response type:', typeof response)
+    console.log('[parseResponse] response instanceof Response:', response instanceof Response)
+    console.log('[parseResponse] response value:', JSON.stringify(response))
+    console.log('[parseResponse] response.data:', (response as ModifiedResponse).data)
 
     if (response instanceof Response) {
-      return (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
+      const result = (response as ModifiedResponse).data ?? (response as ModifiedResponse).content
+      console.log('[parseResponse] extracted from Response — .data/.content:', JSON.stringify(result))
+      return result
     }
 
     // otherwise, we don't really know what this is, so return as-is
+    console.log('[parseResponse] returning as-is (not a Response instance)')
     return response
   }
 

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -720,7 +720,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     return action.executeDynamicField(fieldKey, data, dynamicFn)
   }
 
-  public async executePollStatus(
+  public async executePoll(
     actionSlug: string,
     {
       event,

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -28,7 +28,6 @@ import type {
   DeletionPayload,
   DynamicFieldResponse,
   ResultMultiStatusNode,
-  AsyncActionResponseType,
   AsyncPollResponseType
 } from './types'
 import type { AllRequestOptions } from '../request-client'
@@ -47,7 +46,6 @@ export type {
   ExecuteInput,
   RequestFn,
   Result,
-  AsyncActionResponseType,
   AsyncPollResponseType
 }
 export { hookTypeStrings }

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -723,7 +723,7 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     return action.executeDynamicField(fieldKey, data, dynamicFn)
   }
 
-  public async executePollStatus(
+  public async executePoll(
     actionSlug: string,
     {
       event,

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -27,7 +27,9 @@ import type {
   Deletion,
   DeletionPayload,
   DynamicFieldResponse,
-  ResultMultiStatusNode
+  ResultMultiStatusNode,
+  AsyncActionResponseType,
+  AsyncPollResponseType
 } from './types'
 import type { AllRequestOptions } from '../request-client'
 import { ErrorCodes, IntegrationError, InvalidAuthenticationError, MultiStatusErrorReporter } from '../errors'
@@ -44,7 +46,9 @@ export type {
   ActionHookType,
   ExecuteInput,
   RequestFn,
-  Result
+  Result,
+  AsyncActionResponseType,
+  AsyncPollResponseType
 }
 export { hookTypeStrings }
 export type { MinimalInputField }
@@ -717,6 +721,49 @@ export class Destination<Settings = JSONObject, AudienceSettings = JSONObject> {
     }
 
     return action.executeDynamicField(fieldKey, data, dynamicFn)
+  }
+
+  public async executePollStatus(
+    actionSlug: string,
+    {
+      event,
+      mapping,
+      subscriptionMetadata,
+      settings,
+      features,
+      statsContext,
+      logger,
+      engageDestinationCache,
+      transactionContext,
+      stateContext,
+      signal
+    }: EventInput<Settings>
+  ): Promise<AsyncPollResponseType> {
+    const action = this.actions[actionSlug]
+    if (!action) {
+      throw new IntegrationError(`Action ${actionSlug} not found`, 'NotImplemented', 404)
+    }
+
+    let audienceSettings = {} as AudienceSettings
+    if (event.context?.personas) {
+      audienceSettings = event.context?.personas?.audience_settings as AudienceSettings
+    }
+    const authData = getAuthData(settings as JSONObject)
+    return action.executePoll({
+      mapping,
+      data: event as unknown as InputData,
+      settings,
+      audienceSettings,
+      auth: authData,
+      features,
+      statsContext,
+      logger,
+      engageDestinationCache,
+      transactionContext,
+      stateContext,
+      subscriptionMetadata,
+      signal
+    })
   }
 
   private async onSubscription(

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -403,15 +403,6 @@ export type ActionDestinationErrorResponseType = {
   body?: JSONLikeObject | string
 }
 
-export type AsyncActionResponseType = {
-  /** Indicates this is an async operation */
-  isAsync: true
-  /** Optional message about the async operation(s) */
-  message?: string
-  /** Initial status code */
-  status?: number
-}
-
 export type AsyncOperationResult = {
   /** The current status of this operation */
   status: 'pending' | 'completed' | 'failed'

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -403,6 +403,40 @@ export type ActionDestinationErrorResponseType = {
   body?: JSONLikeObject | string
 }
 
+export type AsyncActionResponseType = {
+  /** Indicates this is an async operation */
+  isAsync: true
+  /** Optional message about the async operation(s) */
+  message?: string
+  /** Initial status code */
+  status?: number
+}
+
+export type AsyncOperationResult = {
+  /** The current status of this operation */
+  status: 'pending' | 'completed' | 'failed'
+  /** Message about current state */
+  message?: string
+  /** Final result data when status is 'completed' */
+  result?: JSONLikeObject
+  /** Error information when status is 'failed' */
+  error?: {
+    code: string
+    message: string
+  }
+  /** Original context for this operation */
+  context?: JSONLikeObject
+}
+
+export type AsyncPollResponseType = {
+  /** Array of operation results - single element for individual operations, multiple for batch */
+  results: AsyncOperationResult[]
+  /** Overall status - completed when all operations are done */
+  overallStatus: 'pending' | 'completed' | 'failed' | 'partial'
+  /** Summary message */
+  message?: string
+}
+
 export type ResultMultiStatusNode =
   | ActionDestinationSuccessResponseType
   | (ActionDestinationErrorResponseType & {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -405,6 +405,40 @@ export type ActionDestinationErrorResponseType = {
   body?: JSONLikeObject | string
 }
 
+export type AsyncActionResponseType = {
+  /** Indicates this is an async operation */
+  isAsync: true
+  /** Optional message about the async operation(s) */
+  message?: string
+  /** Initial status code */
+  status?: number
+}
+
+export type AsyncOperationResult = {
+  /** The current status of this operation */
+  status: 'pending' | 'completed' | 'failed'
+  /** Message about current state */
+  message?: string
+  /** Final result data when status is 'completed' */
+  result?: JSONLikeObject
+  /** Error information when status is 'failed' */
+  error?: {
+    code: string
+    message: string
+  }
+  /** Original context for this operation */
+  context?: JSONLikeObject
+}
+
+export type AsyncPollResponseType = {
+  /** Array of operation results - single element for individual operations, multiple for batch */
+  results: AsyncOperationResult[]
+  /** Overall status - completed when all operations are done */
+  overallStatus: 'pending' | 'completed' | 'failed' | 'partial'
+  /** Summary message */
+  message?: string
+}
+
 export type ResultMultiStatusNode =
   | ActionDestinationSuccessResponseType
   | (ActionDestinationErrorResponseType & {

--- a/packages/core/src/destination-kit/types.ts
+++ b/packages/core/src/destination-kit/types.ts
@@ -405,15 +405,6 @@ export type ActionDestinationErrorResponseType = {
   body?: JSONLikeObject | string
 }
 
-export type AsyncActionResponseType = {
-  /** Indicates this is an async operation */
-  isAsync: true
-  /** Optional message about the async operation(s) */
-  message?: string
-  /** Initial status code */
-  status?: number
-}
-
 export type AsyncOperationResult = {
   /** The current status of this operation */
   status: 'pending' | 'completed' | 'failed'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,7 +82,9 @@ export type {
   StatsContext,
   Logger,
   Preset,
-  Result
+  Result,
+  AsyncActionResponseType,
+  AsyncPollResponseType
 } from './destination-kit'
 
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,7 +83,6 @@ export type {
   Logger,
   Preset,
   Result,
-  AsyncActionResponseType,
   AsyncPollResponseType
 } from './destination-kit'
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -1,10 +1,15 @@
-import { ActionDefinition, IntegrationError } from '@segment/actions-core'
+import { ActionDefinition, IntegrationError, JSONLikeObject } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { keys, values_dataExtensionFields, dataExtensionHook } from '../sfmc-properties'
-import { getDataExtensionFields, asyncUpsertRowsV2 } from '../sfmc-operations'
+import { getDataExtensionFields, asyncUpsertRowsV2, pollAsyncOperation } from '../sfmc-operations'
 
-const action: ActionDefinition<Settings, Payload> = {
+// Define the minimal payload type for polling operations
+interface PollPayload {
+  operationId: string
+}
+
+const action: ActionDefinition<Settings, Payload, unknown, unknown, unknown, PollPayload> = {
   title: 'Send Event asynchronously to Data Extension',
   description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.
   
@@ -54,6 +59,14 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
+  pollFields: {
+    operationId: {
+      label: 'Operation ID',
+      description: 'The ID of the asynchronous operation to poll.',
+      type: 'string',
+      required: true
+    }
+  },
   hooks: {
     retlOnMappingSave: {
       ...dataExtensionHook
@@ -81,6 +94,54 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('No Data Extension Connected', 'INVALID_CONFIGURATION', 400)
     }
     return asyncUpsertRowsV2(request, settings.subdomain, payload, dataExtensionId)
+  },
+
+  pollStatus: async (request, { settings, payload }) => {
+    // Get the operation ID from the payload
+    const operationId = payload.operationId
+
+    if (!operationId) {
+      throw new IntegrationError('Operation ID is required for polling.', 'INVALID_REQUEST', 400)
+    }
+
+    // Poll the SFMC async operation status
+    const pollResult = await pollAsyncOperation(request, settings.subdomain, operationId)
+
+    // Map SFMC status to framework status
+    let status: 'pending' | 'completed' | 'failed'
+    switch (pollResult.status) {
+      case 'Complete':
+        status = 'completed'
+        break
+      case 'Failed':
+      case 'Error':
+        status = 'failed'
+        break
+      case 'InProcess':
+      case 'Queued':
+      default:
+        status = 'pending'
+        break
+    }
+
+    const results = pollResult.results || {}
+    const context: JSONLikeObject = {
+      operationId: pollResult.operationId,
+      completedAt: pollResult.completedAt
+    }
+
+    return {
+      results: [
+        {
+          status: status,
+          message: pollResult.errorMessage || `Operation ${operationId} is ${pollResult.status}`,
+          result: results as JSONLikeObject,
+          context: context
+        }
+      ],
+      overallStatus: status,
+      message: pollResult.errorMessage || `Async operation ${status}`
+    }
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -108,20 +108,22 @@ const action: ActionDefinition<Settings, Payload, unknown, unknown, unknown, Pol
     const pollResult = await pollAsyncOperation(request, settings.subdomain, operationId)
 
     // Map SFMC status to framework status
+    // Check both requestStatus (Complete/InProcess/etc) and resultStatus (OK/Error)
     let status: 'pending' | 'completed' | 'failed'
-    switch (pollResult.status) {
-      case 'Complete':
-        status = 'completed'
-        break
-      case 'Failed':
-      case 'Error':
+    const sfmcStatus = pollResult.results as any
+
+    if (pollResult.status === 'Complete') {
+      // Request finished - check if it succeeded or had errors
+      if (sfmcStatus?.hasErrors || sfmcStatus?.resultStatus === 'Error') {
         status = 'failed'
-        break
-      case 'InProcess':
-      case 'Queued':
-      default:
-        status = 'pending'
-        break
+      } else {
+        status = 'completed'
+      }
+    } else if (pollResult.status === 'Failed' || pollResult.status === 'Error') {
+      status = 'failed'
+    } else {
+      // InProcess, Queued, etc.
+      status = 'pending'
     }
 
     const results = pollResult.results || {}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -40,14 +40,6 @@ interface SFMCAsyncStatus {
 }
 
 /**
- * Interface for async upsert response
- */
-interface AsyncUpsertResponse {
-  requestId: string
-  resultMessages: string[]
-}
-
-/**
  * Interface for poll response
  */
 interface PollResponse {
@@ -153,7 +145,7 @@ export async function asyncUpsertRowsV2(
   subdomain: String,
   payloads: payload_dataExtension[] | payload_contactDataExtension[],
   dataExtensionId?: string
-): Promise<MultiStatusResponse> {
+) {
   if (!dataExtensionId) {
     throw new IntegrationError(
       `In order to send an event to a data extension Data Extension ID must be defined.`,
@@ -163,25 +155,14 @@ export async function asyncUpsertRowsV2(
   }
   // Use flattened rows for async API
   const rows = generateFlattenedRows(payloads)
-  const response = await request<AsyncUpsertResponse>(
+  const response = await request(
     `https://${subdomain}.rest.marketingcloudapis.com/data/v1/async/dataextensions/${dataExtensionId}/rows`,
     {
       method: 'PUT',
       json: { items: rows }
     }
   )
-  const multiStatusResponse = new MultiStatusResponse()
-  for (let i = 0; i < payloads.length; i++) {
-    multiStatusResponse.setSuccessResponseAtIndex(i, {
-      status: 202,
-      sent: rows[i] as Object as JSONLikeObject,
-      body: {
-        requestId: response.data.requestId,
-        resultMessages: response.data.resultMessages
-      }
-    })
-  }
-  return multiStatusResponse
+  return response
 }
 
 export function upsertRows(

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -109,7 +109,16 @@ export async function pollAsyncOperation(
       status: data.status.requestStatus,
       operationId: operationId,
       completedAt: data.status.completionDateTime,
-      errorMessage: data.status.hasErrors ? 'Operation completed with errors' : undefined
+      errorMessage: data.status.hasErrors ? 'Operation completed with errors' : undefined,
+      results: {
+        requestStatus: data.status.requestStatus,
+        resultStatus: data.status.resultStatus,
+        hasErrors: data.status.hasErrors,
+        resultMessages: data.resultMessages || [],
+        callDateTime: data.status.callDateTime,
+        pickupDateTime: data.status.pickupDateTime,
+        completionDateTime: data.status.completionDateTime
+      }
     }
   } catch (error) {
     console.log('poll error', error)
@@ -162,6 +171,7 @@ export async function asyncUpsertRowsV2(
       json: { items: rows }
     }
   )
+  console.log('no multistatsus')
   return response
 }
 


### PR DESCRIPTION
This PR adds an onPoll method for Actions with Async Support.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
