### PR TITLE
STRATCONN-6744 - [Voiceops] - [ENG-5172] add base url as a setting

### DIFF
--- a/packages/destination-actions/src/destinations/voiceops/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/voiceops/__tests__/index.test.ts
@@ -2,11 +2,12 @@ import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 import { Settings } from '../generated-types'
-import { VOICEOPS_BASE_URL } from '../constants'
+import { DEFAULT_VOICEOPS_BASE_URL } from '../constants'
 
 const testDestination = createTestIntegration(Definition)
 const SETTINGS: Settings = {
-  accessToken: 'voiceops-token'
+  accessToken: 'voiceops-token',
+  baseUrl: DEFAULT_VOICEOPS_BASE_URL
 }
 
 describe('Voiceops', () => {
@@ -16,7 +17,7 @@ describe('Voiceops', () => {
     })
 
     it('accepts a valid bearer token', async () => {
-      nock(VOICEOPS_BASE_URL)
+      nock(DEFAULT_VOICEOPS_BASE_URL)
         .get('/frontline-api/integrations/v1/segment/authentication')
         .matchHeader('authorization', 'Bearer voiceops-token')
         .matchHeader('user-agent', 'Segment')
@@ -26,7 +27,7 @@ describe('Voiceops', () => {
     })
 
     it('surfaces invalid bearer tokens as credential failures', async () => {
-      nock(VOICEOPS_BASE_URL)
+      nock(DEFAULT_VOICEOPS_BASE_URL)
         .get('/frontline-api/integrations/v1/segment/authentication')
         .matchHeader('authorization', 'Bearer voiceops-token')
         .reply(401, {

--- a/packages/destination-actions/src/destinations/voiceops/constants.ts
+++ b/packages/destination-actions/src/destinations/voiceops/constants.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_VOICEOPS_BASE_URL = 'https://projectfrontline.net'
 
 export function normalizeVoiceopsBaseUrl(baseUrl?: string): string {
-  return (baseUrl ?? DEFAULT_VOICEOPS_BASE_URL).replace(/\/$/, '')
+  return (baseUrl ?? DEFAULT_VOICEOPS_BASE_URL).trim().replace(/\/+$/, '')
 }
 
 export function getVoiceopsAuthenticationEndpoint(baseUrl?: string): string {

--- a/packages/destination-actions/src/destinations/voiceops/constants.ts
+++ b/packages/destination-actions/src/destinations/voiceops/constants.ts
@@ -1,5 +1,15 @@
-export const VOICEOPS_BASE_URL = process?.env?.ACTIONS_VOICEOPS_BASE_URL_SECRET ?? 'https://projectfrontline.net'
+export const DEFAULT_VOICEOPS_BASE_URL = 'https://projectfrontline.net'
 
-export const VOICEOPS_AUTHENTICATION_ENDPOINT = `${VOICEOPS_BASE_URL}/frontline-api/integrations/v1/segment/authentication`
-export const VOICEOPS_CALLS_ENDPOINT = `${VOICEOPS_BASE_URL}/frontline-api/integrations/v1/segment/calls`
+export function normalizeVoiceopsBaseUrl(baseUrl?: string): string {
+  return (baseUrl ?? DEFAULT_VOICEOPS_BASE_URL).replace(/\/$/, '')
+}
+
+export function getVoiceopsAuthenticationEndpoint(baseUrl?: string): string {
+  return `${normalizeVoiceopsBaseUrl(baseUrl)}/frontline-api/integrations/v1/segment/authentication`
+}
+
+export function getVoiceopsCallsEndpoint(baseUrl?: string): string {
+  return `${normalizeVoiceopsBaseUrl(baseUrl)}/frontline-api/integrations/v1/segment/calls`
+}
+
 export const SEGMENT_USER_AGENT = 'Segment'

--- a/packages/destination-actions/src/destinations/voiceops/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voiceops/generated-types.ts
@@ -5,4 +5,8 @@ export interface Settings {
    * Your Voiceops access token.
    */
   accessToken: string
+  /**
+   * Your Voiceops base URL.
+   */
+  baseUrl: string
 }

--- a/packages/destination-actions/src/destinations/voiceops/index.ts
+++ b/packages/destination-actions/src/destinations/voiceops/index.ts
@@ -2,7 +2,7 @@ import { defaultValues, InvalidAuthenticationError } from '@segment/actions-core
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import sendCallCompleted from './sendCallCompleted'
-import { SEGMENT_USER_AGENT, VOICEOPS_AUTHENTICATION_ENDPOINT } from './constants'
+import { DEFAULT_VOICEOPS_BASE_URL, getVoiceopsAuthenticationEndpoint, SEGMENT_USER_AGENT } from './constants'
 
 function buildHeaders(accessToken: string) {
   return {
@@ -38,11 +38,19 @@ const destination: DestinationDefinition<Settings> = {
         description: 'Your Voiceops access token.',
         type: 'password',
         required: true
+      },
+      baseUrl: {
+        label: 'Base URL',
+        description: 'Your Voiceops base URL.',
+        type: 'string',
+        format: 'uri',
+        required: true,
+        default: DEFAULT_VOICEOPS_BASE_URL
       }
     },
     testAuthentication: async (request, { settings }) => {
       try {
-        return await request(VOICEOPS_AUTHENTICATION_ENDPOINT, {
+        return await request(getVoiceopsAuthenticationEndpoint(settings.baseUrl), {
           method: 'get',
           headers: buildHeaders(settings.accessToken)
         })

--- a/packages/destination-actions/src/destinations/voiceops/sendCallCompleted/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/voiceops/sendCallCompleted/__tests__/index.test.ts
@@ -2,11 +2,12 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Settings } from '../../generated-types'
-import { VOICEOPS_BASE_URL } from '../../constants'
+import { DEFAULT_VOICEOPS_BASE_URL } from '../../constants'
 
 const testDestination = createTestIntegration(Destination)
 const SETTINGS: Settings = {
-  accessToken: 'voiceops-token'
+  accessToken: 'voiceops-token',
+  baseUrl: DEFAULT_VOICEOPS_BASE_URL
 }
 
 function createCallCompletedEvent(
@@ -37,7 +38,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('posts the minimal valid call payload with bearer auth', async () => {
-    nock(VOICEOPS_BASE_URL)
+    nock(DEFAULT_VOICEOPS_BASE_URL)
       .post('/frontline-api/integrations/v1/segment/calls')
       .matchHeader('authorization', 'Bearer voiceops-token')
       .matchHeader('user-agent', 'Segment')
@@ -64,7 +65,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('forwards channels with a supported type unchanged', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({
       recording_url: 'https://example.com/audio.wav',
@@ -102,7 +103,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('forwards agentLegs unchanged', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({
       agentLegs: [
@@ -165,7 +166,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('forwards extraMetadata unchanged', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({
       extraMetadata: {
@@ -203,7 +204,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('still succeeds when first_name and last_name are omitted', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({ first_name: undefined, last_name: undefined })
 
@@ -223,7 +224,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('still succeeds when neither channels nor agentLegs are provided', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent()
 
@@ -418,7 +419,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('allows a CONTACT channel identifier that is not an email address', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({
       channels: [
@@ -451,7 +452,7 @@ describe('Voiceops.sendCallCompleted', () => {
   })
 
   it('allows a TRANSFER_AGENT channel identifier that is not an email address', async () => {
-    nock(VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
+    nock(DEFAULT_VOICEOPS_BASE_URL).post('/frontline-api/integrations/v1/segment/calls').reply(200, {})
 
     const event = createCallCompletedEvent({
       channels: [
@@ -481,5 +482,27 @@ describe('Voiceops.sendCallCompleted', () => {
         }
       ]
     })
+  })
+
+  it('uses a custom base URL when provided in settings', async () => {
+    nock('https://custom.projectfrontline.net')
+      .post('/frontline-api/integrations/v1/segment/calls')
+      .matchHeader('authorization', 'Bearer voiceops-token')
+      .reply(200, {})
+
+    const customSettings: Settings = {
+      accessToken: 'voiceops-token',
+      baseUrl: 'https://custom.projectfrontline.net/'
+    }
+
+    const event = createCallCompletedEvent()
+
+    const responses = await testDestination.testAction('sendCallCompleted', {
+      event,
+      settings: customSettings,
+      useDefaultMappings: true
+    })
+
+    expect(responses[0].status).toBe(200)
   })
 })

--- a/packages/destination-actions/src/destinations/voiceops/sendCallCompleted/index.ts
+++ b/packages/destination-actions/src/destinations/voiceops/sendCallCompleted/index.ts
@@ -2,7 +2,7 @@ import { PayloadValidationError } from '@segment/actions-core'
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { VOICEOPS_CALLS_ENDPOINT } from '../constants'
+import { getVoiceopsCallsEndpoint } from '../constants'
 
 const HANDLING_AGENT_TYPE = 'HANDLING_AGENT'
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -259,7 +259,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, data) => {
     validateSegmentPayload(data.payload)
 
-    return request(VOICEOPS_CALLS_ENDPOINT, {
+    return request(getVoiceopsCallsEndpoint(data.settings.baseUrl), {
       method: 'post',
       json: data.payload
     })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Added base url to the destination settings

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
