### PR TITLE
[Amplitude Cohorts] - setting field format update

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude-cohorts/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/index.ts
@@ -35,7 +35,6 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         label: 'Cohort Owner Email',
         description: 'The email of the user who will own the cohorts in Amplitude. This can be overriden per Audience, but if left blank, all cohorts will be owned by this user.',
         type: 'string',
-        format: 'email',
         required: true
       },
       endpoint: {


### PR DESCRIPTION
Unable to test new amplitude cohorts destination due to setting field not displaying. This is because the field has format:email, which is not supported in the UI. 

## Testing
Not needed. This is a completely new integration

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
