### PR TITLE
Feature/adding project name field user mappings

### DIFF
--- a/packages/destination-actions/src/destinations/moengage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/moengage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -70,7 +70,6 @@ Object {
     "os": Object {},
   },
   "event": "E@t!q#n(^u",
-  "properties": Object {},
   "type": "E@t!q#n(^u",
   "update_existing_only": false,
 }

--- a/packages/destination-actions/src/destinations/moengage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/moengage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -52,6 +52,7 @@ Object {
   },
   "event": "E@t!q#n(^u",
   "properties": Object {
+    "moe_project_name": "E@t!q#n(^u",
     "testType": "E@t!q#n(^u",
   },
   "timestamp": "2021-02-01T00:00:00.000Z",
@@ -69,6 +70,7 @@ Object {
     "os": Object {},
   },
   "event": "E@t!q#n(^u",
+  "properties": Object {},
   "type": "E@t!q#n(^u",
   "update_existing_only": false,
 }

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,6 +16,7 @@ Object {
   },
   "event": "[3(wtAyZqr",
   "properties": Object {
+    "moe_project_name": "[3(wtAyZqr",
     "testType": "[3(wtAyZqr",
   },
   "timestamp": "2021-02-01T00:00:00.000Z",
@@ -33,6 +34,7 @@ Object {
     "os": Object {},
   },
   "event": "[3(wtAyZqr",
+  "properties": Object {},
   "type": "[3(wtAyZqr",
   "update_existing_only": false,
 }

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -34,7 +34,6 @@ Object {
     "os": Object {},
   },
   "event": "[3(wtAyZqr",
-  "properties": Object {},
   "type": "[3(wtAyZqr",
   "update_existing_only": false,
 }

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/index.test.ts
@@ -125,8 +125,8 @@ describe('ActionsMoengage.trackEvent', () => {
 
     nock(`${endpoint}`).post(`/v1/integrations/segment?appId=${api_id}`).reply(200, {})
 
-    try {
-      await testDestination.testAction('trackEvent', {
+    await expect(
+      testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
@@ -135,8 +135,6 @@ describe('ActionsMoengage.trackEvent', () => {
           region
         }
       })
-    } catch (e) {
-      expect(e.message).toBe("The root value is missing the required field 'event'.")
-    }
+    ).rejects.toThrow("The root value is missing the required field 'event'.")
   })
 })

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/__tests__/index.test.ts
@@ -3,17 +3,14 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { getEndpointByRegion } from '../../regional-endpoints'
 
-
 const testDestination = createTestIntegration(Destination)
