### PR TITLE
STRATCONN-6647 - [Hubspot] - adding stats and logger to cleanPropObj function

### DIFF
--- a/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
@@ -83,6 +83,11 @@ describe('Hubspot.customEvent', () => {
       jest.clearAllMocks()
     })
 
+    const subscriptionMetadata = {
+      destinationConfigId: 'dest-123',
+      sourceId: 'src-456'
+    }
+
     it('should emit a metric and log when an empty string is coerced to a number', () => {
       const payloadWithEmptyString: Payload = {
         event_name: 'Test Event',
@@ -95,7 +100,7 @@ describe('Hubspot.customEvent', () => {
         }
       }
 
-      validate(payloadWithEmptyString, statsContext, logger)
+      validate(payloadWithEmptyString, statsContext, logger, subscriptionMetadata)
 
       expect(statsClient.incr).toHaveBeenCalledWith(
         'hubspot.custom_event.empty_string_to_number',
@@ -103,7 +108,7 @@ describe('Hubspot.customEvent', () => {
         statsContext.tags
       )
       expect(logger.warn).toHaveBeenCalledWith(
-        'hubspot.custom_event.empty_string_to_number property: some_prop'
+        'hubspot.custom_event.empty_string_to_number destinationConfigId: dest-123 sourceId: src-456'
       )
     })
 
@@ -121,7 +126,7 @@ describe('Hubspot.customEvent', () => {
         }
       }
 
-      validate(payloadWithNormalValues, statsContext, logger)
+      validate(payloadWithNormalValues, statsContext, logger, subscriptionMetadata)
 
       expect(statsClient.incr).not.toHaveBeenCalledWith(
         'hubspot.custom_event.empty_string_to_number',

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
@@ -51,4 +51,84 @@ describe('Hubspot.customEvent', () => {
     const validatedPayload = validate(payload)
     expect(validatedPayload).toEqual(expectedValidatedPayload)
   })
+
+  describe('empty string to number instrumentation', () => {
+    const statsClient = {
+      incr: jest.fn(),
+      observe: jest.fn(),
+      _name: jest.fn(),
+      _tags: jest.fn(),
+      set: jest.fn(),
+      histogram: jest.fn()
+    }
+
+    const statsContext = {
+      statsClient,
+      tags: ['test:tag']
+    }
+
+    const logger = {
+      level: 'warn',
+      name: 'test-logger',
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      crit: jest.fn(),
+      log: jest.fn(),
+      withTags: jest.fn()
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should emit a metric and log when an empty string is coerced to a number', () => {
+      const payloadWithEmptyString: Payload = {
+        event_name: 'Test Event',
+        record_details: {
+          object_type: 'contact',
+          email: 'test@example.com'
+        },
+        properties: {
+          some_prop: ''
+        }
+      }
+
+      validate(payloadWithEmptyString, statsContext, logger)
+
+      expect(statsClient.incr).toHaveBeenCalledWith(
+        'hubspot.custom_event.empty_string_to_number',
+        1,
+        statsContext.tags
+      )
+      expect(logger.warn).toHaveBeenCalledWith(
+        'hubspot.custom_event.empty_string_to_number property: some_prop'
+      )
+    })
+
+    it('should not emit a metric for non-empty string values', () => {
+      const payloadWithNormalValues: Payload = {
+        event_name: 'Test Event',
+        record_details: {
+          object_type: 'contact',
+          email: 'test@example.com'
+        },
+        properties: {
+          str_prop: 'hello',
+          num_prop: 42,
+          bool_prop: true
+        }
+      }
+
+      validate(payloadWithNormalValues, statsContext, logger)
+
+      expect(statsClient.incr).not.toHaveBeenCalledWith(
+        'hubspot.custom_event.empty_string_to_number',
+        expect.anything(),
+        expect.anything()
+      )
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/__tests__/validate.test.ts
@@ -112,6 +112,26 @@ describe('Hubspot.customEvent', () => {
       )
     })
 
+    it('should emit only once even when multiple properties are empty strings', () => {
+      const payloadWithMultipleEmpty: Payload = {
+        event_name: 'Test Event',
+        record_details: {
+          object_type: 'contact',
+          email: 'test@example.com'
+        },
+        properties: {
+          prop_a: '',
+          prop_b: '',
+          prop_c: 'hello'
+        }
+      }
+
+      validate(payloadWithMultipleEmpty, statsContext, logger, subscriptionMetadata)
+
+      expect(statsClient.incr).toHaveBeenCalledTimes(1)
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+    })
+
     it('should not emit a metric for non-empty string values', () => {
       const payloadWithNormalValues: Payload = {
         event_name: 'Test Event',

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
@@ -90,7 +90,7 @@ function cleanPropObj(
 
   if (hasEmptyStringToNumber) {
     statsContext?.statsClient?.incr('hubspot.custom_event.empty_string_to_number', 1, statsContext?.tags)
-    logger?.warn(
+    logger?.warn?.(
       `hubspot.custom_event.empty_string_to_number destinationConfigId: ${subscriptionMetadata?.destinationConfigId} sourceId: ${subscriptionMetadata?.sourceId}`
     )
   }

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
@@ -1,7 +1,13 @@
 import { Payload } from '../generated-types'
 import { PayloadValidationError, StatsContext, Logger } from '@segment/actions-core'
+import { SubscriptionMetadata } from '@segment/actions-core/destination-kit'
 
-export function validate(payload: Payload, statsContext?: StatsContext, logger?: Logger): Payload {
+export function validate(
+  payload: Payload,
+  statsContext?: StatsContext,
+  logger?: Logger,
+  subscriptionMetadata?: SubscriptionMetadata
+): Payload {
   if (payload.record_details.object_type !== 'contact' && typeof payload.record_details.object_id !== 'number') {
     throw new PayloadValidationError('object_id is required and must be numeric')
   }
@@ -19,7 +25,7 @@ export function validate(payload: Payload, statsContext?: StatsContext, logger?:
 
   cleanIdentifiers(payload)
   payload.event_name = cleanEventName(payload.event_name)
-  payload.properties = cleanPropObj(payload.properties ?? {}, statsContext, logger)
+  payload.properties = cleanPropObj(payload.properties ?? {}, statsContext, logger, subscriptionMetadata)
 
   return payload
 }
@@ -44,7 +50,8 @@ export function cleanEventName(str: string): string {
 function cleanPropObj(
   obj: { [k: string]: unknown } | undefined,
   statsContext?: StatsContext,
-  logger?: Logger
+  logger?: Logger,
+  subscriptionMetadata?: SubscriptionMetadata
 ): { [k: string]: string | number | boolean } | undefined {
   const cleanObj: { [k: string]: string | number | boolean } = {}
 
@@ -67,7 +74,9 @@ function cleanPropObj(
     } else if (!isNaN(Number(value))) {
       if (typeof value === 'string' && value.trim() === '') {
         statsContext?.statsClient?.incr('hubspot.custom_event.empty_string_to_number', 1, statsContext?.tags)
-        logger?.warn(`hubspot.custom_event.empty_string_to_number property: ${cleanKey}`)
+        logger?.warn(
+          `hubspot.custom_event.empty_string_to_number destinationConfigId: ${subscriptionMetadata?.destinationConfigId} sourceId: ${subscriptionMetadata?.sourceId}`
+        )
       }
       // If the value can be cast to a number
       cleanObj[cleanKey] = Number(value)

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
@@ -1,7 +1,7 @@
 import { Payload } from '../generated-types'
-import { PayloadValidationError } from '@segment/actions-core'
+import { PayloadValidationError, StatsContext, Logger } from '@segment/actions-core'
 
-export function validate(payload: Payload): Payload {
+export function validate(payload: Payload, statsContext?: StatsContext, logger?: Logger): Payload {
   if (payload.record_details.object_type !== 'contact' && typeof payload.record_details.object_id !== 'number') {
     throw new PayloadValidationError('object_id is required and must be numeric')
   }
@@ -19,7 +19,7 @@ export function validate(payload: Payload): Payload {
 
   cleanIdentifiers(payload)
   payload.event_name = cleanEventName(payload.event_name)
-  payload.properties = cleanPropObj(payload.properties ?? {})
+  payload.properties = cleanPropObj(payload.properties ?? {}, statsContext, logger)
 
   return payload
 }
@@ -42,7 +42,9 @@ export function cleanEventName(str: string): string {
 }
 
 function cleanPropObj(
-  obj: { [k: string]: unknown } | undefined
+  obj: { [k: string]: unknown } | undefined,
+  statsContext?: StatsContext,
+  logger?: Logger
 ): { [k: string]: string | number | boolean } | undefined {
   const cleanObj: { [k: string]: string | number | boolean } = {}
 
@@ -63,6 +65,10 @@ function cleanPropObj(
       // If the value can be cast to a boolean
       cleanObj[cleanKey] = value.toLowerCase().trim() === 'true'
     } else if (!isNaN(Number(value))) {
+      if (typeof value === 'string' && value.trim() === '') {
+        statsContext?.statsClient?.incr('hubspot.custom_event.empty_string_to_number', 1, statsContext?.tags)
+        logger?.warn(`hubspot.custom_event.empty_string_to_number property: ${cleanKey}`)
+      }
       // If the value can be cast to a number
       cleanObj[cleanKey] = Number(value)
     } else if (typeof value === 'object' && value !== null) {

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/functions/validation-functions.ts
@@ -59,6 +59,8 @@ function cleanPropObj(
     return undefined
   }
 
+  let hasEmptyStringToNumber = false
+
   Object.keys(obj).forEach((key) => {
     const value = obj[key]
     const cleanKey = cleanProp(key)
@@ -73,10 +75,7 @@ function cleanPropObj(
       cleanObj[cleanKey] = value.toLowerCase().trim() === 'true'
     } else if (!isNaN(Number(value))) {
       if (typeof value === 'string' && value.trim() === '') {
-        statsContext?.statsClient?.incr('hubspot.custom_event.empty_string_to_number', 1, statsContext?.tags)
-        logger?.warn(
-          `hubspot.custom_event.empty_string_to_number destinationConfigId: ${subscriptionMetadata?.destinationConfigId} sourceId: ${subscriptionMetadata?.sourceId}`
-        )
+        hasEmptyStringToNumber = true
       }
       // If the value can be cast to a number
       cleanObj[cleanKey] = Number(value)
@@ -88,6 +87,14 @@ function cleanPropObj(
       cleanObj[cleanKey] = String(value).trim()
     }
   })
+
+  if (hasEmptyStringToNumber) {
+    statsContext?.statsClient?.incr('hubspot.custom_event.empty_string_to_number', 1, statsContext?.tags)
+    logger?.warn(
+      `hubspot.custom_event.empty_string_to_number destinationConfigId: ${subscriptionMetadata?.destinationConfigId} sourceId: ${subscriptionMetadata?.sourceId}`
+    )
+  }
+
   return cleanObj
 }
 

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/index.ts
@@ -54,7 +54,7 @@ const send = async (
   statsContext?.tags?.push('action:custom_event')
 
   const client = new Client(request)
-  const validPayload = validate(payload, statsContext, logger)
+  const validPayload = validate(payload, statsContext, logger, subscriptionMetadata)
   const schema = eventSchema(validPayload)
   const cachedSchema = getSchemaFromCache(schema.name, subscriptionMetadata, statsContext)
 

--- a/packages/destination-actions/src/destinations/hubspot/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/hubspot/customEvent/index.ts
@@ -2,7 +2,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { commonFields } from './common-fields'
 import { Client } from './client'
-import { ActionDefinition, RequestClient, IntegrationError, StatsContext } from '@segment/actions-core'
+import { ActionDefinition, RequestClient, IntegrationError, StatsContext, Logger } from '@segment/actions-core'
 import { dynamicFields } from './functions/dynamic-field-functions'
 import { SyncMode, SchemaMatch, CachableSchema } from './types'
 import { SubscriptionMetadata } from '@segment/actions-core/destination-kit'
@@ -38,8 +38,8 @@ const action: ActionDefinition<Settings, Payload> = {
     ...commonFields
   },
   dynamicFields,
-  perform: async (request, { payload, syncMode, subscriptionMetadata, statsContext }) => {
-    return await send(request, payload, syncMode as SyncMode, subscriptionMetadata, statsContext)
+  perform: async (request, { payload, syncMode, subscriptionMetadata, statsContext, logger }) => {
+    return await send(request, payload, syncMode as SyncMode, subscriptionMetadata, statsContext, logger)
   }
 }
 
@@ -48,12 +48,13 @@ const send = async (
   payload: Payload,
   syncMode: SyncMode,
   subscriptionMetadata?: SubscriptionMetadata,
-  statsContext?: StatsContext
+  statsContext?: StatsContext,
+  logger?: Logger
 ) => {
   statsContext?.tags?.push('action:custom_event')
 
   const client = new Client(request)
-  const validPayload = validate(payload)
+  const validPayload = validate(payload, statsContext, logger)
   const schema = eventSchema(validPayload)
   const cachedSchema = getSchemaFromCache(schema.name, subscriptionMetadata, statsContext)
 


### PR DESCRIPTION
Adding logging and stats collection to gauge the scale of the Hubspot customEvent empty string to 0 issue. 

## Testing
Sanity checked in staging. 

Also created a datadog notebook to track the data point.  
<img width="790" height="474" alt="image" src="https://github.com/user-attachments/assets/80173a0f-d091-498d-b122-5f271a4b1bda" />

In staging: able to reproduce the bug the metric will track. 
<img width="1013" height="144" alt="image" src="https://github.com/user-attachments/assets/597e22c5-f84b-487e-858a-576e62a17a78" />


## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
