### PR TITLE
[DEVED-13663] No observability in async action note

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -6,7 +6,9 @@ import { getDataExtensionFields, asyncUpsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event asynchronously to Data Extension',
-  description: 'Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.',
+  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.
+  
+    Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action.`,
   fields: {
     keys: { ...keys, required: true, dynamic: true },
     values: { ...values_dataExtensionFields, dynamic: true },

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -8,7 +8,7 @@ const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event asynchronously to Data Extension',
   description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.
   
-    Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action.`,
+    Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future`,
   fields: {
     keys: { ...keys, required: true, dynamic: true },
     values: { ...values_dataExtensionFields, dynamic: true },


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

(Hopefully) A workaround for getting [this note](https://twilio-productivity.atlassian.net/browse/DEVED-13663) added to Salesforce destination doc 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