-const api_id = "APP_ID"
-const api_key = "APP_KEY"
-const region = "SOME_REGION"
-
+const api_id = 'APP_ID'
+const api_key = 'APP_KEY'
+const region = 'SOME_REGION'
 
 const endpoint = getEndpointByRegion()
 
 describe('ActionsMoengage.trackEvent', () => {
-
   it('should validate action fields', async () => {
     const event = createTestEvent({ event: 'Test Event' })
 
@@ -28,17 +25,98 @@ describe('ActionsMoengage.trackEvent', () => {
         region
       }
     })
-  
+
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
     expect(responses[0].data).toMatchObject({})
-    expect(responses[0].options.json).toMatchObject(
-      {
-        type: 'track',
-        event: 'Test Event',
-        context: {library: { version: '2.11.1' }}
+    expect(responses[0].options.json).toMatchObject({
+      type: 'track',
+      event: 'Test Event',
+      context: { library: { version: '2.11.1' } }
+    })
+  })
+
+  it('should include project_name in properties when provided', async () => {
+    const event = createTestEvent({
+      event: 'Test Event',
+      properties: { key1: 'value1' }
+    })
+
+    nock(`${endpoint}`).post(`/v1/integrations/segment?appId=${api_id}`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      mapping: { project_name: 'MyProject' },
+      settings: {
+        api_id,
+        api_key,
+        region
       }
-    )
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      type: 'track',
+      event: 'Test Event',
+      properties: {
+        key1: 'value1',
+        moe_project_name: 'MyProject'
+      }
+    })
+  })
+
+  it('should not include project_name in properties when it is empty string', async () => {
+    const event = createTestEvent({
+      event: 'Test Event',
+      properties: { key1: 'value1' }
+    })
+
+    nock(`${endpoint}`).post(`/v1/integrations/segment?appId=${api_id}`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      mapping: { project_name: '' },
+      settings: {
+        api_id,
+        api_key,
+        region
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    const payload = responses[0].options.json as Record<string, unknown>
+    const properties = payload.properties as Record<string, unknown>
+    expect(properties).not.toHaveProperty('moe_project_name')
+    expect(properties).toMatchObject({ key1: 'value1' })
+  })
+
+  it('should not include project_name in properties when it is not provided', async () => {
+    const event = createTestEvent({
+      event: 'Test Event',
+      properties: { key1: 'value1' }
+    })
+
+    nock(`${endpoint}`).post(`/v1/integrations/segment?appId=${api_id}`).reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent', {
+      event,
+      useDefaultMappings: true,
+      settings: {
+        api_id,
+        api_key,
+        region
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    const payload = responses[0].options.json as Record<string, unknown>
+    const properties = payload.properties as Record<string, unknown>
+    expect(properties).not.toHaveProperty('moe_project_name')
   })
 
   it('should require event field', async () => {
@@ -49,7 +127,9 @@ describe('ActionsMoengage.trackEvent', () => {
 
     try {
       await testDestination.testAction('trackEvent', {
-        event, useDefaultMappings: true, settings: {
+        event,
+        useDefaultMappings: true,
+        settings: {
           api_id,
           api_key,
           region

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/generated-types.ts
@@ -40,6 +40,10 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
+   * Enter the Project Name from MoEngage Settings > Portfolio. Values must match exactly. Mismatched events stay at the portfolio level and are unusable for project-level analysis. Leave this field blank if Portfolio is not enabled for your workspace.
+   */
+  project_name?: string
+  /**
    * If set to true, events from the Segment will only trigger updates for users who already exist in Moengage.
    */
   update_existing_only?: boolean

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/index.ts
@@ -106,9 +106,12 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Missing API ID or API KEY', 'Missing required field', 400)
     }
 
-    const properties = payload.properties ? { ...payload.properties } : {}
+    let properties = payload.properties
     if (payload.project_name) {
-      properties.moe_project_name = payload.project_name
+      properties = {
+        ...(payload.properties ?? {}),
+        moe_project_name: payload.project_name
+      }
     }
 
     const event = {

--- a/packages/destination-actions/src/destinations/moengage/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/moengage/trackEvent/index.ts
@@ -84,6 +84,14 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties'
       }
     },
+    project_name: {
+      label: 'Project Name',
+      type: 'string',
+      description:
+        'Enter the Project Name from MoEngage Settings > Portfolio. Values must match exactly. Mismatched events stay at the portfolio level and are unusable for project-level analysis. Leave this field blank if Portfolio is not enabled for your workspace.',
+      required: false,
+      default: ''
+    },
     update_existing_only: {
       label: 'Update Existing Users Only',
       type: 'boolean',
@@ -98,6 +106,11 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new IntegrationError('Missing API ID or API KEY', 'Missing required field', 400)
     }
 
+    const properties = payload.properties ? { ...payload.properties } : {}
+    if (payload.project_name) {
+      properties.moe_project_name = payload.project_name
+    }
+
     const event = {
       type: payload.type,
       user_id: payload.userId,
@@ -108,7 +121,7 @@ const action: ActionDefinition<Settings, Payload> = {
         os: { name: payload.os_name },
         library: { version: payload.library_version }
       },
-      properties: payload.properties,
+      properties,
       timestamp: payload.timestamp,
       update_existing_only: payload.update_existing_only || false
     }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
