### PR TITLE
Revert "[MAIN] Logger added in yahoo audiences to track taxonomy (#37…

### DIFF
--- a/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/index.ts
@@ -64,7 +64,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
           400
         )
       } else {
-        // The last 3 params are undefined because statsContext.statsClient, statsContext.tags, and logger are not available in testAuthentication()
+        // The last 2 params are undefined because statsContext.statsClient and statsContext.tags are not available testAuthentication()
         return await update_taxonomy('', tx_creds, request, body_form_data, undefined, undefined)
       }
     },

--- a/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/utils-tax.ts
@@ -108,21 +108,10 @@ export async function update_taxonomy(
     engage_space_id.length > 0 ? '/' + engage_space_id : ''
   }`
 
-  console.info(
-    '[update_taxonomy] Starting taxonomy update request',
-    `engage_space_id: ${engage_space_id}`,
-    `url: ${url}`,
-    `tx_client_key: ${tx_client_key ? 'present' : 'missing'}`
-  )
-
   // Get a short-lived Bearer token using the same JWT client-credentials flow as the Online API
   const access_token = await get_taxonomy_access_token(request, tx_client_key, tx_client_secret)
 
-  console.info('[update_taxonomy] Access token obtained successfully')
-
   try {
-    console.info('[update_taxonomy] Sending PUT request to Yahoo Taxonomy API', `url: ${url}`)
-
     const add_segment_node = await request(url, {
       method: 'PUT',
       body: body_form_data,
@@ -131,34 +120,12 @@ export async function update_taxonomy(
         'Content-Type': 'multipart/form-data; boundary=SEGMENT-DATA'
       }
     })
-
-    console.info(
-      '[update_taxonomy] Received response from Yahoo Taxonomy API',
-      `status: ${add_segment_node.status}`,
-      `statusText: ${add_segment_node.statusText}`
-    )
-
     if (statsClient && statsTags) {
       statsClient.incr('update_taxonomy.success', 1, statsTags)
     }
-
-    const responseData = await add_segment_node.json()
-
-    console.info(
-      '[update_taxonomy] Response data from Yahoo Taxonomy API',
-      `responseData: ${JSON.stringify(responseData)}`
-    )
-
-    return responseData
+    return await add_segment_node.json()
   } catch (error) {
     const _error = error as { response: { data: unknown; status: string } }
-
-    console.warn(
-      '[update_taxonomy] Error occurred during taxonomy update',
-      `status: ${_error.response?.status || 'unknown'}`,
-      `responseData: ${JSON.stringify(_error.response?.data || {})}`
-    )
-
     if (statsClient && statsTags) {
       statsClient.incr('update_taxonomy.error', 1, statsTags)
     }


### PR DESCRIPTION
…10)"

This reverts commit 46632cc7b1af27c95fb70c30d7cde51899ab7eba.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
