### PR TITLE
[Amplitude Cohorts] - bug fix for email setting field

### DIFF
--- a/packages/destination-actions/src/destinations/amplitude-cohorts/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/__tests__/index.test.ts
@@ -8,7 +8,7 @@ const settings = {
   api_key: 'test_api_key',
   secret_key: 'test_secret_key',
   app_id: 'test_app_id',
-  owner_email: 'owner@example.com',
+  default_owner_email: 'owner@example.com',
   endpoint: 'north_america'
 }
 
@@ -17,7 +17,7 @@ describe('Amplitude Cohorts', () => {
     it('should validate authentication inputs', async () => {
       nock('https://amplitude.com')
         .get('/api/2/usersearch')
-        .query({ user: settings.owner_email })
+        .query({ user: settings.default_owner_email })
         .reply(200, {})
 
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/amplitude-cohorts/functions.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/functions.ts
@@ -12,7 +12,7 @@ export async function createAudience(request: RequestClient, settings: Settings,
   const { 
     endpoint,
     app_id,
-    owner_email: default_owner_email
+    default_owner_email 
   } = settings
 
   if (!name) {

--- a/packages/destination-actions/src/destinations/amplitude-cohorts/generated-types.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/generated-types.ts
@@ -16,7 +16,7 @@ export interface Settings {
   /**
    * The email of the user who will own the cohorts in Amplitude. This can be overriden per Audience, but if left blank, all cohorts will be owned by this user.
    */
-  owner_email: string
+  default_owner_email: string
   /**
    * The region to send your data.
    */

--- a/packages/destination-actions/src/destinations/amplitude-cohorts/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/index.ts
@@ -31,7 +31,7 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
         type: 'string',
         required: true
       },
-      owner_email: {
+      default_owner_email: {
         label: 'Cohort Owner Email',
         description: 'The email of the user who will own the cohorts in Amplitude. This can be overriden per Audience, but if left blank, all cohorts will be owned by this user.',
         type: 'string',
@@ -59,10 +59,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
     testAuthentication: (request, { settings }) => {
       const { 
         endpoint,
-        owner_email
+        default_owner_email
       } = settings
       const baseUrl = getEndpointByRegion('usersearch', endpoint)
-      return request(`${baseUrl}?user=${owner_email}`)
+      return request(`${baseUrl}?user=${default_owner_email}`)
     }
   },
   extendRequest({ settings }) {


### PR DESCRIPTION
The email field in settings doesn't display in the UI. This is because there is an audience settings with the same name, and the app UI logic isn't able to handle it (this is an app bug which we should fix).

This PR changes the email setting field name. 

This destination is new.  

## Testing

None needed. 

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
