### PR TITLE
feat: add metadata.json for browser destinations (40 files)

### DIFF
--- a/packages/browser-destinations/destinations/1flow/metadata.json
+++ b/packages/browser-destinations/destinations/1flow/metadata.json
@@ -1,0 +1,270 @@
+{
+  "name": "1Flow Web (Actions)",
+  "description": "Send analytics from Segment to 1Flow",
+  "basicOptions": ["projectApiKey"],
+  "options": {
+    "projectApiKey": {
+      "tags": [],
+      "default": "",
+      "description": "This is the unique app_id for your 1Flow application, serving as the identifier for data storage and retrieval. This field is mandatory.",
+      "encrypt": true,
+      "hidden": false,
+      "label": "Project API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The projectApiKey property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Create or update a user in 1Flow.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "The user's custom attributes.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Custom Attributes",
+                "description": "The user's custom attributes.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Submit an event to 1Flow.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "An anonymous identifier for the user.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "An anonymous identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Information associated with the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Information associated with the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/1flow/metadata.json
+++ b/packages/browser-destinations/destinations/1flow/metadata.json
@@ -1,254 +1,191 @@
 {
+  "slug": "actions-1flow",
   "name": "1Flow Web (Actions)",
+  "mode": "device",
   "description": "Send analytics from Segment to 1Flow",
-  "basicOptions": ["projectApiKey"],
-  "options": {
-    "projectApiKey": {
-      "tags": [],
-      "default": "",
-      "description": "This is the unique app_id for your 1Flow application, serving as the identifier for data storage and retrieval. This field is mandatory.",
-      "encrypt": true,
-      "hidden": false,
-      "label": "Project API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The projectApiKey property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "projectApiKey": {
+        "label": "Project API Key",
+        "description": "This is the unique app_id for your 1Flow application, serving as the identifier for data storage and retrieval. This field is mandatory.",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Create or update a user in 1Flow.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Custom Attributes",
-          "description": "The user's custom attributes.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Custom Attributes",
-                "description": "The user's custom attributes.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Submit an event to 1Flow.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
           "label": "Event Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["event_name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "A unique identifier for the user.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "An anonymous identifier for the user.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "An anonymous identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Information associated with the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Information associated with the event",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Create or update a user in 1Flow.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
         "userId": {
-          "@path": "$.userId"
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "Custom Attributes",
+          "description": "The user's custom attributes.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
-    },
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "event_name": {
@@ -264,7 +201,22 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/1flow/metadata.json
+++ b/packages/browser-destinations/destinations/1flow/metadata.json
@@ -11,8 +11,10 @@
         "description": "This is the unique app_id for your 1Flow application, serving as the identifier for data storage and retrieval. This field is mandatory.",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -26,7 +28,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -49,7 +51,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -72,7 +76,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -95,7 +101,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -118,7 +126,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -130,7 +140,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -153,7 +163,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Custom Attributes",
@@ -176,7 +188,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/adobe-target/metadata.json
+++ b/packages/browser-destinations/destinations/adobe-target/metadata.json
@@ -1,390 +1,78 @@
 {
+  "slug": "actions-adobe-target-web",
   "name": "Adobe Target Web",
-  "basicOptions": ["client_code", "admin_number", "version", "mbox_name", "cookie_domain"],
-  "options": {
-    "client_code": {
-      "tags": [],
-      "default": "",
-      "description": "Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Client Code",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The client_code property is required."]],
-      "uIMetadata": null
-    },
-    "admin_number": {
-      "tags": [],
-      "default": "",
-      "description": "Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Admin number",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The admin_number property is required."]],
-      "uIMetadata": null
-    },
-    "version": {
-      "tags": [],
-      "default": "2.8.0",
-      "description": "The version of ATJS to use. Defaults to 2.8.0.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "ATJS Version",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "2.8.0",
-          "label": "2.8.0",
-          "text": "2.8.0"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The version property is required."]],
-      "uIMetadata": null
-    },
-    "mbox_name": {
-      "tags": [],
-      "default": "target-global-mbox",
-      "description": "The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Mbox Name",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The mbox_name property is required."]],
-      "uIMetadata": null
-    },
-    "cookie_domain": {
-      "tags": [],
-      "default": "",
-      "description": "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Domain",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The cookie_domain property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "client_code": {
+        "label": "Client Code",
+        "description": "Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "admin_number": {
+        "label": "Admin number",
+        "description": "Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "version": {
+        "label": "ATJS Version",
+        "description": "The version of ATJS to use. Defaults to 2.8.0.",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "value": "2.8.0",
+            "label": "2.8.0"
+          }
+        ],
+        "default": "2.8.0"
+      },
+      "mbox_name": {
+        "label": "Mbox Name",
+        "description": "The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": "target-global-mbox"
+      },
+      "cookie_domain": {
+        "label": "Cookie Domain",
+        "description": "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Send user actions, such as clicks and conversions, to Adobe Target.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "type",
-          "type": "string",
-          "label": "Event Type",
-          "description": "The event type. Please ensure the type entered here is registered and available.",
-          "defaultValue": "display",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "type": {
-                "title": "Event Type",
-                "description": "The event type. Please ensure the type entered here is registered and available.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "eventName",
-          "type": "string",
-          "label": "Event Name",
-          "description": "This will be sent to Adobe Target as an event parameter called \"event_name\".",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Event Name",
-                "description": "This will be sent to Adobe Target as an event parameter called \"event_name\".",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "Parameters specific to the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Parameters",
-                "description": "Parameters specific to the event.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "Mbox 3rd Party ID",
-          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "Mbox 3rd Party ID",
-                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "triggerView",
-      "name": "Trigger View",
-      "description": "Send page-level data to Adobe Target.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "viewName",
-          "type": "string",
-          "label": "View Name",
-          "description": "Name of the view or page.",
-          "defaultValue": {
-            "@path": "$.name"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "viewName": {
-                "title": "View Name",
-                "description": "Name of the view or page.",
-                "type": "string"
-              }
-            },
-            "required": ["viewName"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "pageParameters",
-          "type": "object",
-          "label": "Page Parameters",
-          "description": "Parameters specific to the view or page.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "pageParameters": {
-                "title": "Page Parameters",
-                "description": "Parameters specific to the view or page.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "sendNotification",
-          "type": "boolean",
-          "label": "Send Notifications to Adobe Target.",
-          "description": "By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "sendNotification": {
-                "title": "Send Notifications to Adobe Target.",
-                "description": "By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "Mbox 3rd Party ID",
-          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "Mbox 3rd Party ID",
-                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "upsertProfile",
-      "name": "Upsert Profile",
+  "audienceConfig": null,
+  "actions": {
+    "upsertProfile": {
+      "title": "Upsert Profile",
       "description": "Create or update a user profile in Adobe Target.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "Mbox 3rd Party ID",
           "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.userId"
@@ -397,58 +85,265 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "Mbox 3rd Party ID",
-                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "Profile Attributes",
           "description": "Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Profile Attributes",
-                "description": "Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "triggerView": {
+      "title": "Trigger View",
+      "description": "Send page-level data to Adobe Target.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "viewName": {
+          "label": "View Name",
+          "description": "Name of the view or page.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "pageParameters": {
+          "label": "Page Parameters",
+          "description": "Parameters specific to the view or page.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "sendNotification": {
+          "label": "Send Notifications to Adobe Target.",
+          "description": "By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "Mbox 3rd Party ID",
+          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Send user actions, such as clicks and conversions, to Adobe Target.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "type": {
+          "label": "Event Type",
+          "description": "The event type. Please ensure the type entered here is registered and available.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "display",
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "eventName": {
+          "label": "Event Name",
+          "description": "This will be sent to Adobe Target as an event parameter called \"event_name\".",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Event Parameters",
+          "description": "Parameters specific to the event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "Mbox 3rd Party ID",
+          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/adobe-target/metadata.json
+++ b/packages/browser-destinations/destinations/adobe-target/metadata.json
@@ -1,0 +1,454 @@
+{
+  "name": "Adobe Target Web",
+  "basicOptions": ["client_code", "admin_number", "version", "mbox_name", "cookie_domain"],
+  "options": {
+    "client_code": {
+      "tags": [],
+      "default": "",
+      "description": "Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Client Code",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The client_code property is required."]],
+      "uIMetadata": null
+    },
+    "admin_number": {
+      "tags": [],
+      "default": "",
+      "description": "Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Admin number",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The admin_number property is required."]],
+      "uIMetadata": null
+    },
+    "version": {
+      "tags": [],
+      "default": "2.8.0",
+      "description": "The version of ATJS to use. Defaults to 2.8.0.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "ATJS Version",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "2.8.0",
+          "label": "2.8.0",
+          "text": "2.8.0"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The version property is required."]],
+      "uIMetadata": null
+    },
+    "mbox_name": {
+      "tags": [],
+      "default": "target-global-mbox",
+      "description": "The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Mbox Name",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The mbox_name property is required."]],
+      "uIMetadata": null
+    },
+    "cookie_domain": {
+      "tags": [],
+      "default": "",
+      "description": "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Domain",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The cookie_domain property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send user actions, such as clicks and conversions, to Adobe Target.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "type",
+          "type": "string",
+          "label": "Event Type",
+          "description": "The event type. Please ensure the type entered here is registered and available.",
+          "defaultValue": "display",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "title": "Event Type",
+                "description": "The event type. Please ensure the type entered here is registered and available.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Event Name",
+          "description": "This will be sent to Adobe Target as an event parameter called \"event_name\".",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Event Name",
+                "description": "This will be sent to Adobe Target as an event parameter called \"event_name\".",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "Parameters specific to the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Parameters",
+                "description": "Parameters specific to the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "Mbox 3rd Party ID",
+          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "Mbox 3rd Party ID",
+                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "triggerView",
+      "name": "Trigger View",
+      "description": "Send page-level data to Adobe Target.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "viewName",
+          "type": "string",
+          "label": "View Name",
+          "description": "Name of the view or page.",
+          "defaultValue": {
+            "@path": "$.name"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "viewName": {
+                "title": "View Name",
+                "description": "Name of the view or page.",
+                "type": "string"
+              }
+            },
+            "required": ["viewName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "pageParameters",
+          "type": "object",
+          "label": "Page Parameters",
+          "description": "Parameters specific to the view or page.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pageParameters": {
+                "title": "Page Parameters",
+                "description": "Parameters specific to the view or page.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "sendNotification",
+          "type": "boolean",
+          "label": "Send Notifications to Adobe Target.",
+          "description": "By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sendNotification": {
+                "title": "Send Notifications to Adobe Target.",
+                "description": "By default, notifications are sent to the Adobe Target backend for incrementing impression count.  If false, notifications are not sent for incrementing impression count. ",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "Mbox 3rd Party ID",
+          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "Mbox 3rd Party ID",
+                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "upsertProfile",
+      "name": "Upsert Profile",
+      "description": "Create or update a user profile in Adobe Target.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "Mbox 3rd Party ID",
+          "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "Mbox 3rd Party ID",
+                "description": "A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Profile Attributes",
+          "description": "Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Profile Attributes",
+                "description": "Profile parameters specific to a user. Please note, Adobe recommends that PII is hashed prior to sending to Adobe.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/adobe-target/metadata.json
+++ b/packages/browser-destinations/destinations/adobe-target/metadata.json
@@ -10,45 +10,55 @@
         "description": "Your Adobe Target client code. To find your client code in Adobe Target, navigate to **Administration > Implementation**. The client code is shown at the top under Account Details.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "admin_number": {
         "label": "Admin number",
         "description": "Your Adobe Target admin number. To find your admin number, please follow the instructions in [Adobe Docs](https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/deploy-at-js/implementing-target-without-a-tag-manager.html).",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "version": {
         "label": "ATJS Version",
         "description": "The version of ATJS to use. Defaults to 2.8.0.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "value": "2.8.0",
             "label": "2.8.0"
           }
         ],
-        "default": "2.8.0"
+        "default": "2.8.0",
+        "depends_on": null
       },
       "mbox_name": {
         "label": "Mbox Name",
         "description": "The name of the Adobe Target mbox to use. Defaults to `target-global-mbox`.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": "target-global-mbox"
+        "default": "target-global-mbox",
+        "depends_on": null
       },
       "cookie_domain": {
         "label": "Cookie Domain",
         "description": "The domain from which you serve the mbox. Adobe Target recommends setting this value to your company's top-level domain.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -62,7 +72,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "Mbox 3rd Party ID",
@@ -95,7 +105,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Profile Attributes",
@@ -116,7 +128,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -128,7 +142,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "viewName": {
           "label": "View Name",
@@ -151,7 +165,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "pageParameters": {
           "label": "Page Parameters",
@@ -174,7 +190,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "sendNotification": {
           "label": "Send Notifications to Adobe Target.",
@@ -195,7 +213,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "Mbox 3rd Party ID",
@@ -228,7 +248,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -240,7 +262,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "type": {
           "label": "Event Type",
@@ -261,7 +283,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "eventName": {
           "label": "Event Name",
@@ -284,7 +308,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Parameters",
@@ -307,7 +333,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "Mbox 3rd Party ID",
@@ -340,7 +368,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/appcues-web/metadata.json
+++ b/packages/browser-destinations/destinations/appcues-web/metadata.json
@@ -1,302 +1,241 @@
 {
+  "slug": "appcues-web-actions",
   "name": "Appcues Web",
-  "basicOptions": ["accountID", "region", "enableURLDetection"],
-  "options": {
-    "accountID": {
-      "tags": [],
-      "default": "",
-      "description": "Your Appcues Account ID.",
-      "encrypt": true,
-      "hidden": false,
-      "label": "Appcues Account ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The accountID property is required."]],
-      "uIMetadata": null
-    },
-    "region": {
-      "tags": [],
-      "default": "US",
-      "description": "Select the Appcues region for your account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Region",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "US",
-          "label": "US",
-          "text": "US"
-        },
-        {
-          "value": "EU",
-          "label": "EU",
-          "text": "EU"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The region property is required."]],
-      "uIMetadata": null
-    },
-    "enableURLDetection": {
-      "tags": [],
-      "default": false,
-      "description": "Enable or disable URL detection in Appcues. If enabled, page events should not be triggered manually using the page action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable URL Detection",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The enableURLDetection property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "accountID": {
+        "label": "Appcues Account ID",
+        "description": "Your Appcues Account ID.",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "region": {
+        "label": "Region",
+        "description": "Select the Appcues region for your account.",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "label": "US",
+            "value": "US"
+          },
+          {
+            "label": "EU",
+            "value": "EU"
+          }
+        ],
+        "default": "US"
+      },
+      "enableURLDetection": {
+        "label": "Enable URL Detection",
+        "description": "Enable or disable URL detection in Appcues. If enabled, page events should not be triggered manually using the page action.",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "group",
-      "name": "Group",
-      "description": "Send Segment group events to Appcues.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
-          "label": "Group ID",
-          "description": "The ID of the group to identify in Appcues.",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Group ID",
-                "description": "The ID of the group to identify in Appcues.",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Group traits",
-          "description": "Properties to associate with the group / account / company.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Group traits",
-                "description": "Properties to associate with the group / account / company.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identify",
-      "name": "Identify",
-      "description": "Send Segment identify events to Appcues.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "The ID of the user to identify in Appcues.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The ID of the user to identify in Appcues.",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "User traits",
-          "description": "Properties to associate with the user.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User traits",
-                "description": "Properties to associate with the user.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "page",
-      "name": "Page",
-      "description": "Send Segment page events to Appcues.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": []
-    },
-    {
-      "slug": "track",
-      "name": "Track",
+  "audienceConfig": null,
+  "actions": {
+    "track": {
+      "title": "Track",
       "description": "Send Segment track events to Appcues.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event": {
           "label": "Event Name",
           "description": "The name of the event to track in Appcues.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "Event Name",
-                "description": "The name of the event to track in Appcues.",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Properties to associate with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Properties to associate with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "page": {
+      "title": "Page",
+      "description": "Send Segment page events to Appcues.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {}
+    },
+    "identify": {
+      "title": "Identify",
+      "description": "Send Segment identify events to Appcues.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "User ID",
+          "description": "The ID of the user to identify in Appcues.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "User traits",
+          "description": "Properties to associate with the user.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "group": {
+      "title": "Group",
+      "description": "Send Segment group events to Appcues.",
+      "platform": "web",
+      "defaultSubscription": "type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "groupId": {
+          "label": "Group ID",
+          "description": "The ID of the group to identify in Appcues.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "Group traits",
+          "description": "Properties to associate with the group / account / company.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "page",
       "name": "Page",
+      "type": "automatic",
+      "partnerAction": "page",
       "subscribe": "type = \"page\"",
       "mapping": {},
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/appcues-web/metadata.json
+++ b/packages/browser-destinations/destinations/appcues-web/metadata.json
@@ -1,0 +1,302 @@
+{
+  "name": "Appcues Web",
+  "basicOptions": ["accountID", "region", "enableURLDetection"],
+  "options": {
+    "accountID": {
+      "tags": [],
+      "default": "",
+      "description": "Your Appcues Account ID.",
+      "encrypt": true,
+      "hidden": false,
+      "label": "Appcues Account ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The accountID property is required."]],
+      "uIMetadata": null
+    },
+    "region": {
+      "tags": [],
+      "default": "US",
+      "description": "Select the Appcues region for your account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Region",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "US",
+          "label": "US",
+          "text": "US"
+        },
+        {
+          "value": "EU",
+          "label": "EU",
+          "text": "EU"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The region property is required."]],
+      "uIMetadata": null
+    },
+    "enableURLDetection": {
+      "tags": [],
+      "default": false,
+      "description": "Enable or disable URL detection in Appcues. If enabled, page events should not be triggered manually using the page action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable URL Detection",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The enableURLDetection property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "group",
+      "name": "Group",
+      "description": "Send Segment group events to Appcues.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Group ID",
+          "description": "The ID of the group to identify in Appcues.",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Group ID",
+                "description": "The ID of the group to identify in Appcues.",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Group traits",
+          "description": "Properties to associate with the group / account / company.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Group traits",
+                "description": "Properties to associate with the group / account / company.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Send Segment identify events to Appcues.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The ID of the user to identify in Appcues.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The ID of the user to identify in Appcues.",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User traits",
+          "description": "Properties to associate with the user.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User traits",
+                "description": "Properties to associate with the user.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "page",
+      "name": "Page",
+      "description": "Send Segment page events to Appcues.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": []
+    },
+    {
+      "slug": "track",
+      "name": "Track",
+      "description": "Send Segment track events to Appcues.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event to track in Appcues.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "Event Name",
+                "description": "The name of the event to track in Appcues.",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Properties to associate with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Properties to associate with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "page",
+      "name": "Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {},
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/appcues-web/metadata.json
+++ b/packages/browser-destinations/destinations/appcues-web/metadata.json
@@ -10,14 +10,17 @@
         "description": "Your Appcues Account ID.",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "region": {
         "label": "Region",
         "description": "Select the Appcues region for your account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "US",
@@ -28,15 +31,18 @@
             "value": "EU"
           }
         ],
-        "default": "US"
+        "default": "US",
+        "depends_on": null
       },
       "enableURLDetection": {
         "label": "Enable URL Detection",
         "description": "Enable or disable URL detection in Appcues. If enabled, page events should not be triggered manually using the page action.",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -50,7 +56,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event": {
           "label": "Event Name",
@@ -73,7 +79,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -96,7 +104,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -108,7 +118,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {}
     },
     "identify": {
@@ -119,7 +129,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -142,7 +152,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User traits",
@@ -165,7 +177,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -177,7 +191,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Group ID",
@@ -200,7 +214,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Group traits",
@@ -223,7 +239,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/braze/metadata.json
+++ b/packages/browser-destinations/destinations/braze/metadata.json
@@ -1,0 +1,1317 @@
+{
+  "name": "Braze Web Mode (Actions)",
+  "basicOptions": [
+    "sdkVersion",
+    "api_key",
+    "endpoint",
+    "allowCrawlerActivity",
+    "allowUserSuppliedJavascript",
+    "deferUntilIdentified",
+    "appVersion",
+    "contentSecurityNonce",
+    "devicePropertyAllowlist",
+    "disablePushTokenMaintenance",
+    "doNotLoadFontAwesome",
+    "enableLogging",
+    "enableSdkAuthentication",
+    "inAppMessageZIndex",
+    "localization",
+    "automaticallyDisplayMessages",
+    "manageServiceWorkerExternally",
+    "minimumIntervalBetweenTriggerActionsInSeconds",
+    "noCookies",
+    "openCardsInNewTab",
+    "openInAppMessagesInNewTab",
+    "requireExplicitInAppMessageDismissal",
+    "safariWebsitePushId",
+    "serviceWorkerLocation",
+    "sessionTimeoutInSeconds"
+  ],
+  "options": {
+    "sdkVersion": {
+      "tags": [],
+      "default": "6.1",
+      "description": "The version of the Braze SDK to use",
+      "encrypt": false,
+      "hidden": false,
+      "label": "SDK Version",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "3.1",
+          "label": "3.1",
+          "text": "3.1"
+        },
+        {
+          "value": "3.3",
+          "label": "3.3",
+          "text": "3.3"
+        },
+        {
+          "value": "3.5",
+          "label": "3.5",
+          "text": "3.5"
+        },
+        {
+          "value": "4.1",
+          "label": "4.1",
+          "text": "4.1"
+        },
+        {
+          "value": "4.6",
+          "label": "4.6",
+          "text": "4.6"
+        },
+        {
+          "value": "4.8",
+          "label": "4.8",
+          "text": "4.8"
+        },
+        {
+          "value": "4.10",
+          "label": "4.10",
+          "text": "4.10"
+        },
+        {
+          "value": "5.4",
+          "label": "5.4",
+          "text": "5.4"
+        },
+        {
+          "value": "5.7",
+          "label": "5.7",
+          "text": "5.7"
+        },
+        {
+          "value": "5.8",
+          "label": "5.8",
+          "text": "5.8"
+        },
+        {
+          "value": "5.9",
+          "label": "5.9",
+          "text": "5.9"
+        },
+        {
+          "value": "6.1",
+          "label": "6.1",
+          "text": "6.1"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The sdkVersion property is required."]],
+      "uIMetadata": null
+    },
+    "api_key": {
+      "tags": [],
+      "default": "",
+      "description": "Found in the Braze Dashboard under Manage Settings → Apps → Web",
+      "encrypt": true,
+      "hidden": false,
+      "label": "API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The api_key property is required."]],
+      "uIMetadata": null
+    },
+    "endpoint": {
+      "tags": [],
+      "default": "sdk.iad-01.braze.com",
+      "description": "Your Braze SDK endpoint. [See more details](https://www.braze.com/docs/user_guide/administrative/access_braze/sdk_endpoints/)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "SDK Endpoint",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "sdk.iad-01.braze.com",
+          "label": "US-01\t(https://dashboard-01.braze.com)",
+          "text": "US-01\t(https://dashboard-01.braze.com)"
+        },
+        {
+          "value": "sdk.iad-02.braze.com",
+          "label": "US-02\t(https://dashboard-02.braze.com)",
+          "text": "US-02\t(https://dashboard-02.braze.com)"
+        },
+        {
+          "value": "sdk.iad-03.braze.com",
+          "label": "US-03\t(https://dashboard-03.braze.com)",
+          "text": "US-03\t(https://dashboard-03.braze.com)"
+        },
+        {
+          "value": "sdk.iad-04.braze.com",
+          "label": "US-04\t(https://dashboard-04.braze.com)",
+          "text": "US-04\t(https://dashboard-04.braze.com)"
+        },
+        {
+          "value": "sdk.iad-05.braze.com",
+          "label": "US-05\t(https://dashboard-05.braze.com)",
+          "text": "US-05\t(https://dashboard-05.braze.com)"
+        },
+        {
+          "value": "sdk.iad-06.braze.com",
+          "label": "US-06\t(https://dashboard-06.braze.com)",
+          "text": "US-06\t(https://dashboard-06.braze.com)"
+        },
+        {
+          "value": "sdk.iad-07.braze.com",
+          "label": "US-07\t(https://dashboard-07.braze.com)",
+          "text": "US-07\t(https://dashboard-07.braze.com)"
+        },
+        {
+          "value": "sdk.iad-08.braze.com",
+          "label": "US-08\t(https://dashboard-08.braze.com)",
+          "text": "US-08\t(https://dashboard-08.braze.com)"
+        },
+        {
+          "value": "sdk.us-09.braze.com",
+          "label": "US-09\t(https://dashboard-09.braze.com)",
+          "text": "US-09\t(https://dashboard-09.braze.com)"
+        },
+        {
+          "value": "sdk.us-10.braze.com",
+          "label": "US-10 (https://dashboard-10.braze.com)",
+          "text": "US-10 (https://dashboard-10.braze.com)"
+        },
+        {
+          "value": "sdk.fra-01.braze.eu",
+          "label": "EU-01\t(https://dashboard-01.braze.eu)",
+          "text": "EU-01\t(https://dashboard-01.braze.eu)"
+        },
+        {
+          "value": "sdk.fra-02.braze.eu",
+          "label": "EU-02\t(https://dashboard-02.braze.eu)",
+          "text": "EU-02\t(https://dashboard-02.braze.eu)"
+        },
+        {
+          "value": "sdk.au-01.braze.com",
+          "label": "AU-01 (https://dashboard.au-01.braze.com)",
+          "text": "AU-01 (https://dashboard.au-01.braze.com)"
+        },
+        {
+          "value": "sdk.id-01.braze.com",
+          "label": "ID-01 (https://dashboard.id-01.braze.com)",
+          "text": "ID-01 (https://dashboard.id-01.braze.com)"
+        },
+        {
+          "value": "sdk.jp-01.braze.com",
+          "label": "JP-01 (https://dashboard.jp-01.braze.com)",
+          "text": "JP-01 (https://dashboard.jp-01.braze.com)"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The endpoint property is required."]],
+      "uIMetadata": null
+    },
+    "allowCrawlerActivity": {
+      "tags": [],
+      "default": false,
+      "description": "Allow Braze to log activity from crawlers. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Allow Crawler Activity",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "allowUserSuppliedJavascript": {
+      "tags": [],
+      "default": false,
+      "description": "To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Allow User Supplied Javascript",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "deferUntilIdentified": {
+      "tags": [],
+      "default": false,
+      "description": "If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Only Track Known Users",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "appVersion": {
+      "tags": [],
+      "default": "",
+      "description": "Version to which user events sent to Braze will be associated with. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "App Version",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "contentSecurityNonce": {
+      "tags": [],
+      "default": "",
+      "description": "Allows Braze to add the nonce to any <script> and <style> elements created by the SDK. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Content Security nonce",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "devicePropertyAllowlist": {
+      "tags": [],
+      "default": "",
+      "description": "By default, the Braze SDK automatically detects and collects all device properties in DeviceProperties. To override this behavior, provide an array of DeviceProperties. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Device Property Allow List",
+      "private": false,
+      "scope": "event_destination",
+      "type": "array",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disablePushTokenMaintenance": {
+      "tags": [],
+      "default": false,
+      "description": "By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Push Token Maintenance",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "doNotLoadFontAwesome": {
+      "tags": [],
+      "default": false,
+      "description": "Braze automatically loads FontAwesome 4.7.0 from the FontAwesome CDN. To disable this behavior set this option to true.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Do Not Load Font Awesome",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "enableLogging": {
+      "tags": [],
+      "default": false,
+      "description": "Set to true to enable logging by default",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Logging",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "enableSdkAuthentication": {
+      "tags": [],
+      "default": false,
+      "description": "Set to true to enable the SDK Authentication feature.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable SDK Authentication",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "inAppMessageZIndex": {
+      "tags": [],
+      "default": 0,
+      "description": "By default, the Braze SDK will show In-App Messages with a z-index of 1040 for the screen overlay, 1050 for the actual in-app message, and 1060 for the message's close button. Provide a value for this option to override these default z-indexes.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "In-App Message Z Index",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "localization": {
+      "tags": [],
+      "default": "en",
+      "description": "By default, any SDK-generated user-visible messages will be displayed in the user's browser language. Provide a value for this option to override that behavior and force a specific language. The value for this option should be a ISO 639-1 Language Code.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Localization",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "automaticallyDisplayMessages": {
+      "tags": [],
+      "default": true,
+      "description": "When this is enabled, all In-App Messages that a user is eligible for are automatically delivered to the user. If you'd like to register your own display subscribers or send soft push notifications to your users, make sure to disable this option.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Automatically Send In-App Messages",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "manageServiceWorkerExternally": {
+      "tags": [],
+      "default": false,
+      "description": "If you have your own service worker that you register and control the lifecycle of, set this option to true and the Braze SDK will not register or unregister a service worker. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Manage Service Worker Externally",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "minimumIntervalBetweenTriggerActionsInSeconds": {
+      "tags": [],
+      "default": 30,
+      "description": "Provide a value to override the default interval between trigger actions with a value of your own. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Minimum Interval Between Trigger Actions in Seconds",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "noCookies": {
+      "tags": [],
+      "default": false,
+      "description": "By default, the Braze SDK will store small amounts of data (user ids, session ids), in cookies. Pass true for this option to disable cookie storage and rely entirely on HTML 5 localStorage to identify users and sessions. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "No Cookies",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "openCardsInNewTab": {
+      "tags": [],
+      "default": false,
+      "description": "By default, links from Card objects load in the current tab or window. Set this option to true to make links from cards open in a new tab or window.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Open Cards In New Tab",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "openInAppMessagesInNewTab": {
+      "tags": [],
+      "default": false,
+      "description": "By default, links from in-app message clicks load in the current tab or a new tab as specified in the dashboard on a message-by-message basis. Set this option to true to force all links from in-app message clicks open in a new tab or window.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Open In-App Messages In New Tab",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "requireExplicitInAppMessageDismissal": {
+      "tags": [],
+      "default": false,
+      "description": "By default, when an in-app message is showing, pressing the escape button or a click on the greyed-out background of the page will dismiss the message. Set this option to true to prevent this behavior and require an explicit button click to dismiss messages.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Require Explicit In-App Message Dismissal",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "safariWebsitePushId": {
+      "tags": [],
+      "default": "",
+      "description": "If you support Safari push, you must specify this option with the website push ID that you provided to Apple when creating your Safari push certificate (starts with \"web\", e.g. \"web.com.example.domain\").",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Safari Website Push ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "serviceWorkerLocation": {
+      "tags": [],
+      "default": "",
+      "description": "By default, when registering users for web push notifications Braze will look for the required service worker file in the root directory of your web server at /service-worker.js. If you want to host your service worker at a different path on that server, provide a value for this option that is the absolute path to the file, e.g. /mycustompath/my-worker.js. VERY IMPORTANT: setting a value here limits the scope of push notifications on your site. For instance, in the above example, because the service  ,worker file is located within the /mycustompath/ directory, appboy.registerAppboyPushMessages MAY ONLY BE CALLED from web pages that start with http://yoursite.com/mycustompath/.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Service Worker Location",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "sessionTimeoutInSeconds": {
+      "tags": [],
+      "default": 1800,
+      "description": "By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Session Timeout in Seconds",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "debounce",
+      "name": "Debounce Middleware",
+      "description": "When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent. Debounce functionality requires a frontend client to work. Therefore, it cannot be used with server-side libraries or with Engage.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\" or type = \"group\"",
+      "fields": []
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Reports that the current user performed a custom named event.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event != \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The identifier for the event to track.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Event Name",
+                "description": "The identifier for the event to track.",
+                "type": "string"
+              }
+            },
+            "required": ["eventName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventProperties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Hash of properties for this event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventProperties": {
+                "title": "Event Properties",
+                "description": "Hash of properties for this event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPurchase",
+      "name": "Track Purchase",
+      "description": "Reports that the current user made an in-app purchase.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "purchaseProperties",
+          "type": "object",
+          "label": "Purchase Properties",
+          "description": "Hash of properties for this purchase. Keys are limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation. Values can be numeric, boolean, Date objects, strings 255 characters or shorter, or nested objects whose values can be numeric, boolean, Date objects, arrays, strings, or null. Total size of purchase properties cannot exceed 50KB.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "purchaseProperties": {
+                "title": "Purchase Properties",
+                "description": "Hash of properties for this purchase. Keys are limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation. Values can be numeric, boolean, Date objects, strings 255 characters or shorter, or nested objects whose values can be numeric, boolean, Date objects, arrays, strings, or null. Total size of purchase properties cannot exceed 50KB.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "products",
+          "type": "object",
+          "label": "Products",
+          "description": "List of products purchased by the user",
+          "defaultValue": {
+            "@path": "$.properties.products"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "products": {
+                "title": "Products",
+                "description": "List of products purchased by the user",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "product_id": {
+                      "title": "Product ID",
+                      "description": "A string identifier for the product purchased, e.g. an SKU. Value is limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "The price paid. Base units depend on the currency. As an example, USD should be reported as Dollars.Cents, whereas JPY should be reported as a whole number of Yen. All provided values will be rounded to two digits with toFixed(2)",
+                      "type": "number"
+                    },
+                    "currency": {
+                      "title": "Currency Code",
+                      "description": "Default USD. Currencies should be represented as an ISO 4217 currency code",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Default 1. The quantity of items purchased expressed as a whole number. Must be at least 1 and at most 100.",
+                      "type": "number"
+                    }
+                  },
+                  "required": ["product_id", "price"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "updateUserProfile",
+      "name": "Update User Profile",
+      "description": "Updates a users profile attributes in Braze",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\" or type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "external_id",
+          "type": "string",
+          "label": "External User ID",
+          "description": "The unique user identifier",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "external_id": {
+                "title": "External User ID",
+                "description": "The unique user identifier",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "country",
+          "type": "string",
+          "label": "Country",
+          "description": "The country code of the user",
+          "defaultValue": {
+            "@path": "$.context.location.country"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "country": {
+                "title": "Country",
+                "description": "The country code of the user",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "current_location",
+          "type": "object",
+          "label": "Current Location",
+          "description": "The user's current longitude/latitude.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "current_location": {
+                "title": "Current Location",
+                "description": "The user's current longitude/latitude.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "title": "Key",
+                    "type": "string"
+                  },
+                  "latitude": {
+                    "title": "Latitude",
+                    "type": "number"
+                  },
+                  "longitude": {
+                    "title": "Longitude",
+                    "type": "number"
+                  }
+                },
+                "required": ["key", "latitude", "longitude"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "custom_attributes",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "Sets a custom user attribute. This can be any key/value pair and is used to collect extra information about the user.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "custom_attributes": {
+                "title": "Custom Attributes",
+                "description": "Sets a custom user attribute. This can be any key/value pair and is used to collect extra information about the user.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "dob",
+          "type": "datetime",
+          "label": "Date of Birth",
+          "description": "The user's date of birth",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dob": {
+                "title": "Date of Birth",
+                "description": "The user's date of birth",
+                "type": ["string", "number", "null"],
+                "format": "date-like"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email",
+                "type": ["string", "null"],
+                "format": "email"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email_subscribe",
+          "type": "string",
+          "label": "Email Subscribe",
+          "description": "The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email_subscribe": {
+                "title": "Email Subscribe",
+                "description": "The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "first_name",
+          "type": "string",
+          "label": "First Name",
+          "description": "The user's first name",
+          "defaultValue": {
+            "@path": "$.traits.firstName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "first_name": {
+                "title": "First Name",
+                "description": "The user's first name",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "last_name",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The user's last name",
+          "defaultValue": {
+            "@path": "$.traits.lastName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "last_name": {
+                "title": "Last Name",
+                "description": "The user's last name",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "gender",
+          "type": "string",
+          "label": "Gender",
+          "description": "The user's gender: “M”, “F”, “O” (other), “N” (not applicable), “P” (prefer not to say) or nil (unknown).",
+          "defaultValue": {
+            "@path": "$.traits.gender"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "gender": {
+                "title": "Gender",
+                "description": "The user's gender: “M”, “F”, “O” (other), “N” (not applicable), “P” (prefer not to say) or nil (unknown).",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "home_city",
+          "type": "string",
+          "label": "Home City",
+          "description": "The user's home city.",
+          "defaultValue": {
+            "@path": "$.traits.address.city"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "home_city": {
+                "title": "Home City",
+                "description": "The user's home city.",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "image_url",
+          "type": "string",
+          "label": "Image URL",
+          "description": "URL of image to be associated with user profile.",
+          "defaultValue": {
+            "@path": "$.traits.avatar"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "image_url": {
+                "title": "Image URL",
+                "description": "URL of image to be associated with user profile.",
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "language",
+          "type": "string",
+          "label": "Language",
+          "description": "The user's preferred language.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "language": {
+                "title": "Language",
+                "description": "The user's preferred language.",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "phone",
+          "type": "string",
+          "label": "Phone Number",
+          "description": "The user's phone number",
+          "defaultValue": {
+            "@path": "$.traits.phone"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "phone": {
+                "title": "Phone Number",
+                "description": "The user's phone number",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "push_subscribe",
+          "type": "string",
+          "label": "Push Subscribe",
+          "description": "The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "push_subscribe": {
+                "title": "Push Subscribe",
+                "description": "The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "subscription_groups",
+          "type": "object",
+          "label": "Subscription Groups",
+          "description": "A list of subscription group IDs and states to set. Subscription group states can be either \"subscribed\" or \"unsubscribed\". Subscription Group IDs are found in the Braze dashboard.",
+          "defaultValue": {
+            "@path": "$.traits.braze_subscription_groups"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "subscription_groups": {
+                "title": "Subscription Groups",
+                "description": "A list of subscription group IDs and states to set. Subscription group states can be either \"subscribed\" or \"unsubscribed\". Subscription Group IDs are found in the Braze dashboard.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "subscription_group_id": {
+                      "title": "Subscription Group ID",
+                      "type": "string"
+                    },
+                    "subscription_group_state": {
+                      "title": "Subscription Group State",
+                      "type": "string",
+                      "enum": ["subscribed", "unsubscribed"]
+                    }
+                  },
+                  "required": ["subscription_group_id", "subscription_group_state"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "updateUserProfile",
+      "name": "Identify Calls",
+      "subscribe": "type = \"identify\" or type = \"group\"",
+      "mapping": {
+        "external_id": {
+          "@path": "$.userId"
+        },
+        "country": {
+          "@path": "$.context.location.country"
+        },
+        "custom_attributes": {
+          "@path": "$.traits"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "first_name": {
+          "@path": "$.traits.firstName"
+        },
+        "last_name": {
+          "@path": "$.traits.lastName"
+        },
+        "gender": {
+          "@path": "$.traits.gender"
+        },
+        "home_city": {
+          "@path": "$.traits.address.city"
+        },
+        "image_url": {
+          "@path": "$.traits.avatar"
+        },
+        "phone": {
+          "@path": "$.traits.phone"
+        },
+        "subscription_groups": {
+          "@path": "$.traits.braze_subscription_groups"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPurchase",
+      "name": "Order Completed calls",
+      "subscribe": "type = \"track\" and event = \"Order Completed\"",
+      "mapping": {
+        "purchaseProperties": {
+          "@path": "$.properties"
+        },
+        "products": {
+          "@path": "$.properties.products"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Calls",
+      "subscribe": "type = \"track\" and event != \"Order Completed\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        },
+        "eventProperties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/braze/metadata.json
+++ b/packages/browser-destinations/destinations/braze/metadata.json
@@ -10,6 +10,7 @@
         "description": "The version of the Braze SDK to use",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "value": "3.1",
@@ -60,21 +61,25 @@
             "label": "6.1"
           }
         ],
-        "default": "6.1"
+        "default": "6.1",
+        "depends_on": null
       },
       "api_key": {
         "label": "API Key",
         "description": "Found in the Braze Dashboard under Manage Settings → Apps → Web",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "endpoint": {
         "label": "SDK Endpoint",
         "description": "Your Braze SDK endpoint. [See more details](https://www.braze.com/docs/user_guide/administrative/access_braze/sdk_endpoints/)",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "US-01\t(https://dashboard-01.braze.com)",
@@ -137,183 +142,228 @@
             "value": "sdk.jp-01.braze.com"
           }
         ],
-        "default": "sdk.iad-01.braze.com"
+        "default": "sdk.iad-01.braze.com",
+        "depends_on": null
       },
       "allowCrawlerActivity": {
         "label": "Allow Crawler Activity",
         "description": "Allow Braze to log activity from crawlers. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "allowUserSuppliedJavascript": {
         "label": "Allow User Supplied Javascript",
         "description": "To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "deferUntilIdentified": {
         "label": "Only Track Known Users",
         "description": "If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "appVersion": {
         "label": "App Version",
         "description": "Version to which user events sent to Braze will be associated with. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "contentSecurityNonce": {
         "label": "Content Security nonce",
         "description": "Allows Braze to add the nonce to any <script> and <style> elements created by the SDK. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "devicePropertyAllowlist": {
         "label": "Device Property Allow List",
         "description": "By default, the Braze SDK automatically detects and collects all device properties in DeviceProperties. To override this behavior, provide an array of DeviceProperties. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "string",
         "required": false,
+        "multiple": true,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "disablePushTokenMaintenance": {
         "label": "Disable Push Token Maintenance",
         "description": "By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "doNotLoadFontAwesome": {
         "label": "Do Not Load Font Awesome",
         "description": "Braze automatically loads FontAwesome 4.7.0 from the FontAwesome CDN. To disable this behavior set this option to true.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "enableLogging": {
         "label": "Enable Logging",
         "description": "Set to true to enable logging by default",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "enableSdkAuthentication": {
         "label": "Enable SDK Authentication",
         "description": "Set to true to enable the SDK Authentication feature.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "inAppMessageZIndex": {
         "label": "In-App Message Z Index",
         "description": "By default, the Braze SDK will show In-App Messages with a z-index of 1040 for the screen overlay, 1050 for the actual in-app message, and 1060 for the message's close button. Provide a value for this option to override these default z-indexes.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "localization": {
         "label": "Localization",
         "description": "By default, any SDK-generated user-visible messages will be displayed in the user's browser language. Provide a value for this option to override that behavior and force a specific language. The value for this option should be a ISO 639-1 Language Code.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "en"
+        "default": "en",
+        "depends_on": null
       },
       "automaticallyDisplayMessages": {
         "label": "Automatically Send In-App Messages",
         "description": "When this is enabled, all In-App Messages that a user is eligible for are automatically delivered to the user. If you'd like to register your own display subscribers or send soft push notifications to your users, make sure to disable this option.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "manageServiceWorkerExternally": {
         "label": "Manage Service Worker Externally",
         "description": "If you have your own service worker that you register and control the lifecycle of, set this option to true and the Braze SDK will not register or unregister a service worker. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "minimumIntervalBetweenTriggerActionsInSeconds": {
         "label": "Minimum Interval Between Trigger Actions in Seconds",
         "description": "Provide a value to override the default interval between trigger actions with a value of your own. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 30
+        "default": 30,
+        "depends_on": null
       },
       "noCookies": {
         "label": "No Cookies",
         "description": "By default, the Braze SDK will store small amounts of data (user ids, session ids), in cookies. Pass true for this option to disable cookie storage and rely entirely on HTML 5 localStorage to identify users and sessions. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "openCardsInNewTab": {
         "label": "Open Cards In New Tab",
         "description": "By default, links from Card objects load in the current tab or window. Set this option to true to make links from cards open in a new tab or window.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "openInAppMessagesInNewTab": {
         "label": "Open In-App Messages In New Tab",
         "description": "By default, links from in-app message clicks load in the current tab or a new tab as specified in the dashboard on a message-by-message basis. Set this option to true to force all links from in-app message clicks open in a new tab or window.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "requireExplicitInAppMessageDismissal": {
         "label": "Require Explicit In-App Message Dismissal",
         "description": "By default, when an in-app message is showing, pressing the escape button or a click on the greyed-out background of the page will dismiss the message. Set this option to true to prevent this behavior and require an explicit button click to dismiss messages.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "safariWebsitePushId": {
         "label": "Safari Website Push ID",
         "description": "If you support Safari push, you must specify this option with the website push ID that you provided to Apple when creating your Safari push certificate (starts with \"web\", e.g. \"web.com.example.domain\").",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "serviceWorkerLocation": {
         "label": "Service Worker Location",
         "description": "By default, when registering users for web push notifications Braze will look for the required service worker file in the root directory of your web server at /service-worker.js. If you want to host your service worker at a different path on that server, provide a value for this option that is the absolute path to the file, e.g. /mycustompath/my-worker.js. VERY IMPORTANT: setting a value here limits the scope of push notifications on your site. For instance, in the above example, because the service  ,worker file is located within the /mycustompath/ directory, appboy.registerAppboyPushMessages MAY ONLY BE CALLED from web pages that start with http://yoursite.com/mycustompath/.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "sessionTimeoutInSeconds": {
         "label": "Session Timeout in Seconds",
         "description": "By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 1800
+        "default": 1800,
+        "depends_on": null
       }
     }
   },
@@ -327,7 +377,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "external_id": {
           "label": "External User ID",
@@ -350,7 +400,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "country": {
           "label": "Country",
@@ -373,7 +425,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "current_location": {
           "label": "Current Location",
@@ -405,7 +459,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "latitude": {
               "label": "Latitude",
@@ -425,7 +481,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "longitude": {
               "label": "Longitude",
@@ -445,7 +503,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -455,7 +515,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "custom_attributes": {
           "label": "Custom Attributes",
@@ -478,7 +540,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "dob": {
           "label": "Date of Birth",
@@ -499,7 +563,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -522,7 +588,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email_subscribe": {
           "label": "Email Subscribe",
@@ -543,7 +611,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "first_name": {
           "label": "First Name",
@@ -566,7 +636,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "last_name": {
           "label": "Last Name",
@@ -589,7 +661,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "gender": {
           "label": "Gender",
@@ -612,7 +686,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "home_city": {
           "label": "Home City",
@@ -635,7 +711,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "image_url": {
           "label": "Image URL",
@@ -658,7 +736,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "language": {
           "label": "Language",
@@ -679,7 +759,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "phone": {
           "label": "Phone Number",
@@ -702,7 +784,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "push_subscribe": {
           "label": "Push Subscribe",
@@ -723,7 +807,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "subscription_groups": {
           "label": "Subscription Groups",
@@ -757,7 +843,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "subscription_group_state": {
               "label": "Subscription Group State",
@@ -786,7 +874,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -796,7 +886,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -808,7 +900,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventName": {
           "label": "Event Name",
@@ -831,7 +923,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "eventProperties": {
           "label": "Event Properties",
@@ -854,7 +948,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -866,7 +962,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "purchaseProperties": {
           "label": "Purchase Properties",
@@ -889,7 +985,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "products": {
           "label": "Products",
@@ -924,7 +1022,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -945,7 +1045,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency Code",
@@ -966,7 +1068,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -987,7 +1091,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -997,7 +1103,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1009,7 +1117,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {}
     }
   },

--- a/packages/browser-destinations/destinations/braze/metadata.json
+++ b/packages/browser-destinations/destinations/braze/metadata.json
@@ -1,1252 +1,1023 @@
 {
+  "slug": "actions-braze-web",
   "name": "Braze Web Mode (Actions)",
-  "basicOptions": [
-    "sdkVersion",
-    "api_key",
-    "endpoint",
-    "allowCrawlerActivity",
-    "allowUserSuppliedJavascript",
-    "deferUntilIdentified",
-    "appVersion",
-    "contentSecurityNonce",
-    "devicePropertyAllowlist",
-    "disablePushTokenMaintenance",
-    "doNotLoadFontAwesome",
-    "enableLogging",
-    "enableSdkAuthentication",
-    "inAppMessageZIndex",
-    "localization",
-    "automaticallyDisplayMessages",
-    "manageServiceWorkerExternally",
-    "minimumIntervalBetweenTriggerActionsInSeconds",
-    "noCookies",
-    "openCardsInNewTab",
-    "openInAppMessagesInNewTab",
-    "requireExplicitInAppMessageDismissal",
-    "safariWebsitePushId",
-    "serviceWorkerLocation",
-    "sessionTimeoutInSeconds"
-  ],
-  "options": {
-    "sdkVersion": {
-      "tags": [],
-      "default": "6.1",
-      "description": "The version of the Braze SDK to use",
-      "encrypt": false,
-      "hidden": false,
-      "label": "SDK Version",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "3.1",
-          "label": "3.1",
-          "text": "3.1"
-        },
-        {
-          "value": "3.3",
-          "label": "3.3",
-          "text": "3.3"
-        },
-        {
-          "value": "3.5",
-          "label": "3.5",
-          "text": "3.5"
-        },
-        {
-          "value": "4.1",
-          "label": "4.1",
-          "text": "4.1"
-        },
-        {
-          "value": "4.6",
-          "label": "4.6",
-          "text": "4.6"
-        },
-        {
-          "value": "4.8",
-          "label": "4.8",
-          "text": "4.8"
-        },
-        {
-          "value": "4.10",
-          "label": "4.10",
-          "text": "4.10"
-        },
-        {
-          "value": "5.4",
-          "label": "5.4",
-          "text": "5.4"
-        },
-        {
-          "value": "5.7",
-          "label": "5.7",
-          "text": "5.7"
-        },
-        {
-          "value": "5.8",
-          "label": "5.8",
-          "text": "5.8"
-        },
-        {
-          "value": "5.9",
-          "label": "5.9",
-          "text": "5.9"
-        },
-        {
-          "value": "6.1",
-          "label": "6.1",
-          "text": "6.1"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The sdkVersion property is required."]],
-      "uIMetadata": null
-    },
-    "api_key": {
-      "tags": [],
-      "default": "",
-      "description": "Found in the Braze Dashboard under Manage Settings → Apps → Web",
-      "encrypt": true,
-      "hidden": false,
-      "label": "API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The api_key property is required."]],
-      "uIMetadata": null
-    },
-    "endpoint": {
-      "tags": [],
-      "default": "sdk.iad-01.braze.com",
-      "description": "Your Braze SDK endpoint. [See more details](https://www.braze.com/docs/user_guide/administrative/access_braze/sdk_endpoints/)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "SDK Endpoint",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "sdk.iad-01.braze.com",
-          "label": "US-01\t(https://dashboard-01.braze.com)",
-          "text": "US-01\t(https://dashboard-01.braze.com)"
-        },
-        {
-          "value": "sdk.iad-02.braze.com",
-          "label": "US-02\t(https://dashboard-02.braze.com)",
-          "text": "US-02\t(https://dashboard-02.braze.com)"
-        },
-        {
-          "value": "sdk.iad-03.braze.com",
-          "label": "US-03\t(https://dashboard-03.braze.com)",
-          "text": "US-03\t(https://dashboard-03.braze.com)"
-        },
-        {
-          "value": "sdk.iad-04.braze.com",
-          "label": "US-04\t(https://dashboard-04.braze.com)",
-          "text": "US-04\t(https://dashboard-04.braze.com)"
-        },
-        {
-          "value": "sdk.iad-05.braze.com",
-          "label": "US-05\t(https://dashboard-05.braze.com)",
-          "text": "US-05\t(https://dashboard-05.braze.com)"
-        },
-        {
-          "value": "sdk.iad-06.braze.com",
-          "label": "US-06\t(https://dashboard-06.braze.com)",
-          "text": "US-06\t(https://dashboard-06.braze.com)"
-        },
-        {
-          "value": "sdk.iad-07.braze.com",
-          "label": "US-07\t(https://dashboard-07.braze.com)",
-          "text": "US-07\t(https://dashboard-07.braze.com)"
-        },
-        {
-          "value": "sdk.iad-08.braze.com",
-          "label": "US-08\t(https://dashboard-08.braze.com)",
-          "text": "US-08\t(https://dashboard-08.braze.com)"
-        },
-        {
-          "value": "sdk.us-09.braze.com",
-          "label": "US-09\t(https://dashboard-09.braze.com)",
-          "text": "US-09\t(https://dashboard-09.braze.com)"
-        },
-        {
-          "value": "sdk.us-10.braze.com",
-          "label": "US-10 (https://dashboard-10.braze.com)",
-          "text": "US-10 (https://dashboard-10.braze.com)"
-        },
-        {
-          "value": "sdk.fra-01.braze.eu",
-          "label": "EU-01\t(https://dashboard-01.braze.eu)",
-          "text": "EU-01\t(https://dashboard-01.braze.eu)"
-        },
-        {
-          "value": "sdk.fra-02.braze.eu",
-          "label": "EU-02\t(https://dashboard-02.braze.eu)",
-          "text": "EU-02\t(https://dashboard-02.braze.eu)"
-        },
-        {
-          "value": "sdk.au-01.braze.com",
-          "label": "AU-01 (https://dashboard.au-01.braze.com)",
-          "text": "AU-01 (https://dashboard.au-01.braze.com)"
-        },
-        {
-          "value": "sdk.id-01.braze.com",
-          "label": "ID-01 (https://dashboard.id-01.braze.com)",
-          "text": "ID-01 (https://dashboard.id-01.braze.com)"
-        },
-        {
-          "value": "sdk.jp-01.braze.com",
-          "label": "JP-01 (https://dashboard.jp-01.braze.com)",
-          "text": "JP-01 (https://dashboard.jp-01.braze.com)"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The endpoint property is required."]],
-      "uIMetadata": null
-    },
-    "allowCrawlerActivity": {
-      "tags": [],
-      "default": false,
-      "description": "Allow Braze to log activity from crawlers. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Allow Crawler Activity",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "allowUserSuppliedJavascript": {
-      "tags": [],
-      "default": false,
-      "description": "To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Allow User Supplied Javascript",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "deferUntilIdentified": {
-      "tags": [],
-      "default": false,
-      "description": "If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Only Track Known Users",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "appVersion": {
-      "tags": [],
-      "default": "",
-      "description": "Version to which user events sent to Braze will be associated with. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "App Version",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "contentSecurityNonce": {
-      "tags": [],
-      "default": "",
-      "description": "Allows Braze to add the nonce to any <script> and <style> elements created by the SDK. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Content Security nonce",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "devicePropertyAllowlist": {
-      "tags": [],
-      "default": "",
-      "description": "By default, the Braze SDK automatically detects and collects all device properties in DeviceProperties. To override this behavior, provide an array of DeviceProperties. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Device Property Allow List",
-      "private": false,
-      "scope": "event_destination",
-      "type": "array",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disablePushTokenMaintenance": {
-      "tags": [],
-      "default": false,
-      "description": "By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Push Token Maintenance",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "doNotLoadFontAwesome": {
-      "tags": [],
-      "default": false,
-      "description": "Braze automatically loads FontAwesome 4.7.0 from the FontAwesome CDN. To disable this behavior set this option to true.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Do Not Load Font Awesome",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "enableLogging": {
-      "tags": [],
-      "default": false,
-      "description": "Set to true to enable logging by default",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Logging",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "enableSdkAuthentication": {
-      "tags": [],
-      "default": false,
-      "description": "Set to true to enable the SDK Authentication feature.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable SDK Authentication",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "inAppMessageZIndex": {
-      "tags": [],
-      "default": 0,
-      "description": "By default, the Braze SDK will show In-App Messages with a z-index of 1040 for the screen overlay, 1050 for the actual in-app message, and 1060 for the message's close button. Provide a value for this option to override these default z-indexes.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "In-App Message Z Index",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "localization": {
-      "tags": [],
-      "default": "en",
-      "description": "By default, any SDK-generated user-visible messages will be displayed in the user's browser language. Provide a value for this option to override that behavior and force a specific language. The value for this option should be a ISO 639-1 Language Code.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Localization",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "automaticallyDisplayMessages": {
-      "tags": [],
-      "default": true,
-      "description": "When this is enabled, all In-App Messages that a user is eligible for are automatically delivered to the user. If you'd like to register your own display subscribers or send soft push notifications to your users, make sure to disable this option.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Automatically Send In-App Messages",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "manageServiceWorkerExternally": {
-      "tags": [],
-      "default": false,
-      "description": "If you have your own service worker that you register and control the lifecycle of, set this option to true and the Braze SDK will not register or unregister a service worker. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Manage Service Worker Externally",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "minimumIntervalBetweenTriggerActionsInSeconds": {
-      "tags": [],
-      "default": 30,
-      "description": "Provide a value to override the default interval between trigger actions with a value of your own. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Minimum Interval Between Trigger Actions in Seconds",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "noCookies": {
-      "tags": [],
-      "default": false,
-      "description": "By default, the Braze SDK will store small amounts of data (user ids, session ids), in cookies. Pass true for this option to disable cookie storage and rely entirely on HTML 5 localStorage to identify users and sessions. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "No Cookies",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "openCardsInNewTab": {
-      "tags": [],
-      "default": false,
-      "description": "By default, links from Card objects load in the current tab or window. Set this option to true to make links from cards open in a new tab or window.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Open Cards In New Tab",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "openInAppMessagesInNewTab": {
-      "tags": [],
-      "default": false,
-      "description": "By default, links from in-app message clicks load in the current tab or a new tab as specified in the dashboard on a message-by-message basis. Set this option to true to force all links from in-app message clicks open in a new tab or window.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Open In-App Messages In New Tab",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "requireExplicitInAppMessageDismissal": {
-      "tags": [],
-      "default": false,
-      "description": "By default, when an in-app message is showing, pressing the escape button or a click on the greyed-out background of the page will dismiss the message. Set this option to true to prevent this behavior and require an explicit button click to dismiss messages.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Require Explicit In-App Message Dismissal",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "safariWebsitePushId": {
-      "tags": [],
-      "default": "",
-      "description": "If you support Safari push, you must specify this option with the website push ID that you provided to Apple when creating your Safari push certificate (starts with \"web\", e.g. \"web.com.example.domain\").",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Safari Website Push ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "serviceWorkerLocation": {
-      "tags": [],
-      "default": "",
-      "description": "By default, when registering users for web push notifications Braze will look for the required service worker file in the root directory of your web server at /service-worker.js. If you want to host your service worker at a different path on that server, provide a value for this option that is the absolute path to the file, e.g. /mycustompath/my-worker.js. VERY IMPORTANT: setting a value here limits the scope of push notifications on your site. For instance, in the above example, because the service  ,worker file is located within the /mycustompath/ directory, appboy.registerAppboyPushMessages MAY ONLY BE CALLED from web pages that start with http://yoursite.com/mycustompath/.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Service Worker Location",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "sessionTimeoutInSeconds": {
-      "tags": [],
-      "default": 1800,
-      "description": "By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Session Timeout in Seconds",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "sdkVersion": {
+        "label": "SDK Version",
+        "description": "The version of the Braze SDK to use",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "value": "3.1",
+            "label": "3.1"
+          },
+          {
+            "value": "3.3",
+            "label": "3.3"
+          },
+          {
+            "value": "3.5",
+            "label": "3.5"
+          },
+          {
+            "value": "4.1",
+            "label": "4.1"
+          },
+          {
+            "value": "4.6",
+            "label": "4.6"
+          },
+          {
+            "value": "4.8",
+            "label": "4.8"
+          },
+          {
+            "value": "4.10",
+            "label": "4.10"
+          },
+          {
+            "value": "5.4",
+            "label": "5.4"
+          },
+          {
+            "value": "5.7",
+            "label": "5.7"
+          },
+          {
+            "value": "5.8",
+            "label": "5.8"
+          },
+          {
+            "value": "5.9",
+            "label": "5.9"
+          },
+          {
+            "value": "6.1",
+            "label": "6.1"
+          }
+        ],
+        "default": "6.1"
+      },
+      "api_key": {
+        "label": "API Key",
+        "description": "Found in the Braze Dashboard under Manage Settings → Apps → Web",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "endpoint": {
+        "label": "SDK Endpoint",
+        "description": "Your Braze SDK endpoint. [See more details](https://www.braze.com/docs/user_guide/administrative/access_braze/sdk_endpoints/)",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "label": "US-01\t(https://dashboard-01.braze.com)",
+            "value": "sdk.iad-01.braze.com"
+          },
+          {
+            "label": "US-02\t(https://dashboard-02.braze.com)",
+            "value": "sdk.iad-02.braze.com"
+          },
+          {
+            "label": "US-03\t(https://dashboard-03.braze.com)",
+            "value": "sdk.iad-03.braze.com"
+          },
+          {
+            "label": "US-04\t(https://dashboard-04.braze.com)",
+            "value": "sdk.iad-04.braze.com"
+          },
+          {
+            "label": "US-05\t(https://dashboard-05.braze.com)",
+            "value": "sdk.iad-05.braze.com"
+          },
+          {
+            "label": "US-06\t(https://dashboard-06.braze.com)",
+            "value": "sdk.iad-06.braze.com"
+          },
+          {
+            "label": "US-07\t(https://dashboard-07.braze.com)",
+            "value": "sdk.iad-07.braze.com"
+          },
+          {
+            "label": "US-08\t(https://dashboard-08.braze.com)",
+            "value": "sdk.iad-08.braze.com"
+          },
+          {
+            "label": "US-09\t(https://dashboard-09.braze.com)",
+            "value": "sdk.us-09.braze.com"
+          },
+          {
+            "label": "US-10 (https://dashboard-10.braze.com)",
+            "value": "sdk.us-10.braze.com"
+          },
+          {
+            "label": "EU-01\t(https://dashboard-01.braze.eu)",
+            "value": "sdk.fra-01.braze.eu"
+          },
+          {
+            "label": "EU-02\t(https://dashboard-02.braze.eu)",
+            "value": "sdk.fra-02.braze.eu"
+          },
+          {
+            "label": "AU-01 (https://dashboard.au-01.braze.com)",
+            "value": "sdk.au-01.braze.com"
+          },
+          {
+            "label": "ID-01 (https://dashboard.id-01.braze.com)",
+            "value": "sdk.id-01.braze.com"
+          },
+          {
+            "label": "JP-01 (https://dashboard.jp-01.braze.com)",
+            "value": "sdk.jp-01.braze.com"
+          }
+        ],
+        "default": "sdk.iad-01.braze.com"
+      },
+      "allowCrawlerActivity": {
+        "label": "Allow Crawler Activity",
+        "description": "Allow Braze to log activity from crawlers. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "allowUserSuppliedJavascript": {
+        "label": "Allow User Supplied Javascript",
+        "description": "To indicate that you trust the Braze dashboard users to write non-malicious Javascript click actions, set this property to true. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "deferUntilIdentified": {
+        "label": "Only Track Known Users",
+        "description": "If enabled, this setting delays initialization of the Braze SDK until the user has been identified. When enabled, events for anonymous users will no longer be sent to Braze.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "appVersion": {
+        "label": "App Version",
+        "description": "Version to which user events sent to Braze will be associated with. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "contentSecurityNonce": {
+        "label": "Content Security nonce",
+        "description": "Allows Braze to add the nonce to any <script> and <style> elements created by the SDK. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "devicePropertyAllowlist": {
+        "label": "Device Property Allow List",
+        "description": "By default, the Braze SDK automatically detects and collects all device properties in DeviceProperties. To override this behavior, provide an array of DeviceProperties. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "disablePushTokenMaintenance": {
+        "label": "Disable Push Token Maintenance",
+        "description": "By default, users who have already granted web push permission will sync their push token with the Braze backend automatically on new session to ensure deliverability. To disable this behavior, set this option to true",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "doNotLoadFontAwesome": {
+        "label": "Do Not Load Font Awesome",
+        "description": "Braze automatically loads FontAwesome 4.7.0 from the FontAwesome CDN. To disable this behavior set this option to true.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "enableLogging": {
+        "label": "Enable Logging",
+        "description": "Set to true to enable logging by default",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "enableSdkAuthentication": {
+        "label": "Enable SDK Authentication",
+        "description": "Set to true to enable the SDK Authentication feature.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "inAppMessageZIndex": {
+        "label": "In-App Message Z Index",
+        "description": "By default, the Braze SDK will show In-App Messages with a z-index of 1040 for the screen overlay, 1050 for the actual in-app message, and 1060 for the message's close button. Provide a value for this option to override these default z-indexes.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "localization": {
+        "label": "Localization",
+        "description": "By default, any SDK-generated user-visible messages will be displayed in the user's browser language. Provide a value for this option to override that behavior and force a specific language. The value for this option should be a ISO 639-1 Language Code.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "en"
+      },
+      "automaticallyDisplayMessages": {
+        "label": "Automatically Send In-App Messages",
+        "description": "When this is enabled, all In-App Messages that a user is eligible for are automatically delivered to the user. If you'd like to register your own display subscribers or send soft push notifications to your users, make sure to disable this option.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "manageServiceWorkerExternally": {
+        "label": "Manage Service Worker Externally",
+        "description": "If you have your own service worker that you register and control the lifecycle of, set this option to true and the Braze SDK will not register or unregister a service worker. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "minimumIntervalBetweenTriggerActionsInSeconds": {
+        "label": "Minimum Interval Between Trigger Actions in Seconds",
+        "description": "Provide a value to override the default interval between trigger actions with a value of your own. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 30
+      },
+      "noCookies": {
+        "label": "No Cookies",
+        "description": "By default, the Braze SDK will store small amounts of data (user ids, session ids), in cookies. Pass true for this option to disable cookie storage and rely entirely on HTML 5 localStorage to identify users and sessions. [See more details](https://js.appboycdn.com/web-sdk/latest/doc/modules/appboy.html#initializationoptions)",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "openCardsInNewTab": {
+        "label": "Open Cards In New Tab",
+        "description": "By default, links from Card objects load in the current tab or window. Set this option to true to make links from cards open in a new tab or window.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "openInAppMessagesInNewTab": {
+        "label": "Open In-App Messages In New Tab",
+        "description": "By default, links from in-app message clicks load in the current tab or a new tab as specified in the dashboard on a message-by-message basis. Set this option to true to force all links from in-app message clicks open in a new tab or window.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "requireExplicitInAppMessageDismissal": {
+        "label": "Require Explicit In-App Message Dismissal",
+        "description": "By default, when an in-app message is showing, pressing the escape button or a click on the greyed-out background of the page will dismiss the message. Set this option to true to prevent this behavior and require an explicit button click to dismiss messages.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "safariWebsitePushId": {
+        "label": "Safari Website Push ID",
+        "description": "If you support Safari push, you must specify this option with the website push ID that you provided to Apple when creating your Safari push certificate (starts with \"web\", e.g. \"web.com.example.domain\").",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "serviceWorkerLocation": {
+        "label": "Service Worker Location",
+        "description": "By default, when registering users for web push notifications Braze will look for the required service worker file in the root directory of your web server at /service-worker.js. If you want to host your service worker at a different path on that server, provide a value for this option that is the absolute path to the file, e.g. /mycustompath/my-worker.js. VERY IMPORTANT: setting a value here limits the scope of push notifications on your site. For instance, in the above example, because the service  ,worker file is located within the /mycustompath/ directory, appboy.registerAppboyPushMessages MAY ONLY BE CALLED from web pages that start with http://yoursite.com/mycustompath/.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "sessionTimeoutInSeconds": {
+        "label": "Session Timeout in Seconds",
+        "description": "By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 1800
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "debounce",
-      "name": "Debounce Middleware",
-      "description": "When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent. Debounce functionality requires a frontend client to work. Therefore, it cannot be used with server-side libraries or with Engage.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\" or type = \"group\"",
-      "fields": []
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Reports that the current user performed a custom named event.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event != \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "eventName",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The identifier for the event to track.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Event Name",
-                "description": "The identifier for the event to track.",
-                "type": "string"
-              }
-            },
-            "required": ["eventName"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "eventProperties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Hash of properties for this event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventProperties": {
-                "title": "Event Properties",
-                "description": "Hash of properties for this event.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackPurchase",
-      "name": "Track Purchase",
-      "description": "Reports that the current user made an in-app purchase.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "purchaseProperties",
-          "type": "object",
-          "label": "Purchase Properties",
-          "description": "Hash of properties for this purchase. Keys are limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation. Values can be numeric, boolean, Date objects, strings 255 characters or shorter, or nested objects whose values can be numeric, boolean, Date objects, arrays, strings, or null. Total size of purchase properties cannot exceed 50KB.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "purchaseProperties": {
-                "title": "Purchase Properties",
-                "description": "Hash of properties for this purchase. Keys are limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation. Values can be numeric, boolean, Date objects, strings 255 characters or shorter, or nested objects whose values can be numeric, boolean, Date objects, arrays, strings, or null. Total size of purchase properties cannot exceed 50KB.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "products",
-          "type": "object",
-          "label": "Products",
-          "description": "List of products purchased by the user",
-          "defaultValue": {
-            "@path": "$.properties.products"
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "products": {
-                "title": "Products",
-                "description": "List of products purchased by the user",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "product_id": {
-                      "title": "Product ID",
-                      "description": "A string identifier for the product purchased, e.g. an SKU. Value is limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "The price paid. Base units depend on the currency. As an example, USD should be reported as Dollars.Cents, whereas JPY should be reported as a whole number of Yen. All provided values will be rounded to two digits with toFixed(2)",
-                      "type": "number"
-                    },
-                    "currency": {
-                      "title": "Currency Code",
-                      "description": "Default USD. Currencies should be represented as an ISO 4217 currency code",
-                      "type": "string"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Default 1. The quantity of items purchased expressed as a whole number. Must be at least 1 and at most 100.",
-                      "type": "number"
-                    }
-                  },
-                  "required": ["product_id", "price"]
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "updateUserProfile",
-      "name": "Update User Profile",
+  "audienceConfig": null,
+  "actions": {
+    "updateUserProfile": {
+      "title": "Update User Profile",
       "description": "Updates a users profile attributes in Braze",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\" or type = \"group\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\" or type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "external_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "external_id": {
           "label": "External User ID",
           "description": "The unique user identifier",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "external_id": {
-                "title": "External User ID",
-                "description": "The unique user identifier",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "country",
-          "type": "string",
+        "country": {
           "label": "Country",
           "description": "The country code of the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.context.location.country"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "title": "Country",
-                "description": "The country code of the user",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "current_location",
-          "type": "object",
+        "current_location": {
           "label": "Current Location",
           "description": "The user's current longitude/latitude.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "current_location": {
-                "title": "Current Location",
-                "description": "The user's current longitude/latitude.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "key": {
-                    "title": "Key",
-                    "type": "string"
-                  },
-                  "latitude": {
-                    "title": "Latitude",
-                    "type": "number"
-                  },
-                  "longitude": {
-                    "title": "Longitude",
-                    "type": "number"
-                  }
-                },
-                "required": ["key", "latitude", "longitude"]
-              }
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "key": {
+              "label": "Key",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "latitude": {
+              "label": "Latitude",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "longitude": {
+              "label": "Longitude",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "custom_attributes",
-          "type": "object",
+        "custom_attributes": {
           "label": "Custom Attributes",
           "description": "Sets a custom user attribute. This can be any key/value pair and is used to collect extra information about the user.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_attributes": {
-                "title": "Custom Attributes",
-                "description": "Sets a custom user attribute. This can be any key/value pair and is used to collect extra information about the user.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "dob",
-          "type": "datetime",
+        "dob": {
           "label": "Date of Birth",
           "description": "The user's date of birth",
+          "type": "datetime",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "dob": {
-                "title": "Date of Birth",
-                "description": "The user's date of birth",
-                "type": ["string", "number", "null"],
-                "format": "date-like"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.email"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email",
-                "type": ["string", "null"],
-                "format": "email"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email_subscribe",
-          "type": "string",
+        "email_subscribe": {
           "label": "Email Subscribe",
           "description": "The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email_subscribe": {
-                "title": "Email Subscribe",
-                "description": "The user's email subscription preference: “opted_in” (explicitly registered to receive email messages), “unsubscribed” (explicitly opted out of email messages), and “subscribed” (neither opted in nor out).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "first_name",
-          "type": "string",
+        "first_name": {
           "label": "First Name",
           "description": "The user's first name",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.firstName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "first_name": {
-                "title": "First Name",
-                "description": "The user's first name",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "last_name",
-          "type": "string",
+        "last_name": {
           "label": "Last Name",
           "description": "The user's last name",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.lastName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "last_name": {
-                "title": "Last Name",
-                "description": "The user's last name",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "gender",
-          "type": "string",
+        "gender": {
           "label": "Gender",
           "description": "The user's gender: “M”, “F”, “O” (other), “N” (not applicable), “P” (prefer not to say) or nil (unknown).",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.gender"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "gender": {
-                "title": "Gender",
-                "description": "The user's gender: “M”, “F”, “O” (other), “N” (not applicable), “P” (prefer not to say) or nil (unknown).",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "home_city",
-          "type": "string",
+        "home_city": {
           "label": "Home City",
           "description": "The user's home city.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.city"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "home_city": {
-                "title": "Home City",
-                "description": "The user's home city.",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "image_url",
-          "type": "string",
+        "image_url": {
           "label": "Image URL",
           "description": "URL of image to be associated with user profile.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.avatar"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "image_url": {
-                "title": "Image URL",
-                "description": "URL of image to be associated with user profile.",
-                "type": "string",
-                "format": "uri"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "language",
-          "type": "string",
+        "language": {
           "label": "Language",
           "description": "The user's preferred language.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "language": {
-                "title": "Language",
-                "description": "The user's preferred language.",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "phone",
-          "type": "string",
+        "phone": {
           "label": "Phone Number",
           "description": "The user's phone number",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.phone"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "phone": {
-                "title": "Phone Number",
-                "description": "The user's phone number",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "push_subscribe",
-          "type": "string",
+        "push_subscribe": {
           "label": "Push Subscribe",
           "description": "The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "push_subscribe": {
-                "title": "Push Subscribe",
-                "description": "The user's push subscription preference: “opted_in” (explicitly registered to receive push messages), “unsubscribed” (explicitly opted out of push messages), and “subscribed” (neither opted in nor out).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "subscription_groups",
-          "type": "object",
+        "subscription_groups": {
           "label": "Subscription Groups",
           "description": "A list of subscription group IDs and states to set. Subscription group states can be either \"subscribed\" or \"unsubscribed\". Subscription Group IDs are found in the Braze dashboard.",
-          "defaultValue": {
-            "@path": "$.traits.braze_subscription_groups"
-          },
+          "type": "object",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "subscription_groups": {
-                "title": "Subscription Groups",
-                "description": "A list of subscription group IDs and states to set. Subscription group states can be either \"subscribed\" or \"unsubscribed\". Subscription Group IDs are found in the Braze dashboard.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "subscription_group_id": {
-                      "title": "Subscription Group ID",
-                      "type": "string"
-                    },
-                    "subscription_group_state": {
-                      "title": "Subscription Group State",
-                      "type": "string",
-                      "enum": ["subscribed", "unsubscribed"]
-                    }
-                  },
-                  "required": ["subscription_group_id", "subscription_group_state"]
-                }
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.braze_subscription_groups"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "subscription_group_id": {
+              "label": "Subscription Group ID",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "subscription_group_state": {
+              "label": "Subscription Group State",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "subscribed",
+                  "label": "Subscribed"
+                },
+                {
+                  "value": "unsubscribed",
+                  "label": "Unsubscribed"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Reports that the current user performed a custom named event.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event != \"Order Completed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventName": {
+          "label": "Event Name",
+          "description": "The identifier for the event to track.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "eventProperties": {
+          "label": "Event Properties",
+          "description": "Hash of properties for this event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "trackPurchase": {
+      "title": "Track Purchase",
+      "description": "Reports that the current user made an in-app purchase.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Order Completed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "purchaseProperties": {
+          "label": "Purchase Properties",
+          "description": "Hash of properties for this purchase. Keys are limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation. Values can be numeric, boolean, Date objects, strings 255 characters or shorter, or nested objects whose values can be numeric, boolean, Date objects, arrays, strings, or null. Total size of purchase properties cannot exceed 50KB.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "products": {
+          "label": "Products",
+          "description": "List of products purchased by the user",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.products"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "product_id": {
+              "label": "Product ID",
+              "description": "A string identifier for the product purchased, e.g. an SKU. Value is limited to 255 characters in length, cannot begin with a $, and can only contain alphanumeric characters and punctuation.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "The price paid. Base units depend on the currency. As an example, USD should be reported as Dollars.Cents, whereas JPY should be reported as a whole number of Yen. All provided values will be rounded to two digits with toFixed(2)",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency Code",
+              "description": "Default USD. Currencies should be represented as an ISO 4217 currency code",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Default 1. The quantity of items purchased expressed as a whole number. Must be at least 1 and at most 100.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "debounce": {
+      "title": "Debounce Middleware",
+      "description": "When enabled, it ensures that only events where at least one changed trait value are sent to Braze, and events with duplicate traits are not sent. Debounce functionality requires a frontend client to work. Therefore, it cannot be used with server-side libraries or with Engage.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\" or type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {}
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "updateUserProfile",
       "name": "Identify Calls",
+      "type": "automatic",
+      "partnerAction": "updateUserProfile",
       "subscribe": "type = \"identify\" or type = \"group\"",
       "mapping": {
         "external_id": {
@@ -1283,11 +1054,12 @@
           "@path": "$.traits.braze_subscription_groups"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackPurchase",
       "name": "Order Completed calls",
+      "type": "automatic",
+      "partnerAction": "trackPurchase",
       "subscribe": "type = \"track\" and event = \"Order Completed\"",
       "mapping": {
         "purchaseProperties": {
@@ -1297,11 +1069,12 @@
           "@path": "$.properties.products"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackEvent",
       "name": "Track Calls",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\" and event != \"Order Completed\"",
       "mapping": {
         "eventName": {
@@ -1311,7 +1084,7 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/bucket/metadata.json
+++ b/packages/browser-destinations/destinations/bucket/metadata.json
@@ -1,309 +1,264 @@
 {
+  "slug": "bucket-web",
   "name": "Bucket Web (Actions)",
+  "mode": "device",
   "description": "Loads the Bucket browser SDK, maps identify(), group() and track() events and enables LiveSatisfaction connections",
-  "basicOptions": ["trackingKey"],
-  "options": {
-    "trackingKey": {
-      "tags": [],
-      "default": "",
-      "description": "The publishable key for your Bucket environment, found on the tracking page on app.bucket.co.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Publishable Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The trackingKey property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "trackingKey": {
+        "label": "Publishable Key",
+        "description": "The publishable key for your Bucket environment, found on the tracking page on app.bucket.co.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "group",
-      "name": "Identify Company",
-      "description": "Creates or updates a Company in Bucket and associates the user with it",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
-          "label": "Company ID",
-          "description": "Unique identifier for the company",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Company ID",
-                "description": "Unique identifier for the company",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "Unique identifier for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Company Attributes",
-          "description": "Additional information to associate with the Company in Bucket",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Company Attributes",
-                "description": "Additional information to associate with the Company in Bucket",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Creates or updates a user profile in Bucket. Also initializes Live Satisfaction",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "Unique identifier for the User",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the User",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "User Attributes",
           "description": "Additional information to associate with the User in Bucket",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Attributes",
-                "description": "Additional information to associate with the User in Bucket",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Map a Segment track() event to Bucket",
+    "group": {
+      "title": "Identify Company",
+      "description": "Creates or updates a Company in Bucket and associates the user with it",
       "platform": "web",
+      "defaultSubscription": "type = \"group\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "groupId": {
+          "label": "Company ID",
+          "description": "Unique identifier for the company",
           "type": "string",
-          "label": "Event name",
-          "description": "The event name",
-          "defaultValue": {
-            "@path": "$.event"
-          },
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event name",
-                "description": "The event name",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "Unique identifier for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
+        "traits": {
+          "label": "Company Attributes",
+          "description": "Additional information to associate with the Company in Bucket",
           "type": "object",
-          "label": "Event Properties",
-          "description": "Object containing the properties of the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Object containing the properties of the event",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Map a Segment track() event to Bucket",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Event name",
+          "description": "The event name",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "group",
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Group",
+      "type": "automatic",
+      "partnerAction": "group",
       "subscribe": "type = \"group\"",
       "mapping": {
         "groupId": {
@@ -316,25 +271,12 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "userId": {
-          "@path": "$.userId"
-        },
-        "traits": {
-          "@path": "$.traits"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -347,7 +289,7 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/bucket/metadata.json
+++ b/packages/browser-destinations/destinations/bucket/metadata.json
@@ -11,8 +11,10 @@
         "description": "The publishable key for your Bucket environment, found on the tracking page on app.bucket.co.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -26,7 +28,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -49,7 +51,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Attributes",
@@ -72,7 +76,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -84,7 +90,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Company ID",
@@ -107,7 +113,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -130,7 +138,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Company Attributes",
@@ -153,7 +163,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -165,7 +177,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event name",
@@ -188,7 +200,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -211,7 +225,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -234,7 +250,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/bucket/metadata.json
+++ b/packages/browser-destinations/destinations/bucket/metadata.json
@@ -1,0 +1,353 @@
+{
+  "name": "Bucket Web (Actions)",
+  "description": "Loads the Bucket browser SDK, maps identify(), group() and track() events and enables LiveSatisfaction connections",
+  "basicOptions": ["trackingKey"],
+  "options": {
+    "trackingKey": {
+      "tags": [],
+      "default": "",
+      "description": "The publishable key for your Bucket environment, found on the tracking page on app.bucket.co.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Publishable Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The trackingKey property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "group",
+      "name": "Identify Company",
+      "description": "Creates or updates a Company in Bucket and associates the user with it",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Company ID",
+          "description": "Unique identifier for the company",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Company ID",
+                "description": "Unique identifier for the company",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Company Attributes",
+          "description": "Additional information to associate with the Company in Bucket",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Company Attributes",
+                "description": "Additional information to associate with the Company in Bucket",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Creates or updates a user profile in Bucket. Also initializes Live Satisfaction",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the User",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the User",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Attributes",
+          "description": "Additional information to associate with the User in Bucket",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Attributes",
+                "description": "Additional information to associate with the User in Bucket",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Map a Segment track() event to Bucket",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event name",
+          "description": "The event name",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event name",
+                "description": "The event name",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Object containing the properties of the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "group",
+      "name": "Group",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/cdpresolution/metadata.json
+++ b/packages/browser-destinations/destinations/cdpresolution/metadata.json
@@ -11,21 +11,25 @@
         "description": "Client identifier provided by CDP Resolution [Hashed Account ID]",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "endpoint": {
         "label": "CDP Resolution Endpoint",
         "description": "Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "CDPRes-Endpoint",
             "value": "https://a.usbrowserspeed.com/cs"
           }
         ],
-        "default": "https://a.usbrowserspeed.com/cs"
+        "default": "https://a.usbrowserspeed.com/cs",
+        "depends_on": null
       }
     }
   },
@@ -39,7 +43,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "anonymousId": {
           "label": "Anonymous Id",
@@ -62,7 +66,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/cdpresolution/metadata.json
+++ b/packages/browser-destinations/destinations/cdpresolution/metadata.json
@@ -1,0 +1,108 @@
+{
+  "name": "CDP Resolution",
+  "description": "Sync Segment user identifier to CDP Resolution",
+  "basicOptions": ["clientIdentifier", "endpoint"],
+  "options": {
+    "clientIdentifier": {
+      "tags": [],
+      "default": "",
+      "description": "Client identifier provided by CDP Resolution [Hashed Account ID]",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Client Identifier",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The clientIdentifier property is required."]],
+      "uIMetadata": null
+    },
+    "endpoint": {
+      "tags": [],
+      "default": "https://a.usbrowserspeed.com/cs",
+      "description": "Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "CDP Resolution Endpoint",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "https://a.usbrowserspeed.com/cs",
+          "label": "CDPRes-Endpoint",
+          "text": "CDPRes-Endpoint"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The endpoint property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "sync",
+      "name": "Sync Anonymous ID",
+      "description": "Sync Anonymous ID to CDP Resolution.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\" or type = \"track\" or type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous Id",
+          "description": "The anonymous id of the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous Id",
+                "description": "The anonymous id of the user",
+                "type": "string"
+              }
+            },
+            "required": ["anonymousId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "sync",
+      "name": "Sync Anonymous ID",
+      "subscribe": "type = \"page\" or type = \"track\" or type = \"identify\"",
+      "mapping": {
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/cdpresolution/metadata.json
+++ b/packages/browser-destinations/destinations/cdpresolution/metadata.json
@@ -1,108 +1,84 @@
 {
+  "slug": "actions-cdpresolution",
   "name": "CDP Resolution",
+  "mode": "device",
   "description": "Sync Segment user identifier to CDP Resolution",
-  "basicOptions": ["clientIdentifier", "endpoint"],
-  "options": {
-    "clientIdentifier": {
-      "tags": [],
-      "default": "",
-      "description": "Client identifier provided by CDP Resolution [Hashed Account ID]",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Client Identifier",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The clientIdentifier property is required."]],
-      "uIMetadata": null
-    },
-    "endpoint": {
-      "tags": [],
-      "default": "https://a.usbrowserspeed.com/cs",
-      "description": "Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "CDP Resolution Endpoint",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "https://a.usbrowserspeed.com/cs",
-          "label": "CDPRes-Endpoint",
-          "text": "CDPRes-Endpoint"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The endpoint property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "clientIdentifier": {
+        "label": "Client Identifier",
+        "description": "Client identifier provided by CDP Resolution [Hashed Account ID]",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "endpoint": {
+        "label": "CDP Resolution Endpoint",
+        "description": "Identity resolution endpoint. [CDP Resolution documentation](https://www.cdpresolution.com/docs/)",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "label": "CDPRes-Endpoint",
+            "value": "https://a.usbrowserspeed.com/cs"
+          }
+        ],
+        "default": "https://a.usbrowserspeed.com/cs"
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "sync",
-      "name": "Sync Anonymous ID",
+  "audienceConfig": null,
+  "actions": {
+    "sync": {
+      "title": "Sync Anonymous ID",
       "description": "Sync Anonymous ID to CDP Resolution.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\" or type = \"track\" or type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\" or type = \"track\" or type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "anonymousId": {
           "label": "Anonymous Id",
           "description": "The anonymous id of the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous Id",
-                "description": "The anonymous id of the user",
-                "type": "string"
-              }
-            },
-            "required": ["anonymousId"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "sync",
       "name": "Sync Anonymous ID",
+      "type": "automatic",
+      "partnerAction": "sync",
       "subscribe": "type = \"page\" or type = \"track\" or type = \"identify\"",
       "mapping": {
         "anonymousId": {
           "@path": "$.anonymousId"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/cj/metadata.json
+++ b/packages/browser-destinations/destinations/cj/metadata.json
@@ -11,16 +11,20 @@
         "description": "Your Commission Junction Tag ID.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "actionTrackerId": {
         "label": "Action Tracker ID",
         "description": "Used with the \"Order\" Action only. Can be overridden at the Action level. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -34,7 +38,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -57,7 +61,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "enterpriseId": {
           "label": "Enterprise ID",
@@ -78,7 +84,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "pageType": {
           "label": "Page Type",
@@ -164,7 +172,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "referringChannel": {
           "label": "Referring Channel",
@@ -210,7 +220,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "cartSubtotal": {
           "label": "Cart Subtotal",
@@ -231,7 +243,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Items",
@@ -282,7 +296,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemId": {
               "label": "Item ID",
@@ -303,7 +319,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -324,7 +342,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -345,7 +365,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -355,7 +377,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -367,7 +391,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "verticalType": {
           "label": "Vertical type",
@@ -401,7 +425,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -424,7 +450,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "enterpriseId": {
           "label": "Enterprise ID",
@@ -445,7 +473,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "pageType": {
           "label": "Page Type",
@@ -471,7 +501,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "emailHash": {
           "label": "Email address",
@@ -504,7 +536,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "orderId": {
           "label": "Order ID",
@@ -527,7 +561,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "actionTrackerId": {
           "label": "Action Tracker ID",
@@ -548,7 +584,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -571,7 +609,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "amount": {
           "label": "Amount",
@@ -594,7 +634,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "discount": {
           "label": "Discount",
@@ -617,7 +659,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -640,7 +684,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "cjeventOrderCookieName": {
           "label": "CJ Event Order Cookie Name",
@@ -661,7 +707,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Items",
@@ -712,7 +760,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemId": {
               "label": "Item ID",
@@ -733,7 +783,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -754,7 +806,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -775,7 +829,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -785,7 +841,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "allVerticals": {
           "label": "All Vertical Parameters",
@@ -984,7 +1042,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "brand": {
               "label": "Brand",
@@ -1005,7 +1065,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "brandId": {
               "label": "Brand ID",
@@ -1026,7 +1088,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "businessUnit": {
               "label": "Business Unit",
@@ -1047,7 +1111,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "campaignId": {
               "label": "Campaign ID",
@@ -1068,7 +1134,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "campaignName": {
               "label": "Campaign Name",
@@ -1089,7 +1157,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "category": {
               "label": "Category",
@@ -1110,7 +1180,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "class": {
               "label": "Class",
@@ -1131,7 +1203,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "confirmationNumber": {
               "label": "Confirmation Number",
@@ -1152,7 +1226,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "couponDiscount": {
               "label": "Coupon Discount",
@@ -1173,7 +1249,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "couponType": {
               "label": "Coupon Type",
@@ -1207,7 +1285,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "customerCountry": {
               "label": "Customer Country",
@@ -1228,7 +1308,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "customerSegment": {
               "label": "Customer Segment",
@@ -1249,7 +1331,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "customerStatus": {
               "label": "Customer Status",
@@ -1283,7 +1367,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "customerType": {
               "label": "Customer Type",
@@ -1304,7 +1390,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "delivery": {
               "label": "Delivery",
@@ -1354,7 +1442,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "description": {
               "label": "Description",
@@ -1375,7 +1465,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "duration": {
               "label": "Duration",
@@ -1396,7 +1488,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "endDateTime": {
               "label": "End Date Time",
@@ -1417,7 +1511,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "genre": {
               "label": "Genre",
@@ -1438,7 +1534,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemId": {
               "label": "Item ID",
@@ -1459,7 +1557,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemName": {
               "label": "Item Name",
@@ -1480,7 +1580,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemType": {
               "label": "Item Type",
@@ -1501,7 +1603,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "lifestage": {
               "label": "Lifestage",
@@ -1522,7 +1626,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location": {
               "label": "Location",
@@ -1543,7 +1649,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "loyaltyEarned": {
               "label": "Loyalty Earned",
@@ -1564,7 +1672,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "loyaltyFirstTimeSignup": {
               "label": "Loyalty First Time Signup",
@@ -1594,7 +1704,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "loyaltyLevel": {
               "label": "Loyalty Level",
@@ -1615,7 +1727,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "loyaltyRedeemed": {
               "label": "Loyalty Redeemed",
@@ -1636,7 +1750,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "loyaltyStatus": {
               "label": "Loyalty Status",
@@ -1666,7 +1782,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "margin": {
               "label": "Margin",
@@ -1687,7 +1805,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "marketingChannel": {
               "label": "Marketing Channel",
@@ -1733,7 +1853,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "noCancellation": {
               "label": "No Cancellation",
@@ -1763,7 +1885,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "orderSubtotal": {
               "label": "Order Subtotal",
@@ -1784,7 +1908,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "paymentMethod": {
               "label": "Payment Method",
@@ -1842,7 +1968,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "paymentModel": {
               "label": "Payment Model",
@@ -1863,7 +1991,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "platformId": {
               "label": "Platform ID",
@@ -1884,7 +2014,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "pointOfSale": {
               "label": "Point of Sale",
@@ -1942,7 +2074,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "preorder": {
               "label": "Preorder",
@@ -1972,7 +2106,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "prepaid": {
               "label": "Prepaid",
@@ -2002,7 +2138,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotion": {
               "label": "Promotion",
@@ -2023,7 +2161,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionAmount": {
               "label": "Promotion Amount",
@@ -2044,7 +2184,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionConditionThreshold": {
               "label": "Promotion Condition Threshold",
@@ -2065,7 +2207,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionConditionType": {
               "label": "Promotion Condition Type",
@@ -2123,7 +2267,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionEnds": {
               "label": "Promotion Ends",
@@ -2144,7 +2290,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionStarts": {
               "label": "Promotion Starts",
@@ -2165,7 +2313,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotionType": {
               "label": "Promotion Type",
@@ -2215,7 +2365,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -2236,7 +2388,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "rating": {
               "label": "Rating",
@@ -2257,7 +2411,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "serviceType": {
               "label": "Service Type",
@@ -2351,7 +2507,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "startDateTime": {
               "label": "Start Date Time",
@@ -2372,7 +2530,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "subscriptionFee": {
               "label": "Subscription Fee",
@@ -2393,7 +2553,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "subscriptionLength": {
               "label": "Subscription Length",
@@ -2414,7 +2576,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "taxAmount": {
               "label": "Tax Amount",
@@ -2435,7 +2599,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "taxType": {
               "label": "Tax Type",
@@ -2501,7 +2667,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "upsell": {
               "label": "Upsell",
@@ -2531,7 +2699,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2541,7 +2711,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "travelVerticals": {
           "label": "Travel Vertical Parameters",
@@ -2674,7 +2846,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "bookingStatus": {
               "label": "Booking Status",
@@ -2695,7 +2869,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "bookingValuePostTax": {
               "label": "Booking Value Post-Tax",
@@ -2716,7 +2892,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "bookingValuePreTax": {
               "label": "Booking Value Pre-Tax",
@@ -2737,7 +2915,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "carOptions": {
               "label": "Car Options",
@@ -2758,7 +2938,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "class": {
               "label": "Class",
@@ -2880,7 +3062,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "cruiseType": {
               "label": "Cruise Type",
@@ -2901,7 +3085,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "destinationCity": {
               "label": "Destination City",
@@ -2922,7 +3108,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "destinationCountry": {
               "label": "Destination Country",
@@ -2943,7 +3131,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "destinationState": {
               "label": "Destination State",
@@ -2964,7 +3154,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "domestic": {
               "label": "Domestic Travel",
@@ -2994,7 +3186,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "dropoffIata": {
               "label": "Dropoff IATA",
@@ -3015,7 +3209,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "dropoffId": {
               "label": "Dropoff ID",
@@ -3036,7 +3232,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "flightFareType": {
               "label": "Flight Fare Type",
@@ -3057,7 +3255,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "flightOptions": {
               "label": "Flight Options",
@@ -3078,7 +3278,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "flightType": {
               "label": "Flight Type",
@@ -3112,7 +3314,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "flyerMiles": {
               "label": "Flyer Miles",
@@ -3133,7 +3337,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "guests": {
               "label": "Guests",
@@ -3154,7 +3360,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "iata": {
               "label": "IATA",
@@ -3175,7 +3383,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itineraryId": {
               "label": "Itinerary ID",
@@ -3196,7 +3406,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "minimumStayDuration": {
               "label": "Minimum Stay Duration",
@@ -3217,7 +3429,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "originCity": {
               "label": "Origin City",
@@ -3238,7 +3452,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "originCountry": {
               "label": "Origin Country",
@@ -3259,7 +3475,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "originState": {
               "label": "Origin State",
@@ -3280,7 +3498,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "paidAtBookingPostTax": {
               "label": "Paid at Booking (Post-Tax)",
@@ -3301,7 +3521,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "paidAtBookingPreTax": {
               "label": "Paid at Booking (Pre-Tax)",
@@ -3322,7 +3544,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "pickupIata": {
               "label": "Pickup IATA",
@@ -3343,7 +3567,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "pickupId": {
               "label": "Pickup ID",
@@ -3364,7 +3590,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "port": {
               "label": "Port",
@@ -3385,7 +3613,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "roomType": {
               "label": "Room Type",
@@ -3406,7 +3636,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "rooms": {
               "label": "Rooms",
@@ -3427,7 +3659,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "shipName": {
               "label": "Ship Name",
@@ -3448,7 +3682,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "travelType": {
               "label": "Travel Type",
@@ -3514,7 +3750,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -3524,7 +3762,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "financeVerticals": {
           "label": "Finance Verticals",
@@ -3618,7 +3858,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "applicationStatus": {
               "label": "Application Status",
@@ -3664,7 +3906,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "apr": {
               "label": "APR",
@@ -3685,7 +3929,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "aprTransfer": {
               "label": "APR Transfer",
@@ -3706,7 +3952,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "aprTransferTime": {
               "label": "APR Transfer Time",
@@ -3727,7 +3975,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "cardCategory": {
               "label": "Card Category",
@@ -3797,7 +4047,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "cashAdvanceFee": {
               "label": "Cash Advance Fee",
@@ -3818,7 +4070,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "contractLength": {
               "label": "Contract Length",
@@ -3839,7 +4093,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "contractType": {
               "label": "Contract Type",
@@ -3860,7 +4116,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creditReport": {
               "label": "Credit Report",
@@ -3894,7 +4152,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creditLine": {
               "label": "Credit Line",
@@ -3915,7 +4175,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creditQuality": {
               "label": "Credit Quality",
@@ -3957,7 +4219,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fundedAmount": {
               "label": "Funded Amount",
@@ -3978,7 +4242,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fundedCurrency": {
               "label": "Funded Currency",
@@ -3999,7 +4265,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "introductoryApr": {
               "label": "Introductory APR",
@@ -4020,7 +4288,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "introductoryAprTime": {
               "label": "Introductory APR Time",
@@ -4041,7 +4311,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "minimumBalance": {
               "label": "Minimum Balance",
@@ -4062,7 +4334,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "minimumDeposit": {
               "label": "Minimum Deposit",
@@ -4083,7 +4357,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "prequalify": {
               "label": "Prequalify",
@@ -4113,7 +4389,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "transferFee": {
               "label": "Transfer Fee",
@@ -4134,7 +4412,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -4144,7 +4424,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "networkServicesVerticals": {
           "label": "Network Services Verticals",
@@ -4190,7 +4472,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "applicationStatus": {
               "label": "Application Status",
@@ -4236,7 +4520,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "contractLength": {
               "label": "Contract Length",
@@ -4257,7 +4543,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "contractType": {
               "label": "Contract Type",
@@ -4278,7 +4566,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -4288,7 +4578,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/cj/metadata.json
+++ b/packages/browser-destinations/destinations/cj/metadata.json
@@ -1,0 +1,2048 @@
+{
+  "name": "Commission Junction (Actions)",
+  "description": "The Commission Junction Browser Destination allows you to install the CJ Javascript pixel onto your site and pass mapped Segment events and metadata to CJ.",
+  "basicOptions": ["tagId", "actionTrackerId"],
+  "options": {
+    "tagId": {
+      "tags": [],
+      "default": "",
+      "description": "Your Commission Junction Tag ID.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Tag ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The tagId property is required."]],
+      "uIMetadata": null
+    },
+    "actionTrackerId": {
+      "tags": [],
+      "default": "",
+      "description": "Used with the \"Order\" Action only. Can be overridden at the Action level. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Action Tracker ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "order",
+      "name": "Order",
+      "description": "Send order data to CJ.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "event = \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "verticalType",
+          "type": "string",
+          "label": "Vertical type",
+          "description": "Send additional data relating to travel, finance network services",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Travel Vertical",
+              "value": "travel"
+            },
+            {
+              "label": "Network Vertical",
+              "value": "network"
+            },
+            {
+              "label": "Finance Vertical",
+              "value": "finance"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "verticalType": {
+                "title": "Vertical type",
+                "description": "Send additional data relating to travel, finance network services",
+                "type": "string",
+                "enum": ["travel", "network", "finance"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique ID assigned by you to the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique ID assigned by you to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "enterpriseId",
+          "type": "number",
+          "label": "Enterprise ID",
+          "description": "Your CJ Enterprise ID.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enterpriseId": {
+                "title": "Enterprise ID",
+                "description": "Your CJ Enterprise ID.",
+                "type": "number"
+              }
+            },
+            "required": ["enterpriseId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "pageType",
+          "type": "string",
+          "label": "Page Type",
+          "description": "Page type to be sent to CJ. Must be set to \"conversionConfirmation\" for order events.",
+          "defaultValue": "conversionConfirmation",
+          "required": true,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Conversion Confirmation",
+              "value": "conversionConfirmation"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pageType": {
+                "title": "Page Type",
+                "description": "Page type to be sent to CJ. Must be set to \"conversionConfirmation\" for order events.",
+                "type": "string",
+                "enum": ["conversionConfirmation"]
+              }
+            },
+            "required": ["pageType"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "emailHash",
+          "type": "string",
+          "label": "Email address",
+          "description": "Segment will ensure the email address is hashed before sending to CJ.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "emailHash": {
+                "title": "Email address",
+                "description": "Segment will ensure the email address is hashed before sending to CJ.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "orderId",
+          "type": "string",
+          "label": "Order ID",
+          "description": "The orderId is a unique identifier, such as an order identifier or invoice number, which must be populated for each order.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "orderId": {
+                "title": "Order ID",
+                "description": "The orderId is a unique identifier, such as an order identifier or invoice number, which must be populated for each order.",
+                "type": "string"
+              }
+            },
+            "required": ["orderId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "actionTrackerId",
+          "type": "string",
+          "label": "Action Tracker ID",
+          "description": "Required if not specified in Settings. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "actionTrackerId": {
+                "title": "Action Tracker ID",
+                "description": "Required if not specified in Settings. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "The currency of the order, e.g. USD, EUR.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "The currency of the order, e.g. USD, EUR.",
+                "type": "string"
+              }
+            },
+            "required": ["currency"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "amount",
+          "type": "number",
+          "label": "Amount",
+          "description": "The total amount of the order. This should exclude shipping or tax.",
+          "defaultValue": {
+            "@path": "$.properties.total"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "title": "Amount",
+                "description": "The total amount of the order. This should exclude shipping or tax.",
+                "type": "number"
+              }
+            },
+            "required": ["amount"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "discount",
+          "type": "number",
+          "label": "Discount",
+          "description": "The total discount applied to the order.",
+          "defaultValue": {
+            "@path": "$.properties.discount"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "discount": {
+                "title": "Discount",
+                "description": "The total discount applied to the order.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "The coupon code applied to the order.",
+          "defaultValue": {
+            "@path": "$.properties.coupon"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "The coupon code applied to the order.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "cjeventOrderCookieName",
+          "type": "string",
+          "label": "CJ Event Order Cookie Name",
+          "description": "The name of the cookie that stores the CJ Event ID. This is required whenever the advertiser uses their own cookie to store the Event ID.",
+          "defaultValue": "cje",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "cjeventOrderCookieName": {
+                "title": "CJ Event Order Cookie Name",
+                "description": "The name of the cookie that stores the CJ Event ID. This is required whenever the advertiser uses their own cookie to store the Event ID.",
+                "type": "string"
+              }
+            },
+            "required": ["cjeventOrderCookieName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Items",
+          "description": "The items to be sent to CJ.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "unitPrice": {
+                  "@path": "$.price"
+                },
+                "itemId": {
+                  "@path": "$.id"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                },
+                "discount": {
+                  "@path": "$.discount"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "items": {
+                "title": "Items",
+                "description": "The items to be sent to CJ.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "unitPrice": {
+                      "title": "Unit Price",
+                      "description": "the price of the item before tax and discount.",
+                      "type": "number"
+                    },
+                    "itemId": {
+                      "title": "Item ID",
+                      "description": "The item sku.",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "The quantity of the item.",
+                      "type": "number"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "The discount applied to the item.",
+                      "type": "number"
+                    }
+                  },
+                  "required": ["unitPrice", "itemId", "quantity"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "allVerticals",
+          "type": "object",
+          "label": "All Vertical Parameters",
+          "description": "This field is used to pass additional parameters specific to the vertical. All vertical parameters listed below can be utilized regardless of the account's vertical.",
+          "defaultValue": {
+            "brand": {
+              "@path": "$.properties.brand"
+            },
+            "brandId": {
+              "@path": "$.properties.brand_id"
+            },
+            "businessUnit": {
+              "@path": "$.properties.business_unit"
+            },
+            "campaignId": {
+              "@path": "$.properties.campaign_id"
+            },
+            "campaignName": {
+              "@path": "$.properties.campaign_name"
+            },
+            "category": {
+              "@path": "$.properties.category"
+            },
+            "class": {
+              "@path": "$.properties.class"
+            },
+            "confirmationNumber": {
+              "@path": "$.properties.confirmation_number"
+            },
+            "couponDiscount": {
+              "@path": "$.properties.coupon_discount"
+            },
+            "couponType": {
+              "@path": "$.properties.coupon_type"
+            },
+            "customerCountry": {
+              "@path": "$.context.locale"
+            },
+            "customerSegment": {
+              "@path": "$.properties.customer_segment"
+            },
+            "customerStatus": {
+              "@path": "$.properties.customer_status"
+            },
+            "customerType": {
+              "@path": "$.properties.customer_type"
+            },
+            "delivery": {
+              "@path": "$.properties.delivery"
+            },
+            "description": {
+              "@path": "$.properties.description"
+            },
+            "duration": {
+              "@path": "$.properties.duration"
+            },
+            "endDateTime": {
+              "@path": "$.properties.end_date_time"
+            },
+            "genre": {
+              "@path": "$.properties.genre"
+            },
+            "itemId": {
+              "@path": "$.properties.item_id"
+            },
+            "itemName": {
+              "@path": "$.properties.item_name"
+            },
+            "itemType": {
+              "@path": "$.properties.item_type"
+            },
+            "lifestage": {
+              "@path": "$.properties.lifestage"
+            },
+            "location": {
+              "@path": "$.properties.location"
+            },
+            "loyaltyEarned": {
+              "@path": "$.properties.loyalty_earned"
+            },
+            "loyaltyFirstTimeSignup": {
+              "@path": "$.properties.loyalty_first_time_signup"
+            },
+            "loyaltyLevel": {
+              "@path": "$.properties.loyalty_level"
+            },
+            "loyaltyRedeemed": {
+              "@path": "$.properties.loyalty_redeemed"
+            },
+            "loyaltyStatus": {
+              "@path": "$.properties.loyalty_status"
+            },
+            "margin": {
+              "@path": "$.properties.margin"
+            },
+            "marketingChannel": {
+              "@path": "$.properties.marketing_channel"
+            },
+            "noCancellation": {
+              "@path": "$.properties.no_cancellation"
+            },
+            "orderSubtotal": {
+              "@path": "$.properties.order_subtotal"
+            },
+            "paymentMethod": {
+              "@path": "$.properties.payment_method"
+            },
+            "paymentModel": {
+              "@path": "$.properties.payment_model"
+            },
+            "platformId": {
+              "@path": "$.properties.platform_id"
+            },
+            "pointOfSale": {
+              "@path": "$.properties.point_of_sale"
+            },
+            "preorder": {
+              "@path": "$.properties.preorder"
+            },
+            "prepaid": {
+              "@path": "$.properties.prepaid"
+            },
+            "promotion": {
+              "@path": "$.properties.promotion"
+            },
+            "promotionAmount": {
+              "@path": "$.properties.promotion_amount"
+            },
+            "promotionConditionThreshold": {
+              "@path": "$.properties.promotion_condition_threshold"
+            },
+            "promotionConditionType": {
+              "@path": "$.properties.promotion_condition_type"
+            },
+            "promotionEnds": {
+              "@path": "$.properties.promotion_ends"
+            },
+            "promotionStarts": {
+              "@path": "$.properties.promotion_starts"
+            },
+            "promotionType": {
+              "@path": "$.properties.promotion_type"
+            },
+            "quantity": {
+              "@path": "$.properties.quantity"
+            },
+            "rating": {
+              "@path": "$.properties.rating"
+            },
+            "serviceType": {
+              "@path": "$.properties.service_type"
+            },
+            "startDateTime": {
+              "@path": "$.properties.start_date_time"
+            },
+            "subscriptionFee": {
+              "@path": "$.properties.subscription_fee"
+            },
+            "subscriptionLength": {
+              "@path": "$.properties.subscription_length"
+            },
+            "taxAmount": {
+              "@path": "$.properties.tax_amount"
+            },
+            "taxType": {
+              "@path": "$.properties.tax_type"
+            },
+            "upsell": {
+              "@path": "$.properties.upsell"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "allVerticals": {
+                "title": "All Vertical Parameters",
+                "description": "This field is used to pass additional parameters specific to the vertical. All vertical parameters listed below can be utilized regardless of the account's vertical.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "ancillarySpend": {
+                    "title": "Ancillary Spend",
+                    "description": "Ancillary spend at the time of transaction, but not commissionable.",
+                    "type": "number"
+                  },
+                  "brand": {
+                    "title": "Brand",
+                    "description": "Brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
+                    "type": "string"
+                  },
+                  "brandId": {
+                    "title": "Brand ID",
+                    "description": "Identifier of brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
+                    "type": "string"
+                  },
+                  "businessUnit": {
+                    "title": "Business Unit",
+                    "description": "Identifies the business unit the customer purchased through. If there are multiple items with different business units, one business unit must be designated for the order.",
+                    "type": "string"
+                  },
+                  "campaignId": {
+                    "title": "Campaign ID",
+                    "description": "Marketing campaign id.",
+                    "type": "string"
+                  },
+                  "campaignName": {
+                    "title": "Campaign Name",
+                    "description": "Marketing campaign name.",
+                    "type": "string"
+                  },
+                  "category": {
+                    "title": "Category",
+                    "description": "Category of items purchased. If there are multiple items with different categories, one category must be designated for the order.",
+                    "type": "string"
+                  },
+                  "class": {
+                    "title": "Class",
+                    "description": "Class of item.",
+                    "type": "string"
+                  },
+                  "confirmationNumber": {
+                    "title": "Confirmation Number",
+                    "description": "Confirmation Number",
+                    "type": "number"
+                  },
+                  "couponDiscount": {
+                    "title": "Coupon Discount",
+                    "description": "The value (amount of discount) of the coupon. This should be the number linked to the \"coupon_type\" parameter",
+                    "type": "number"
+                  },
+                  "couponType": {
+                    "title": "Coupon Type",
+                    "description": "The type of coupon used in the order. This should be the number linked to the \"coupon_discount\" parameter.",
+                    "type": "string",
+                    "enum": ["percent", "dollars", "added_value"]
+                  },
+                  "customerCountry": {
+                    "title": "Customer Country",
+                    "description": "The customer's country. ISO 3166-1 alpha 2 country code, eg. US, UK, AU, FR.",
+                    "type": "string"
+                  },
+                  "customerSegment": {
+                    "title": "Customer Segment",
+                    "description": "Advertiser-specific customer segment definition.",
+                    "type": "string"
+                  },
+                  "customerStatus": {
+                    "title": "Customer Status",
+                    "description": "The status of the customer, e.g. new, returning.",
+                    "type": "string",
+                    "enum": ["New", "Lapsed", "Return"]
+                  },
+                  "customerType": {
+                    "title": "Customer Type",
+                    "description": "Indicates the type of individual making the purchase as someone representing a group.",
+                    "type": "string"
+                  },
+                  "delivery": {
+                    "title": "Delivery",
+                    "description": "The delivery method used for the order.",
+                    "type": "string",
+                    "enum": ["IN_STORE", "PICK_UP", "RECURRING", "STANDARD", "NEXT_DAY", "DIGITAL", "EXPRESS"]
+                  },
+                  "description": {
+                    "title": "Description",
+                    "description": "Description of the product.",
+                    "type": "string"
+                  },
+                  "duration": {
+                    "title": "Duration",
+                    "description": "Duration in days.",
+                    "type": "number"
+                  },
+                  "endDateTime": {
+                    "title": "End Date Time",
+                    "description": "End date and time of the order, in ISO 8601 format.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "genre": {
+                    "title": "Genre",
+                    "description": "Product genre. If there are multiple items with different genres, one genre must be designated for the order.",
+                    "type": "string"
+                  },
+                  "itemId": {
+                    "title": "Item ID",
+                    "description": "Id for the item. (Simple Actions Only).",
+                    "type": "string"
+                  },
+                  "itemName": {
+                    "title": "Item Name",
+                    "description": "Advertiser assigned item name.",
+                    "type": "string"
+                  },
+                  "itemType": {
+                    "title": "Item Type",
+                    "description": "Advertiser assigned item type.",
+                    "type": "string"
+                  },
+                  "lifestage": {
+                    "title": "Lifestage",
+                    "description": "Advertiser assigned general demographic.",
+                    "type": "string"
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Identifies the customer location if different from customerCountry.",
+                    "type": "string"
+                  },
+                  "loyaltyEarned": {
+                    "title": "Loyalty Earned",
+                    "description": "Loyalty points earned on the transaction.",
+                    "type": "number"
+                  },
+                  "loyaltyFirstTimeSignup": {
+                    "title": "Loyalty First Time Signup",
+                    "description": "Indicates whether this order coincided with the consumer joining the loyalty program.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "loyaltyLevel": {
+                    "title": "Loyalty Level",
+                    "description": "Indicates the level of the customer's loyalty status.",
+                    "type": "string"
+                  },
+                  "loyaltyRedeemed": {
+                    "title": "Loyalty Redeemed",
+                    "description": "Loyalty points used during the transaction.",
+                    "type": "number"
+                  },
+                  "loyaltyStatus": {
+                    "title": "Loyalty Status",
+                    "description": "Indicates if the customer is a loyalty member.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "margin": {
+                    "title": "Margin",
+                    "description": "Margin on total order. Can be a dollar value or a custom indicator.",
+                    "type": "string"
+                  },
+                  "marketingChannel": {
+                    "title": "Marketing Channel",
+                    "description": "Advertiser-defined marketing channel assigned to this transaction.",
+                    "type": "string",
+                    "enum": ["affiliate", "display", "social", "search", "email", "direct navigation"]
+                  },
+                  "noCancellation": {
+                    "title": "No Cancellation",
+                    "description": "Indicates if the purchase has a no cancellation policy. \"Yes\" means there is a \"no cancellation\" policy, \"no\" means there is no policy.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "orderSubtotal": {
+                    "title": "Order Subtotal",
+                    "description": "Subtotal for order.",
+                    "type": "number"
+                  },
+                  "paymentMethod": {
+                    "title": "Payment Method",
+                    "description": "Method of payment.",
+                    "type": "string",
+                    "enum": [
+                      "credit_debit_card",
+                      "direct_debit",
+                      "EFTPOS",
+                      "online_payments",
+                      "cash",
+                      "check",
+                      "money_order",
+                      "gift_card_voucher",
+                      "digital_currency"
+                    ]
+                  },
+                  "paymentModel": {
+                    "title": "Payment Model",
+                    "description": "Model of payment used; advertiser-specific.",
+                    "type": "string"
+                  },
+                  "platformId": {
+                    "title": "Platform ID",
+                    "description": "Device platform customer is using.",
+                    "type": "string"
+                  },
+                  "pointOfSale": {
+                    "title": "Point of Sale",
+                    "description": "Point of sale for the transaction.",
+                    "type": "string",
+                    "enum": [
+                      "AMAZON",
+                      "CALL_CENTER",
+                      "CAR_RENTAL",
+                      "CATALOG",
+                      "HOTEL_LOCATION",
+                      "INTERNET",
+                      "IN_APP",
+                      "OUTLET",
+                      "RETAIL_STORE"
+                    ]
+                  },
+                  "preorder": {
+                    "title": "Preorder",
+                    "description": "Indicates if the purchase was made prior to the item becoming available.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "prepaid": {
+                    "title": "Prepaid",
+                    "description": "Indicates if the payment was made in advance of the item's consumption.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "promotion": {
+                    "title": "Promotion",
+                    "description": "Promotion applied. If multiple, must be comma-separated.",
+                    "type": "string"
+                  },
+                  "promotionAmount": {
+                    "title": "Promotion Amount",
+                    "description": "The numeric value associated with the promotion.",
+                    "type": "number"
+                  },
+                  "promotionConditionThreshold": {
+                    "title": "Promotion Condition Threshold",
+                    "description": "Threshold needed to qualify for the promotion.",
+                    "type": "number"
+                  },
+                  "promotionConditionType": {
+                    "title": "Promotion Condition Type",
+                    "description": "Type of conditions applied to the promotion.",
+                    "type": "string",
+                    "enum": [
+                      "BRAND_CARD_SIGNUP_SPECIFIC",
+                      "BRAND_CARD_SPECIFIC",
+                      "LOCATION_SPECIFIC",
+                      "MEMBERSHIP_REQUIRED",
+                      "LOYALTY_REQUIRED",
+                      "EMAIL_SIGNUP_REQUIRED",
+                      "NEW_CUSTOMER_SPECIFIC",
+                      "PRODUCT_SPECIFIC",
+                      "POINT_OF_SALE_SPECIFIC"
+                    ]
+                  },
+                  "promotionEnds": {
+                    "title": "Promotion Ends",
+                    "description": "End date of the promotion, in ISO 8601 format.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "promotionStarts": {
+                    "title": "Promotion Starts",
+                    "description": "Start date of the promotion, in ISO 8601 format.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "promotionType": {
+                    "title": "Promotion Type",
+                    "description": "Category of promotion.",
+                    "type": "string",
+                    "enum": [
+                      "BOGO",
+                      "AMOUNT_OFF",
+                      "FREE_GIFT",
+                      "FREE_SHIP",
+                      "INTRODUCTORY_OFFER",
+                      "PERCENT_OFF",
+                      "COUPON"
+                    ]
+                  },
+                  "quantity": {
+                    "title": "Quantity",
+                    "description": "Quantity for a given SKU. (Simple Actions Only).",
+                    "type": "integer"
+                  },
+                  "rating": {
+                    "title": "Rating",
+                    "description": "Rating of the product.",
+                    "type": "string"
+                  },
+                  "serviceType": {
+                    "title": "Service Type",
+                    "description": "Classification of service offered.",
+                    "type": "string",
+                    "enum": [
+                      "cable",
+                      "checking_internet",
+                      "credit_card",
+                      "identity",
+                      "insurance",
+                      "investment",
+                      "loan",
+                      "payment",
+                      "phone",
+                      "prepaid_debit",
+                      "savings",
+                      "tax",
+                      "tv_sat",
+                      "tv_stream",
+                      "wireless",
+                      "wireless_bus",
+                      "wireless_fam",
+                      "wireless_ind"
+                    ]
+                  },
+                  "startDateTime": {
+                    "title": "Start Date Time",
+                    "description": "Start of item duration (e.g., check-out or departure date/time). Must be in ISO 8601 format.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "subscriptionFee": {
+                    "title": "Subscription Fee",
+                    "description": "Cost of subscription fee featured when signing up for free trial.",
+                    "type": "number"
+                  },
+                  "subscriptionLength": {
+                    "title": "Subscription Length",
+                    "description": "Product duration.",
+                    "type": "string"
+                  },
+                  "taxAmount": {
+                    "title": "Tax Amount",
+                    "description": "Total tax for the order.",
+                    "type": "number"
+                  },
+                  "taxType": {
+                    "title": "Tax Type",
+                    "description": "Type of tax assessed.",
+                    "type": "string",
+                    "enum": [
+                      "ADMINISTRATIVE",
+                      "CARRIER",
+                      "DELIVERY",
+                      "FEDERAL_UNIVERSAL_SERVICE",
+                      "LOCAL",
+                      "REGULATORY_COST_RECOVERY",
+                      "ROOM",
+                      "SEGMENT",
+                      "STATE",
+                      "TOURIST",
+                      "V911_SERVICE"
+                    ]
+                  },
+                  "upsell": {
+                    "title": "Upsell",
+                    "description": "Indicates if someone converted from a trial to a subscription.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "travelVerticals",
+          "type": "object",
+          "label": "Travel Vertical Parameters",
+          "description": "This field is used to pass additional parameters specific to the travel vertical.",
+          "defaultValue": {
+            "bookingDate": {
+              "@path": "$.properties.booking_date"
+            },
+            "bookingStatus": {
+              "@path": "$.properties.booking_status"
+            },
+            "bookingValuePostTax": {
+              "@path": "$.properties.booking_value_post_tax"
+            },
+            "bookingValuePreTax": {
+              "@path": "$.properties.booking_value_pre_tax"
+            },
+            "carOptions": {
+              "@path": "$.properties.car_options"
+            },
+            "class": {
+              "@path": "$.properties.class"
+            },
+            "cruiseType": {
+              "@path": "$.properties.cruise_type"
+            },
+            "destinationCity": {
+              "@path": "$.properties.destination_city"
+            },
+            "destinationCountry": {
+              "@path": "$.properties.destination_country"
+            },
+            "destinationState": {
+              "@path": "$.properties.destination_state"
+            },
+            "domestic": {
+              "@path": "$.properties.domestic"
+            },
+            "dropoffIata": {
+              "@path": "$.properties.dropoff_iata"
+            },
+            "dropoffId": {
+              "@path": "$.properties.dropoff_id"
+            },
+            "flightFareType": {
+              "@path": "$.properties.flight_fare_type"
+            },
+            "flightOptions": {
+              "@path": "$.properties.flight_options"
+            },
+            "flightType": {
+              "@path": "$.properties.flight_type"
+            },
+            "flyerMiles": {
+              "@path": "$.properties.flyer_miles"
+            },
+            "guests": {
+              "@path": "$.properties.guests"
+            },
+            "iata": {
+              "@path": "$.properties.iata"
+            },
+            "itineraryId": {
+              "@path": "$.properties.itinerary_id"
+            },
+            "minimumStayDuration": {
+              "@path": "$.properties.minimum_stay_duration"
+            },
+            "originCity": {
+              "@path": "$.properties.origin_city"
+            },
+            "originCountry": {
+              "@path": "$.properties.origin_country"
+            },
+            "originState": {
+              "@path": "$.properties.origin_state"
+            },
+            "paidAtBookingPostTax": {
+              "@path": "$.properties.paid_at_booking_post_tax"
+            },
+            "paidAtBookingPreTax": {
+              "@path": "$.properties.paid_at_booking_pre_tax"
+            },
+            "pickupIata": {
+              "@path": "$.properties.pickup_iata"
+            },
+            "pickupId": {
+              "@path": "$.properties.pickup_id"
+            },
+            "port": {
+              "@path": "$.properties.port"
+            },
+            "roomType": {
+              "@path": "$.properties.room_type"
+            },
+            "rooms": {
+              "@path": "$.properties.rooms"
+            },
+            "shipName": {
+              "@path": "$.properties.ship_name"
+            },
+            "travelType": {
+              "@path": "$.properties.travel_type"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "travelVerticals": {
+                "title": "Travel Vertical Parameters",
+                "description": "This field is used to pass additional parameters specific to the travel vertical.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "bookingDate": {
+                    "title": "Booking Date",
+                    "description": "Date the booking was made.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "bookingStatus": {
+                    "title": "Booking Status",
+                    "description": "Booking status at the time of tag firing.",
+                    "type": "string"
+                  },
+                  "bookingValuePostTax": {
+                    "title": "Booking Value Post-Tax",
+                    "description": "Value of booking after taxes.",
+                    "type": "number"
+                  },
+                  "bookingValuePreTax": {
+                    "title": "Booking Value Pre-Tax",
+                    "description": "Value of booking before taxes.",
+                    "type": "number"
+                  },
+                  "carOptions": {
+                    "title": "Car Options",
+                    "description": "Other items added to the reservation beyond the vehicle itself (e.g. \"insurance\", \"GPS\", \"Car Seat\").",
+                    "type": "string"
+                  },
+                  "class": {
+                    "title": "Class",
+                    "description": "Class of item (flight, hotel, car, or cruise specific classes).",
+                    "type": "string",
+                    "enum": [
+                      "first",
+                      "business",
+                      "premiumeconomy",
+                      "economy",
+                      "basiceconomy",
+                      "standard",
+                      "deluxe",
+                      "junior_suite",
+                      "suite",
+                      "economy",
+                      "compact",
+                      "mid_size",
+                      "full_size",
+                      "premium",
+                      "luxury",
+                      "mini_van",
+                      "convertible",
+                      "mid_size_suv",
+                      "standard_suv",
+                      "full_size_suv",
+                      "full_size_van",
+                      "interior",
+                      "ocean_view",
+                      "suite",
+                      "balcony"
+                    ]
+                  },
+                  "cruiseType": {
+                    "title": "Cruise Type",
+                    "description": "Type of cruise (Alaskan, Caribbean, etc...).",
+                    "type": "string"
+                  },
+                  "destinationCity": {
+                    "title": "Destination City",
+                    "description": "Customer service destination city name (New York City, Boston, Atlanta, etc...). If destinationCity is provided, destinationState must also be provided. If there is no Origin/Destination combo, but needs to indicate a location of service (network service, event) use 'destination' set of parameters.",
+                    "type": "string"
+                  },
+                  "destinationCountry": {
+                    "title": "Destination Country",
+                    "description": "Customer service destination country code, per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
+                    "type": "string"
+                  },
+                  "destinationState": {
+                    "title": "Destination State",
+                    "description": "Customer service destination state/province code. ISO 3166-2 country subdivision standards. e.g. US-NY, US-CA, US-FL, US-TX",
+                    "type": "string"
+                  },
+                  "domestic": {
+                    "title": "Domestic Travel",
+                    "description": "Indicates whether the travel is domestic (Yes) or international (No).",
+                    "type": "string",
+                    "enum": ["YES", "NO"]
+                  },
+                  "dropoffIata": {
+                    "title": "Dropoff IATA",
+                    "description": "Destination location IATA code. 3 letter IATA code.",
+                    "type": "string"
+                  },
+                  "dropoffId": {
+                    "title": "Dropoff ID",
+                    "description": "Advertiser ID for destination location.",
+                    "type": "string"
+                  },
+                  "flightFareType": {
+                    "title": "Flight Fare Type",
+                    "description": "Type of flight fare (e.g. gotta get away).",
+                    "type": "string"
+                  },
+                  "flightOptions": {
+                    "title": "Flight Options",
+                    "description": "Other items added to the reservation (e.g. Wi-Fi).",
+                    "type": "string"
+                  },
+                  "flightType": {
+                    "title": "Flight Type",
+                    "description": "Type of flight (e.g. direct, layover, overnight).",
+                    "type": "string",
+                    "enum": ["MULTI_CITY", "ONE_WAY", "ROUND_TRIP"]
+                  },
+                  "flyerMiles": {
+                    "title": "Flyer Miles",
+                    "description": "Flyer miles earned from this flight.",
+                    "type": "number"
+                  },
+                  "guests": {
+                    "title": "Guests",
+                    "description": "Number of guests.",
+                    "type": "integer"
+                  },
+                  "iata": {
+                    "title": "IATA",
+                    "description": "IATA code (3-letter); If using for a multi-stop flight each city in a flight can be provided in a comma-separated list.",
+                    "type": "string"
+                  },
+                  "itineraryId": {
+                    "title": "Itinerary ID",
+                    "description": "Booking itinerary ID.",
+                    "type": "string"
+                  },
+                  "minimumStayDuration": {
+                    "title": "Minimum Stay Duration",
+                    "description": "Minimum stay duration required in days.",
+                    "type": "number"
+                  },
+                  "originCity": {
+                    "title": "Origin City",
+                    "description": "Customer service origin city name (New York City, Ottawa, Los Angeles, etc...). If originCity is provided, originState is also provided",
+                    "type": "string"
+                  },
+                  "originCountry": {
+                    "title": "Origin Country",
+                    "description": "Customer service origin country code per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
+                    "type": "string"
+                  },
+                  "originState": {
+                    "title": "Origin State",
+                    "description": "Customer service origin state/province code per ISO 3166-2 country subdivision standards (Alaska would be \"or_state=US-AK\", Bangkok would be \"or_state=TH-10\").",
+                    "type": "string"
+                  },
+                  "paidAtBookingPostTax": {
+                    "title": "Paid at Booking (Post-Tax)",
+                    "description": "Amount paid at booking after taxes.",
+                    "type": "number"
+                  },
+                  "paidAtBookingPreTax": {
+                    "title": "Paid at Booking (Pre-Tax)",
+                    "description": "Amount paid at booking before taxes.",
+                    "type": "number"
+                  },
+                  "pickupIata": {
+                    "title": "Pickup IATA",
+                    "description": "Origin location IATA code.",
+                    "type": "string"
+                  },
+                  "pickupId": {
+                    "title": "Pickup ID",
+                    "description": "Advertiser ID for origin location.",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Departure port city (for cruises).",
+                    "type": "string"
+                  },
+                  "roomType": {
+                    "title": "Room Type",
+                    "description": "Room type booked. If using the same values listed for \"class\" parameter, use that parameter instead.",
+                    "type": "string"
+                  },
+                  "rooms": {
+                    "title": "Rooms",
+                    "description": "Number of rooms booked.",
+                    "type": "integer"
+                  },
+                  "shipName": {
+                    "title": "Ship Name",
+                    "description": "Name of the cruise ship.",
+                    "type": "string"
+                  },
+                  "travelType": {
+                    "title": "Travel Type",
+                    "description": "\tType of travel being booked. If you want access to standardized benchmark reporting, you must pass a value from the following list.",
+                    "type": "string",
+                    "enum": [
+                      "ACTIVITIES",
+                      "AIR",
+                      "CAR",
+                      "CRUISE",
+                      "EVENTS",
+                      "HOTEL",
+                      "OTHER",
+                      "PACKAGE",
+                      "RESTAURANTS",
+                      "TRAVEL_GUIDES",
+                      "VACATION_RENTAL"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "financeVerticals",
+          "type": "object",
+          "label": "Finance Verticals",
+          "description": "This field is used to pass additional parameters specific to the finance vertical.",
+          "defaultValue": {
+            "annualFee": {
+              "@path": "$.properties.annual_fee"
+            },
+            "applicationStatus": {
+              "@path": "$.properties.application_status"
+            },
+            "apr": {
+              "@path": "$.properties.apr"
+            },
+            "aprTransfer": {
+              "@path": "$.properties.apr_transfer"
+            },
+            "aprTransferTime": {
+              "@path": "$.properties.apr_transfer_time"
+            },
+            "cardCategory": {
+              "@path": "$.properties.card_category"
+            },
+            "cashAdvanceFee": {
+              "@path": "$.properties.cash_advance_fee"
+            },
+            "contractLength": {
+              "@path": "$.properties.contract_length"
+            },
+            "contractType": {
+              "@path": "$.properties.contract_type"
+            },
+            "creditReport": {
+              "@path": "$.properties.credit_report"
+            },
+            "creditLine": {
+              "@path": "$.properties.credit_line"
+            },
+            "creditQuality": {
+              "@path": "$.properties.credit_quality"
+            },
+            "fundedAmount": {
+              "@path": "$.properties.funded_amount"
+            },
+            "fundedCurrency": {
+              "@path": "$.properties.funded_currency"
+            },
+            "introductoryApr": {
+              "@path": "$.properties.introductory_apr"
+            },
+            "introductoryAprTime": {
+              "@path": "$.properties.introductory_apr_time"
+            },
+            "minimumBalance": {
+              "@path": "$.properties.minimum_balance"
+            },
+            "minimumDeposit": {
+              "@path": "$.properties.minimum_deposit"
+            },
+            "prequalify": {
+              "@path": "$.properties.prequalify"
+            },
+            "transferFee": {
+              "@path": "$.properties.transfer_fee"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "financeVerticals": {
+                "title": "Finance Verticals",
+                "description": "This field is used to pass additional parameters specific to the finance vertical.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "annualFee": {
+                    "title": "Annual Fee",
+                    "description": "Amount of the annual fee.",
+                    "type": "number"
+                  },
+                  "applicationStatus": {
+                    "title": "Application Status",
+                    "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
+                    "type": "string",
+                    "enum": [
+                      "instant_approved",
+                      "instant_declined",
+                      "pended",
+                      "approved",
+                      "declined",
+                      "declined_counter"
+                    ]
+                  },
+                  "apr": {
+                    "title": "APR",
+                    "description": "APR at time of application approval.",
+                    "type": "number"
+                  },
+                  "aprTransfer": {
+                    "title": "APR Transfer",
+                    "description": "APR for transfers.",
+                    "type": "number"
+                  },
+                  "aprTransferTime": {
+                    "title": "APR Transfer Time",
+                    "description": "If transfer APR is only for a certain period of time, pass the number of months here.",
+                    "type": "integer"
+                  },
+                  "cardCategory": {
+                    "title": "Card Category",
+                    "description": "Category of the card.",
+                    "type": "string",
+                    "enum": [
+                      "BALANCE_TRANSFER_CARDS",
+                      "CASH_BACK_REWARD_CARDS",
+                      "CHARGE_CARDS",
+                      "CLICKS",
+                      "MILITARY_AFFILIATE",
+                      "OTHER",
+                      "REWARD_POINTS_CARDS",
+                      "CREDIT_BUILDING_CARDS",
+                      "STUDENT_CARDS",
+                      "TRAVEL_REWARD_CARDS",
+                      "UNKNOWN_PRODUCT",
+                      "LOW_APR_CARDS"
+                    ]
+                  },
+                  "cashAdvanceFee": {
+                    "title": "Cash Advance Fee",
+                    "description": "Amount of the fee associated with the cash advance.",
+                    "type": "number"
+                  },
+                  "contractLength": {
+                    "title": "Contract Length",
+                    "description": "Contract length, in months.",
+                    "type": "number"
+                  },
+                  "contractType": {
+                    "title": "Contract Type",
+                    "description": "Advertiser-specific contract description.",
+                    "type": "string"
+                  },
+                  "creditReport": {
+                    "title": "Credit Report",
+                    "description": "Indicates if the customer received a credit report and if it was purchased.",
+                    "type": "string",
+                    "enum": ["purchase", "free", "trial"]
+                  },
+                  "creditLine": {
+                    "title": "Credit Line",
+                    "description": "Amount of credit extended through product.",
+                    "type": "number"
+                  },
+                  "creditQuality": {
+                    "title": "Credit Quality",
+                    "description": "Minimum credit tier required for product approval. (300-579=Very Poor, 580-669=Fair, 670-739=Good,740-799=Very Good, 800-850=Exceptional).",
+                    "type": "string",
+                    "enum": ["Very Poor", "Fair", "Good", "Very Good", "Exceptional"]
+                  },
+                  "fundedAmount": {
+                    "title": "Funded Amount",
+                    "description": "Indicates the amount of funding added to the account at the time of transaction.",
+                    "type": "number"
+                  },
+                  "fundedCurrency": {
+                    "title": "Funded Currency",
+                    "description": "Currency of the funding provided for the new account.",
+                    "type": "number"
+                  },
+                  "introductoryApr": {
+                    "title": "Introductory APR",
+                    "description": "The introductory APR amount. (If the intro APR is not different than overall APR, use the \"APR\" parameter).",
+                    "type": "number"
+                  },
+                  "introductoryAprTime": {
+                    "title": "Introductory APR Time",
+                    "description": "The number of months the intro APR applies for.",
+                    "type": "integer"
+                  },
+                  "minimumBalance": {
+                    "title": "Minimum Balance",
+                    "description": "Value of the minimum cash balance requirement for the account.",
+                    "type": "number"
+                  },
+                  "minimumDeposit": {
+                    "title": "Minimum Deposit",
+                    "description": "Indicates the value if a minimum deposit is required.",
+                    "type": "number"
+                  },
+                  "prequalify": {
+                    "title": "Prequalify",
+                    "description": "Indicates if the applicant was pre-qualified for the card.",
+                    "type": "string",
+                    "enum": ["Yes", "No"]
+                  },
+                  "transferFee": {
+                    "title": "Transfer Fee",
+                    "description": "The transfer fee amount (i.e. for a credit card).",
+                    "type": "number"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "networkServicesVerticals",
+          "type": "object",
+          "label": "Network Services Verticals",
+          "description": "This field is used to pass additional parameters specific to the network services vertical.",
+          "defaultValue": {
+            "annualFee": {
+              "@path": "$.properties.annual_fee"
+            },
+            "applicationStatus": {
+              "@path": "$.properties.application_status"
+            },
+            "contractLength": {
+              "@path": "$.properties.contract_length"
+            },
+            "contractType": {
+              "@path": "$.properties.contract_type"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "networkServicesVerticals": {
+                "title": "Network Services Verticals",
+                "description": "This field is used to pass additional parameters specific to the network services vertical.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "annualFee": {
+                    "title": "Annual Fee",
+                    "description": "Amount of the annual fee.",
+                    "type": "number"
+                  },
+                  "applicationStatus": {
+                    "title": "Application Status",
+                    "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
+                    "type": "string",
+                    "enum": [
+                      "instant_approved",
+                      "instant_declined",
+                      "pended",
+                      "approved",
+                      "declined",
+                      "declined_counter"
+                    ]
+                  },
+                  "contractLength": {
+                    "title": "Contract Length",
+                    "description": "Contract length, in months.",
+                    "type": "number"
+                  },
+                  "contractType": {
+                    "title": "Contract Type",
+                    "description": "Advertiser-specific contract description.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "sitePage",
+      "name": "Site Page",
+      "description": "Send site page data to CJ.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique ID assigned by you to the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique ID assigned by you to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "enterpriseId",
+          "type": "number",
+          "label": "Enterprise ID",
+          "description": "Your CJ Enterprise ID.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enterpriseId": {
+                "title": "Enterprise ID",
+                "description": "Your CJ Enterprise ID.",
+                "type": "number"
+              }
+            },
+            "required": ["enterpriseId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "pageType",
+          "type": "string",
+          "label": "Page Type",
+          "description": "Page type to be sent to CJ.",
+          "required": true,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Account Center",
+              "value": "accountCenter"
+            },
+            {
+              "label": "Account Signup",
+              "value": "accountSignup"
+            },
+            {
+              "label": "Application Start",
+              "value": "applicationStart"
+            },
+            {
+              "label": "Branch Locator",
+              "value": "branchLocator"
+            },
+            {
+              "label": "Cart",
+              "value": "cart"
+            },
+            {
+              "label": "Category",
+              "value": "category"
+            },
+            {
+              "label": "Conversion Confirmation",
+              "value": "conversionConfirmation"
+            },
+            {
+              "label": "Department",
+              "value": "department"
+            },
+            {
+              "label": "Homepage",
+              "value": "homepage"
+            },
+            {
+              "label": "Information",
+              "value": "information"
+            },
+            {
+              "label": "Product Detail",
+              "value": "productDetail"
+            },
+            {
+              "label": "Property Detail",
+              "value": "propertyDetail"
+            },
+            {
+              "label": "Property Results",
+              "value": "propertyResults"
+            },
+            {
+              "label": "Search Results",
+              "value": "searchResults"
+            },
+            {
+              "label": "Store Locator",
+              "value": "storeLocator"
+            },
+            {
+              "label": "Sub Category",
+              "value": "subCategory"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pageType": {
+                "title": "Page Type",
+                "description": "Page type to be sent to CJ.",
+                "type": "string",
+                "enum": [
+                  "accountCenter",
+                  "accountSignup",
+                  "applicationStart",
+                  "branchLocator",
+                  "cart",
+                  "category",
+                  "conversionConfirmation",
+                  "department",
+                  "homepage",
+                  "information",
+                  "productDetail",
+                  "propertyDetail",
+                  "propertyResults",
+                  "searchResults",
+                  "storeLocator",
+                  "subCategory"
+                ]
+              }
+            },
+            "required": ["pageType"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "referringChannel",
+          "type": "string",
+          "label": "Referring Channel",
+          "description": "The referring channel to be sent to CJ.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Affiliate",
+              "value": "Affiliate"
+            },
+            {
+              "label": "Display",
+              "value": "Display"
+            },
+            {
+              "label": "Social",
+              "value": "Social"
+            },
+            {
+              "label": "Search",
+              "value": "Search"
+            },
+            {
+              "label": "Email",
+              "value": "Email"
+            },
+            {
+              "label": "Direct Navigation",
+              "value": "Direct_Navigation"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "referringChannel": {
+                "title": "Referring Channel",
+                "description": "The referring channel to be sent to CJ.",
+                "type": "string",
+                "enum": ["Affiliate", "Display", "Social", "Search", "Email", "Direct_Navigation"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "cartSubtotal",
+          "type": "number",
+          "label": "Cart Subtotal",
+          "description": "The cart subtotal to be sent to CJ.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "cartSubtotal": {
+                "title": "Cart Subtotal",
+                "description": "The cart subtotal to be sent to CJ.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Items",
+          "description": "The items to be sent to CJ.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "unitPrice": {
+                  "@path": "$.price"
+                },
+                "itemId": {
+                  "@path": "$.id"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                },
+                "discount": {
+                  "@path": "$.discount"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "items": {
+                "title": "Items",
+                "description": "The items to be sent to CJ.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "unitPrice": {
+                      "title": "Unit Price",
+                      "description": "the price of the item before tax and discount.",
+                      "type": "number"
+                    },
+                    "itemId": {
+                      "title": "Item ID",
+                      "description": "The item sku.",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "The quantity of the item.",
+                      "type": "number"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "The discount applied to the item.",
+                      "type": "number"
+                    }
+                  },
+                  "required": ["unitPrice", "itemId", "quantity"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/cj/metadata.json
+++ b/packages/browser-destinations/destinations/cj/metadata.json
@@ -1,441 +1,247 @@
 {
+  "slug": "actions-cj",
   "name": "Commission Junction (Actions)",
+  "mode": "device",
   "description": "The Commission Junction Browser Destination allows you to install the CJ Javascript pixel onto your site and pass mapped Segment events and metadata to CJ.",
-  "basicOptions": ["tagId", "actionTrackerId"],
-  "options": {
-    "tagId": {
-      "tags": [],
-      "default": "",
-      "description": "Your Commission Junction Tag ID.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Tag ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The tagId property is required."]],
-      "uIMetadata": null
-    },
-    "actionTrackerId": {
-      "tags": [],
-      "default": "",
-      "description": "Used with the \"Order\" Action only. Can be overridden at the Action level. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Action Tracker ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "tagId": {
+        "label": "Tag ID",
+        "description": "Your Commission Junction Tag ID.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "actionTrackerId": {
+        "label": "Action Tracker ID",
+        "description": "Used with the \"Order\" Action only. Can be overridden at the Action level. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "order",
-      "name": "Order",
-      "description": "Send order data to CJ.",
+  "audienceConfig": null,
+  "actions": {
+    "sitePage": {
+      "title": "Site Page",
+      "description": "Send site page data to CJ.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "event = \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "verticalType",
-          "type": "string",
-          "label": "Vertical type",
-          "description": "Send additional data relating to travel, finance network services",
-          "required": false,
-          "multiple": false,
-          "choices": [
-            {
-              "label": "Travel Vertical",
-              "value": "travel"
-            },
-            {
-              "label": "Network Vertical",
-              "value": "network"
-            },
-            {
-              "label": "Finance Vertical",
-              "value": "finance"
-            }
-          ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "verticalType": {
-                "title": "Vertical type",
-                "description": "Send additional data relating to travel, finance network services",
-                "type": "string",
-                "enum": ["travel", "network", "finance"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "A unique ID assigned by you to the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique ID assigned by you to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "enterpriseId",
-          "type": "number",
+        "enterpriseId": {
           "label": "Enterprise ID",
           "description": "Your CJ Enterprise ID.",
+          "type": "number",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enterpriseId": {
-                "title": "Enterprise ID",
-                "description": "Your CJ Enterprise ID.",
-                "type": "number"
-              }
-            },
-            "required": ["enterpriseId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "pageType",
-          "type": "string",
+        "pageType": {
           "label": "Page Type",
-          "description": "Page type to be sent to CJ. Must be set to \"conversionConfirmation\" for order events.",
-          "defaultValue": "conversionConfirmation",
+          "description": "Page type to be sent to CJ.",
+          "type": "string",
           "required": true,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
+            {
+              "label": "Account Center",
+              "value": "accountCenter"
+            },
+            {
+              "label": "Account Signup",
+              "value": "accountSignup"
+            },
+            {
+              "label": "Application Start",
+              "value": "applicationStart"
+            },
+            {
+              "label": "Branch Locator",
+              "value": "branchLocator"
+            },
+            {
+              "label": "Cart",
+              "value": "cart"
+            },
+            {
+              "label": "Category",
+              "value": "category"
+            },
             {
               "label": "Conversion Confirmation",
               "value": "conversionConfirmation"
+            },
+            {
+              "label": "Department",
+              "value": "department"
+            },
+            {
+              "label": "Homepage",
+              "value": "homepage"
+            },
+            {
+              "label": "Information",
+              "value": "information"
+            },
+            {
+              "label": "Product Detail",
+              "value": "productDetail"
+            },
+            {
+              "label": "Property Detail",
+              "value": "propertyDetail"
+            },
+            {
+              "label": "Property Results",
+              "value": "propertyResults"
+            },
+            {
+              "label": "Search Results",
+              "value": "searchResults"
+            },
+            {
+              "label": "Store Locator",
+              "value": "storeLocator"
+            },
+            {
+              "label": "Sub Category",
+              "value": "subCategory"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "readOnly": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "pageType": {
-                "title": "Page Type",
-                "description": "Page type to be sent to CJ. Must be set to \"conversionConfirmation\" for order events.",
-                "type": "string",
-                "enum": ["conversionConfirmation"]
-              }
-            },
-            "required": ["pageType"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "emailHash",
+        "referringChannel": {
+          "label": "Referring Channel",
+          "description": "The referring channel to be sent to CJ.",
           "type": "string",
-          "label": "Email address",
-          "description": "Segment will ensure the email address is hashed before sending to CJ.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": [
+            {
+              "label": "Affiliate",
+              "value": "Affiliate"
+            },
+            {
+              "label": "Display",
+              "value": "Display"
+            },
+            {
+              "label": "Social",
+              "value": "Social"
+            },
+            {
+              "label": "Search",
+              "value": "Search"
+            },
+            {
+              "label": "Email",
+              "value": "Email"
+            },
+            {
+              "label": "Direct Navigation",
+              "value": "Direct_Navigation"
             }
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "emailHash": {
-                "title": "Email address",
-                "description": "Segment will ensure the email address is hashed before sending to CJ.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "orderId",
-          "type": "string",
-          "label": "Order ID",
-          "description": "The orderId is a unique identifier, such as an order identifier or invoice number, which must be populated for each order.",
-          "defaultValue": {
-            "@path": "$.properties.order_id"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "orderId": {
-                "title": "Order ID",
-                "description": "The orderId is a unique identifier, such as an order identifier or invoice number, which must be populated for each order.",
-                "type": "string"
-              }
-            },
-            "required": ["orderId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "actionTrackerId",
-          "type": "string",
-          "label": "Action Tracker ID",
-          "description": "Required if not specified in Settings. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "actionTrackerId": {
-                "title": "Action Tracker ID",
-                "description": "Required if not specified in Settings. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "The currency of the order, e.g. USD, EUR.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "The currency of the order, e.g. USD, EUR.",
-                "type": "string"
-              }
-            },
-            "required": ["currency"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "amount",
+        "cartSubtotal": {
+          "label": "Cart Subtotal",
+          "description": "The cart subtotal to be sent to CJ.",
           "type": "number",
-          "label": "Amount",
-          "description": "The total amount of the order. This should exclude shipping or tax.",
-          "defaultValue": {
-            "@path": "$.properties.total"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "amount": {
-                "title": "Amount",
-                "description": "The total amount of the order. This should exclude shipping or tax.",
-                "type": "number"
-              }
-            },
-            "required": ["amount"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "discount",
-          "type": "number",
-          "label": "Discount",
-          "description": "The total discount applied to the order.",
-          "defaultValue": {
-            "@path": "$.properties.discount"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "discount": {
-                "title": "Discount",
-                "description": "The total discount applied to the order.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
-          "label": "Coupon",
-          "description": "The coupon code applied to the order.",
-          "defaultValue": {
-            "@path": "$.properties.coupon"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "The coupon code applied to the order.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "cjeventOrderCookieName",
-          "type": "string",
-          "label": "CJ Event Order Cookie Name",
-          "description": "The name of the cookie that stores the CJ Event ID. This is required whenever the advertiser uses their own cookie to store the Event ID.",
-          "defaultValue": "cje",
-          "required": true,
-          "multiple": false,
+          "default": null,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "cjeventOrderCookieName": {
-                "title": "CJ Event Order Cookie Name",
-                "description": "The name of the cookie that stores the CJ Event ID. This is required whenever the advertiser uses their own cookie to store the Event ID.",
-                "type": "string"
-              }
-            },
-            "required": ["cjeventOrderCookieName"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "items",
-          "type": "object",
+        "items": {
           "label": "Items",
           "description": "The items to be sent to CJ.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -454,62 +260,542 @@
               }
             ]
           },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "unitPrice": {
+              "label": "Unit Price",
+              "description": "the price of the item before tax and discount.",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itemId": {
+              "label": "Item ID",
+              "description": "The item sku.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "The quantity of the item.",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "The discount applied to the item.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "order": {
+      "title": "Order",
+      "description": "Send order data to CJ.",
+      "platform": "web",
+      "defaultSubscription": "event = \"Order Completed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "verticalType": {
+          "label": "Vertical type",
+          "description": "Send additional data relating to travel, finance network services",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": [
+            {
+              "label": "Travel Vertical",
+              "value": "travel"
+            },
+            {
+              "label": "Network Vertical",
+              "value": "network"
+            },
+            {
+              "label": "Finance Vertical",
+              "value": "finance"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "A unique ID assigned by you to the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "enterpriseId": {
+          "label": "Enterprise ID",
+          "description": "Your CJ Enterprise ID.",
+          "type": "number",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "pageType": {
+          "label": "Page Type",
+          "description": "Page type to be sent to CJ. Must be set to \"conversionConfirmation\" for order events.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "conversionConfirmation",
+          "choices": [
+            {
+              "label": "Conversion Confirmation",
+              "value": "conversionConfirmation"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": true,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "emailHash": {
+          "label": "Email address",
+          "description": "Segment will ensure the email address is hashed before sending to CJ.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "orderId": {
+          "label": "Order ID",
+          "description": "The orderId is a unique identifier, such as an order identifier or invoice number, which must be populated for each order.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.order_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "actionTrackerId": {
+          "label": "Action Tracker ID",
+          "description": "Required if not specified in Settings. This is a static value provided by CJ. Each account may have multiple actions and each will be referenced by a different actionTrackerId value.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "The currency of the order, e.g. USD, EUR.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "amount": {
+          "label": "Amount",
+          "description": "The total amount of the order. This should exclude shipping or tax.",
+          "type": "number",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.total"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "discount": {
+          "label": "Discount",
+          "description": "The total discount applied to the order.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.discount"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "coupon": {
+          "label": "Coupon",
+          "description": "The coupon code applied to the order.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.coupon"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "cjeventOrderCookieName": {
+          "label": "CJ Event Order Cookie Name",
+          "description": "The name of the cookie that stores the CJ Event ID. This is required whenever the advertiser uses their own cookie to store the Event ID.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "cje",
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Items",
+          "description": "The items to be sent to CJ.",
+          "type": "object",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "items": {
-                "title": "Items",
-                "description": "The items to be sent to CJ.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "unitPrice": {
-                      "title": "Unit Price",
-                      "description": "the price of the item before tax and discount.",
-                      "type": "number"
-                    },
-                    "itemId": {
-                      "title": "Item ID",
-                      "description": "The item sku.",
-                      "type": "string"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "The quantity of the item.",
-                      "type": "number"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "The discount applied to the item.",
-                      "type": "number"
-                    }
-                  },
-                  "required": ["unitPrice", "itemId", "quantity"]
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "unitPrice": {
+                  "@path": "$.price"
+                },
+                "itemId": {
+                  "@path": "$.id"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                },
+                "discount": {
+                  "@path": "$.discount"
                 }
               }
-            },
-            "required": []
+            ]
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "unitPrice": {
+              "label": "Unit Price",
+              "description": "the price of the item before tax and discount.",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itemId": {
+              "label": "Item ID",
+              "description": "The item sku.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "The quantity of the item.",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "The discount applied to the item.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "allVerticals",
-          "type": "object",
+        "allVerticals": {
           "label": "All Vertical Parameters",
           "description": "This field is used to pass additional parameters specific to the vertical. All vertical parameters listed below can be utilized regardless of the account's vertical.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "brand": {
               "@path": "$.properties.brand"
             },
@@ -676,409 +962,1596 @@
               "@path": "$.properties.upsell"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "allVerticals": {
-                "title": "All Vertical Parameters",
-                "description": "This field is used to pass additional parameters specific to the vertical. All vertical parameters listed below can be utilized regardless of the account's vertical.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "ancillarySpend": {
-                    "title": "Ancillary Spend",
-                    "description": "Ancillary spend at the time of transaction, but not commissionable.",
-                    "type": "number"
-                  },
-                  "brand": {
-                    "title": "Brand",
-                    "description": "Brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
-                    "type": "string"
-                  },
-                  "brandId": {
-                    "title": "Brand ID",
-                    "description": "Identifier of brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
-                    "type": "string"
-                  },
-                  "businessUnit": {
-                    "title": "Business Unit",
-                    "description": "Identifies the business unit the customer purchased through. If there are multiple items with different business units, one business unit must be designated for the order.",
-                    "type": "string"
-                  },
-                  "campaignId": {
-                    "title": "Campaign ID",
-                    "description": "Marketing campaign id.",
-                    "type": "string"
-                  },
-                  "campaignName": {
-                    "title": "Campaign Name",
-                    "description": "Marketing campaign name.",
-                    "type": "string"
-                  },
-                  "category": {
-                    "title": "Category",
-                    "description": "Category of items purchased. If there are multiple items with different categories, one category must be designated for the order.",
-                    "type": "string"
-                  },
-                  "class": {
-                    "title": "Class",
-                    "description": "Class of item.",
-                    "type": "string"
-                  },
-                  "confirmationNumber": {
-                    "title": "Confirmation Number",
-                    "description": "Confirmation Number",
-                    "type": "number"
-                  },
-                  "couponDiscount": {
-                    "title": "Coupon Discount",
-                    "description": "The value (amount of discount) of the coupon. This should be the number linked to the \"coupon_type\" parameter",
-                    "type": "number"
-                  },
-                  "couponType": {
-                    "title": "Coupon Type",
-                    "description": "The type of coupon used in the order. This should be the number linked to the \"coupon_discount\" parameter.",
-                    "type": "string",
-                    "enum": ["percent", "dollars", "added_value"]
-                  },
-                  "customerCountry": {
-                    "title": "Customer Country",
-                    "description": "The customer's country. ISO 3166-1 alpha 2 country code, eg. US, UK, AU, FR.",
-                    "type": "string"
-                  },
-                  "customerSegment": {
-                    "title": "Customer Segment",
-                    "description": "Advertiser-specific customer segment definition.",
-                    "type": "string"
-                  },
-                  "customerStatus": {
-                    "title": "Customer Status",
-                    "description": "The status of the customer, e.g. new, returning.",
-                    "type": "string",
-                    "enum": ["New", "Lapsed", "Return"]
-                  },
-                  "customerType": {
-                    "title": "Customer Type",
-                    "description": "Indicates the type of individual making the purchase as someone representing a group.",
-                    "type": "string"
-                  },
-                  "delivery": {
-                    "title": "Delivery",
-                    "description": "The delivery method used for the order.",
-                    "type": "string",
-                    "enum": ["IN_STORE", "PICK_UP", "RECURRING", "STANDARD", "NEXT_DAY", "DIGITAL", "EXPRESS"]
-                  },
-                  "description": {
-                    "title": "Description",
-                    "description": "Description of the product.",
-                    "type": "string"
-                  },
-                  "duration": {
-                    "title": "Duration",
-                    "description": "Duration in days.",
-                    "type": "number"
-                  },
-                  "endDateTime": {
-                    "title": "End Date Time",
-                    "description": "End date and time of the order, in ISO 8601 format.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "genre": {
-                    "title": "Genre",
-                    "description": "Product genre. If there are multiple items with different genres, one genre must be designated for the order.",
-                    "type": "string"
-                  },
-                  "itemId": {
-                    "title": "Item ID",
-                    "description": "Id for the item. (Simple Actions Only).",
-                    "type": "string"
-                  },
-                  "itemName": {
-                    "title": "Item Name",
-                    "description": "Advertiser assigned item name.",
-                    "type": "string"
-                  },
-                  "itemType": {
-                    "title": "Item Type",
-                    "description": "Advertiser assigned item type.",
-                    "type": "string"
-                  },
-                  "lifestage": {
-                    "title": "Lifestage",
-                    "description": "Advertiser assigned general demographic.",
-                    "type": "string"
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Identifies the customer location if different from customerCountry.",
-                    "type": "string"
-                  },
-                  "loyaltyEarned": {
-                    "title": "Loyalty Earned",
-                    "description": "Loyalty points earned on the transaction.",
-                    "type": "number"
-                  },
-                  "loyaltyFirstTimeSignup": {
-                    "title": "Loyalty First Time Signup",
-                    "description": "Indicates whether this order coincided with the consumer joining the loyalty program.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "loyaltyLevel": {
-                    "title": "Loyalty Level",
-                    "description": "Indicates the level of the customer's loyalty status.",
-                    "type": "string"
-                  },
-                  "loyaltyRedeemed": {
-                    "title": "Loyalty Redeemed",
-                    "description": "Loyalty points used during the transaction.",
-                    "type": "number"
-                  },
-                  "loyaltyStatus": {
-                    "title": "Loyalty Status",
-                    "description": "Indicates if the customer is a loyalty member.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "margin": {
-                    "title": "Margin",
-                    "description": "Margin on total order. Can be a dollar value or a custom indicator.",
-                    "type": "string"
-                  },
-                  "marketingChannel": {
-                    "title": "Marketing Channel",
-                    "description": "Advertiser-defined marketing channel assigned to this transaction.",
-                    "type": "string",
-                    "enum": ["affiliate", "display", "social", "search", "email", "direct navigation"]
-                  },
-                  "noCancellation": {
-                    "title": "No Cancellation",
-                    "description": "Indicates if the purchase has a no cancellation policy. \"Yes\" means there is a \"no cancellation\" policy, \"no\" means there is no policy.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "orderSubtotal": {
-                    "title": "Order Subtotal",
-                    "description": "Subtotal for order.",
-                    "type": "number"
-                  },
-                  "paymentMethod": {
-                    "title": "Payment Method",
-                    "description": "Method of payment.",
-                    "type": "string",
-                    "enum": [
-                      "credit_debit_card",
-                      "direct_debit",
-                      "EFTPOS",
-                      "online_payments",
-                      "cash",
-                      "check",
-                      "money_order",
-                      "gift_card_voucher",
-                      "digital_currency"
-                    ]
-                  },
-                  "paymentModel": {
-                    "title": "Payment Model",
-                    "description": "Model of payment used; advertiser-specific.",
-                    "type": "string"
-                  },
-                  "platformId": {
-                    "title": "Platform ID",
-                    "description": "Device platform customer is using.",
-                    "type": "string"
-                  },
-                  "pointOfSale": {
-                    "title": "Point of Sale",
-                    "description": "Point of sale for the transaction.",
-                    "type": "string",
-                    "enum": [
-                      "AMAZON",
-                      "CALL_CENTER",
-                      "CAR_RENTAL",
-                      "CATALOG",
-                      "HOTEL_LOCATION",
-                      "INTERNET",
-                      "IN_APP",
-                      "OUTLET",
-                      "RETAIL_STORE"
-                    ]
-                  },
-                  "preorder": {
-                    "title": "Preorder",
-                    "description": "Indicates if the purchase was made prior to the item becoming available.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "prepaid": {
-                    "title": "Prepaid",
-                    "description": "Indicates if the payment was made in advance of the item's consumption.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "promotion": {
-                    "title": "Promotion",
-                    "description": "Promotion applied. If multiple, must be comma-separated.",
-                    "type": "string"
-                  },
-                  "promotionAmount": {
-                    "title": "Promotion Amount",
-                    "description": "The numeric value associated with the promotion.",
-                    "type": "number"
-                  },
-                  "promotionConditionThreshold": {
-                    "title": "Promotion Condition Threshold",
-                    "description": "Threshold needed to qualify for the promotion.",
-                    "type": "number"
-                  },
-                  "promotionConditionType": {
-                    "title": "Promotion Condition Type",
-                    "description": "Type of conditions applied to the promotion.",
-                    "type": "string",
-                    "enum": [
-                      "BRAND_CARD_SIGNUP_SPECIFIC",
-                      "BRAND_CARD_SPECIFIC",
-                      "LOCATION_SPECIFIC",
-                      "MEMBERSHIP_REQUIRED",
-                      "LOYALTY_REQUIRED",
-                      "EMAIL_SIGNUP_REQUIRED",
-                      "NEW_CUSTOMER_SPECIFIC",
-                      "PRODUCT_SPECIFIC",
-                      "POINT_OF_SALE_SPECIFIC"
-                    ]
-                  },
-                  "promotionEnds": {
-                    "title": "Promotion Ends",
-                    "description": "End date of the promotion, in ISO 8601 format.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "promotionStarts": {
-                    "title": "Promotion Starts",
-                    "description": "Start date of the promotion, in ISO 8601 format.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "promotionType": {
-                    "title": "Promotion Type",
-                    "description": "Category of promotion.",
-                    "type": "string",
-                    "enum": [
-                      "BOGO",
-                      "AMOUNT_OFF",
-                      "FREE_GIFT",
-                      "FREE_SHIP",
-                      "INTRODUCTORY_OFFER",
-                      "PERCENT_OFF",
-                      "COUPON"
-                    ]
-                  },
-                  "quantity": {
-                    "title": "Quantity",
-                    "description": "Quantity for a given SKU. (Simple Actions Only).",
-                    "type": "integer"
-                  },
-                  "rating": {
-                    "title": "Rating",
-                    "description": "Rating of the product.",
-                    "type": "string"
-                  },
-                  "serviceType": {
-                    "title": "Service Type",
-                    "description": "Classification of service offered.",
-                    "type": "string",
-                    "enum": [
-                      "cable",
-                      "checking_internet",
-                      "credit_card",
-                      "identity",
-                      "insurance",
-                      "investment",
-                      "loan",
-                      "payment",
-                      "phone",
-                      "prepaid_debit",
-                      "savings",
-                      "tax",
-                      "tv_sat",
-                      "tv_stream",
-                      "wireless",
-                      "wireless_bus",
-                      "wireless_fam",
-                      "wireless_ind"
-                    ]
-                  },
-                  "startDateTime": {
-                    "title": "Start Date Time",
-                    "description": "Start of item duration (e.g., check-out or departure date/time). Must be in ISO 8601 format.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "subscriptionFee": {
-                    "title": "Subscription Fee",
-                    "description": "Cost of subscription fee featured when signing up for free trial.",
-                    "type": "number"
-                  },
-                  "subscriptionLength": {
-                    "title": "Subscription Length",
-                    "description": "Product duration.",
-                    "type": "string"
-                  },
-                  "taxAmount": {
-                    "title": "Tax Amount",
-                    "description": "Total tax for the order.",
-                    "type": "number"
-                  },
-                  "taxType": {
-                    "title": "Tax Type",
-                    "description": "Type of tax assessed.",
-                    "type": "string",
-                    "enum": [
-                      "ADMINISTRATIVE",
-                      "CARRIER",
-                      "DELIVERY",
-                      "FEDERAL_UNIVERSAL_SERVICE",
-                      "LOCAL",
-                      "REGULATORY_COST_RECOVERY",
-                      "ROOM",
-                      "SEGMENT",
-                      "STATE",
-                      "TOURIST",
-                      "V911_SERVICE"
-                    ]
-                  },
-                  "upsell": {
-                    "title": "Upsell",
-                    "description": "Indicates if someone converted from a trial to a subscription.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "ancillarySpend": {
+              "label": "Ancillary Spend",
+              "description": "Ancillary spend at the time of transaction, but not commissionable.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "brand": {
+              "label": "Brand",
+              "description": "Brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "brandId": {
+              "label": "Brand ID",
+              "description": "Identifier of brand of items purchased. If there are multiple items with different brands, one brand must be designated for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "businessUnit": {
+              "label": "Business Unit",
+              "description": "Identifies the business unit the customer purchased through. If there are multiple items with different business units, one business unit must be designated for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "campaignId": {
+              "label": "Campaign ID",
+              "description": "Marketing campaign id.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "campaignName": {
+              "label": "Campaign Name",
+              "description": "Marketing campaign name.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "category": {
+              "label": "Category",
+              "description": "Category of items purchased. If there are multiple items with different categories, one category must be designated for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "class": {
+              "label": "Class",
+              "description": "Class of item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "confirmationNumber": {
+              "label": "Confirmation Number",
+              "description": "Confirmation Number",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "couponDiscount": {
+              "label": "Coupon Discount",
+              "description": "The value (amount of discount) of the coupon. This should be the number linked to the \"coupon_type\" parameter",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "couponType": {
+              "label": "Coupon Type",
+              "description": "The type of coupon used in the order. This should be the number linked to the \"coupon_discount\" parameter.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Percent",
+                  "value": "percent"
+                },
+                {
+                  "label": "Dollars",
+                  "value": "dollars"
+                },
+                {
+                  "label": "Added Value",
+                  "value": "added_value"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "customerCountry": {
+              "label": "Customer Country",
+              "description": "The customer's country. ISO 3166-1 alpha 2 country code, eg. US, UK, AU, FR.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "customerSegment": {
+              "label": "Customer Segment",
+              "description": "Advertiser-specific customer segment definition.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "customerStatus": {
+              "label": "Customer Status",
+              "description": "The status of the customer, e.g. new, returning.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "New",
+                  "value": "New"
+                },
+                {
+                  "label": "Lapsed",
+                  "value": "Lapsed"
+                },
+                {
+                  "label": "Return",
+                  "value": "Return"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "customerType": {
+              "label": "Customer Type",
+              "description": "Indicates the type of individual making the purchase as someone representing a group.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "delivery": {
+              "label": "Delivery",
+              "description": "The delivery method used for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "In-Store",
+                  "value": "IN_STORE"
+                },
+                {
+                  "label": "Pick-up",
+                  "value": "PICK_UP"
+                },
+                {
+                  "label": "Recurring",
+                  "value": "RECURRING"
+                },
+                {
+                  "label": "Standard",
+                  "value": "STANDARD"
+                },
+                {
+                  "label": "Next day",
+                  "value": "NEXT_DAY"
+                },
+                {
+                  "label": "Digital",
+                  "value": "DIGITAL"
+                },
+                {
+                  "label": "Express",
+                  "value": "EXPRESS"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "description": {
+              "label": "Description",
+              "description": "Description of the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "duration": {
+              "label": "Duration",
+              "description": "Duration in days.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "endDateTime": {
+              "label": "End Date Time",
+              "description": "End date and time of the order, in ISO 8601 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "genre": {
+              "label": "Genre",
+              "description": "Product genre. If there are multiple items with different genres, one genre must be designated for the order.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itemId": {
+              "label": "Item ID",
+              "description": "Id for the item. (Simple Actions Only).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itemName": {
+              "label": "Item Name",
+              "description": "Advertiser assigned item name.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itemType": {
+              "label": "Item Type",
+              "description": "Advertiser assigned item type.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "lifestage": {
+              "label": "Lifestage",
+              "description": "Advertiser assigned general demographic.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location": {
+              "label": "Location",
+              "description": "Identifies the customer location if different from customerCountry.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "loyaltyEarned": {
+              "label": "Loyalty Earned",
+              "description": "Loyalty points earned on the transaction.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "loyaltyFirstTimeSignup": {
+              "label": "Loyalty First Time Signup",
+              "description": "Indicates whether this order coincided with the consumer joining the loyalty program.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "loyaltyLevel": {
+              "label": "Loyalty Level",
+              "description": "Indicates the level of the customer's loyalty status.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "loyaltyRedeemed": {
+              "label": "Loyalty Redeemed",
+              "description": "Loyalty points used during the transaction.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "loyaltyStatus": {
+              "label": "Loyalty Status",
+              "description": "Indicates if the customer is a loyalty member.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "margin": {
+              "label": "Margin",
+              "description": "Margin on total order. Can be a dollar value or a custom indicator.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "marketingChannel": {
+              "label": "Marketing Channel",
+              "description": "Advertiser-defined marketing channel assigned to this transaction.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Affiliate",
+                  "value": "affiliate"
+                },
+                {
+                  "label": "Display",
+                  "value": "display"
+                },
+                {
+                  "label": "Social",
+                  "value": "social"
+                },
+                {
+                  "label": "Search",
+                  "value": "search"
+                },
+                {
+                  "label": "Email",
+                  "value": "email"
+                },
+                {
+                  "label": "Direct Navigation",
+                  "value": "direct navigation"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "noCancellation": {
+              "label": "No Cancellation",
+              "description": "Indicates if the purchase has a no cancellation policy. \"Yes\" means there is a \"no cancellation\" policy, \"no\" means there is no policy.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "orderSubtotal": {
+              "label": "Order Subtotal",
+              "description": "Subtotal for order.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "paymentMethod": {
+              "label": "Payment Method",
+              "description": "Method of payment.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Credit/Debit Card",
+                  "value": "credit_debit_card"
+                },
+                {
+                  "label": "Direct Debit",
+                  "value": "direct_debit"
+                },
+                {
+                  "label": "EFTPOS",
+                  "value": "EFTPOS"
+                },
+                {
+                  "label": "Online Payments",
+                  "value": "online_payments"
+                },
+                {
+                  "label": "Cash",
+                  "value": "cash"
+                },
+                {
+                  "label": "Check",
+                  "value": "check"
+                },
+                {
+                  "label": "Money Order",
+                  "value": "money_order"
+                },
+                {
+                  "label": "Gift Card/Voucher",
+                  "value": "gift_card_voucher"
+                },
+                {
+                  "label": "Digital Currency",
+                  "value": "digital_currency"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "paymentModel": {
+              "label": "Payment Model",
+              "description": "Model of payment used; advertiser-specific.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "platformId": {
+              "label": "Platform ID",
+              "description": "Device platform customer is using.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "pointOfSale": {
+              "label": "Point of Sale",
+              "description": "Point of sale for the transaction.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Amazon",
+                  "value": "AMAZON"
+                },
+                {
+                  "label": "Call Center",
+                  "value": "CALL_CENTER"
+                },
+                {
+                  "label": "Car Rental",
+                  "value": "CAR_RENTAL"
+                },
+                {
+                  "label": "Catalog",
+                  "value": "CATALOG"
+                },
+                {
+                  "label": "Hotel Location",
+                  "value": "HOTEL_LOCATION"
+                },
+                {
+                  "label": "Internet",
+                  "value": "INTERNET"
+                },
+                {
+                  "label": "In-App",
+                  "value": "IN_APP"
+                },
+                {
+                  "label": "Outlet",
+                  "value": "OUTLET"
+                },
+                {
+                  "label": "Retail Store",
+                  "value": "RETAIL_STORE"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "preorder": {
+              "label": "Preorder",
+              "description": "Indicates if the purchase was made prior to the item becoming available.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "prepaid": {
+              "label": "Prepaid",
+              "description": "Indicates if the payment was made in advance of the item's consumption.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotion": {
+              "label": "Promotion",
+              "description": "Promotion applied. If multiple, must be comma-separated.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionAmount": {
+              "label": "Promotion Amount",
+              "description": "The numeric value associated with the promotion.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionConditionThreshold": {
+              "label": "Promotion Condition Threshold",
+              "description": "Threshold needed to qualify for the promotion.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionConditionType": {
+              "label": "Promotion Condition Type",
+              "description": "Type of conditions applied to the promotion.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Brand Card Signup Specific",
+                  "value": "BRAND_CARD_SIGNUP_SPECIFIC"
+                },
+                {
+                  "label": "Brand Card Specific",
+                  "value": "BRAND_CARD_SPECIFIC"
+                },
+                {
+                  "label": "Location Specific",
+                  "value": "LOCATION_SPECIFIC"
+                },
+                {
+                  "label": "Membership Required",
+                  "value": "MEMBERSHIP_REQUIRED"
+                },
+                {
+                  "label": "Loyalty Required",
+                  "value": "LOYALTY_REQUIRED"
+                },
+                {
+                  "label": "Email Signup Required",
+                  "value": "EMAIL_SIGNUP_REQUIRED"
+                },
+                {
+                  "label": "New Customer Specific",
+                  "value": "NEW_CUSTOMER_SPECIFIC"
+                },
+                {
+                  "label": "Product Specific",
+                  "value": "PRODUCT_SPECIFIC"
+                },
+                {
+                  "label": "Point of Sale Specific",
+                  "value": "POINT_OF_SALE_SPECIFIC"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionEnds": {
+              "label": "Promotion Ends",
+              "description": "End date of the promotion, in ISO 8601 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionStarts": {
+              "label": "Promotion Starts",
+              "description": "Start date of the promotion, in ISO 8601 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotionType": {
+              "label": "Promotion Type",
+              "description": "Category of promotion.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "BOGO",
+                  "value": "BOGO"
+                },
+                {
+                  "label": "Amount Off",
+                  "value": "AMOUNT_OFF"
+                },
+                {
+                  "label": "Free Gift",
+                  "value": "FREE_GIFT"
+                },
+                {
+                  "label": "Free Shipping",
+                  "value": "FREE_SHIP"
+                },
+                {
+                  "label": "Introductory Offer",
+                  "value": "INTRODUCTORY_OFFER"
+                },
+                {
+                  "label": "Percent Off",
+                  "value": "PERCENT_OFF"
+                },
+                {
+                  "label": "Coupon",
+                  "value": "COUPON"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Quantity for a given SKU. (Simple Actions Only).",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "rating": {
+              "label": "Rating",
+              "description": "Rating of the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "serviceType": {
+              "label": "Service Type",
+              "description": "Classification of service offered.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Cable",
+                  "value": "cable"
+                },
+                {
+                  "label": "Checking Internet",
+                  "value": "checking_internet"
+                },
+                {
+                  "label": "Credit Card",
+                  "value": "credit_card"
+                },
+                {
+                  "label": "Identity",
+                  "value": "identity"
+                },
+                {
+                  "label": "Insurance",
+                  "value": "insurance"
+                },
+                {
+                  "label": "Investment",
+                  "value": "investment"
+                },
+                {
+                  "label": "Loan",
+                  "value": "loan"
+                },
+                {
+                  "label": "Payment",
+                  "value": "payment"
+                },
+                {
+                  "label": "Phone",
+                  "value": "phone"
+                },
+                {
+                  "label": "Prepaid Debit",
+                  "value": "prepaid_debit"
+                },
+                {
+                  "label": "Savings",
+                  "value": "savings"
+                },
+                {
+                  "label": "Tax",
+                  "value": "tax"
+                },
+                {
+                  "label": "TV Satellite",
+                  "value": "tv_sat"
+                },
+                {
+                  "label": "TV Streaming",
+                  "value": "tv_stream"
+                },
+                {
+                  "label": "Wireless",
+                  "value": "wireless"
+                },
+                {
+                  "label": "Wireless Business",
+                  "value": "wireless_bus"
+                },
+                {
+                  "label": "Wireless Family",
+                  "value": "wireless_fam"
+                },
+                {
+                  "label": "Wireless Individual",
+                  "value": "wireless_ind"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "startDateTime": {
+              "label": "Start Date Time",
+              "description": "Start of item duration (e.g., check-out or departure date/time). Must be in ISO 8601 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "subscriptionFee": {
+              "label": "Subscription Fee",
+              "description": "Cost of subscription fee featured when signing up for free trial.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "subscriptionLength": {
+              "label": "Subscription Length",
+              "description": "Product duration.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "taxAmount": {
+              "label": "Tax Amount",
+              "description": "Total tax for the order.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "taxType": {
+              "label": "Tax Type",
+              "description": "Type of tax assessed.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Administrative",
+                  "value": "ADMINISTRATIVE"
+                },
+                {
+                  "label": "Carrier",
+                  "value": "CARRIER"
+                },
+                {
+                  "label": "Delivery",
+                  "value": "DELIVERY"
+                },
+                {
+                  "label": "Federal Universal Service",
+                  "value": "FEDERAL_UNIVERSAL_SERVICE"
+                },
+                {
+                  "label": "Local",
+                  "value": "LOCAL"
+                },
+                {
+                  "label": "Regulatory Cost Recovery",
+                  "value": "REGULATORY_COST_RECOVERY"
+                },
+                {
+                  "label": "Room",
+                  "value": "ROOM"
+                },
+                {
+                  "label": "Segment",
+                  "value": "SEGMENT"
+                },
+                {
+                  "label": "State",
+                  "value": "STATE"
+                },
+                {
+                  "label": "Tourist",
+                  "value": "TOURIST"
+                },
+                {
+                  "label": "V911 Service",
+                  "value": "V911_SERVICE"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "upsell": {
+              "label": "Upsell",
+              "description": "Indicates if someone converted from a trial to a subscription.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "travelVerticals",
-          "type": "object",
+        "travelVerticals": {
           "label": "Travel Vertical Parameters",
           "description": "This field is used to pass additional parameters specific to the travel vertical.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "bookingDate": {
               "@path": "$.properties.booking_date"
             },
@@ -1179,248 +2652,889 @@
               "@path": "$.properties.travel_type"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "travelVerticals": {
-                "title": "Travel Vertical Parameters",
-                "description": "This field is used to pass additional parameters specific to the travel vertical.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "bookingDate": {
-                    "title": "Booking Date",
-                    "description": "Date the booking was made.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "bookingStatus": {
-                    "title": "Booking Status",
-                    "description": "Booking status at the time of tag firing.",
-                    "type": "string"
-                  },
-                  "bookingValuePostTax": {
-                    "title": "Booking Value Post-Tax",
-                    "description": "Value of booking after taxes.",
-                    "type": "number"
-                  },
-                  "bookingValuePreTax": {
-                    "title": "Booking Value Pre-Tax",
-                    "description": "Value of booking before taxes.",
-                    "type": "number"
-                  },
-                  "carOptions": {
-                    "title": "Car Options",
-                    "description": "Other items added to the reservation beyond the vehicle itself (e.g. \"insurance\", \"GPS\", \"Car Seat\").",
-                    "type": "string"
-                  },
-                  "class": {
-                    "title": "Class",
-                    "description": "Class of item (flight, hotel, car, or cruise specific classes).",
-                    "type": "string",
-                    "enum": [
-                      "first",
-                      "business",
-                      "premiumeconomy",
-                      "economy",
-                      "basiceconomy",
-                      "standard",
-                      "deluxe",
-                      "junior_suite",
-                      "suite",
-                      "economy",
-                      "compact",
-                      "mid_size",
-                      "full_size",
-                      "premium",
-                      "luxury",
-                      "mini_van",
-                      "convertible",
-                      "mid_size_suv",
-                      "standard_suv",
-                      "full_size_suv",
-                      "full_size_van",
-                      "interior",
-                      "ocean_view",
-                      "suite",
-                      "balcony"
-                    ]
-                  },
-                  "cruiseType": {
-                    "title": "Cruise Type",
-                    "description": "Type of cruise (Alaskan, Caribbean, etc...).",
-                    "type": "string"
-                  },
-                  "destinationCity": {
-                    "title": "Destination City",
-                    "description": "Customer service destination city name (New York City, Boston, Atlanta, etc...). If destinationCity is provided, destinationState must also be provided. If there is no Origin/Destination combo, but needs to indicate a location of service (network service, event) use 'destination' set of parameters.",
-                    "type": "string"
-                  },
-                  "destinationCountry": {
-                    "title": "Destination Country",
-                    "description": "Customer service destination country code, per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
-                    "type": "string"
-                  },
-                  "destinationState": {
-                    "title": "Destination State",
-                    "description": "Customer service destination state/province code. ISO 3166-2 country subdivision standards. e.g. US-NY, US-CA, US-FL, US-TX",
-                    "type": "string"
-                  },
-                  "domestic": {
-                    "title": "Domestic Travel",
-                    "description": "Indicates whether the travel is domestic (Yes) or international (No).",
-                    "type": "string",
-                    "enum": ["YES", "NO"]
-                  },
-                  "dropoffIata": {
-                    "title": "Dropoff IATA",
-                    "description": "Destination location IATA code. 3 letter IATA code.",
-                    "type": "string"
-                  },
-                  "dropoffId": {
-                    "title": "Dropoff ID",
-                    "description": "Advertiser ID for destination location.",
-                    "type": "string"
-                  },
-                  "flightFareType": {
-                    "title": "Flight Fare Type",
-                    "description": "Type of flight fare (e.g. gotta get away).",
-                    "type": "string"
-                  },
-                  "flightOptions": {
-                    "title": "Flight Options",
-                    "description": "Other items added to the reservation (e.g. Wi-Fi).",
-                    "type": "string"
-                  },
-                  "flightType": {
-                    "title": "Flight Type",
-                    "description": "Type of flight (e.g. direct, layover, overnight).",
-                    "type": "string",
-                    "enum": ["MULTI_CITY", "ONE_WAY", "ROUND_TRIP"]
-                  },
-                  "flyerMiles": {
-                    "title": "Flyer Miles",
-                    "description": "Flyer miles earned from this flight.",
-                    "type": "number"
-                  },
-                  "guests": {
-                    "title": "Guests",
-                    "description": "Number of guests.",
-                    "type": "integer"
-                  },
-                  "iata": {
-                    "title": "IATA",
-                    "description": "IATA code (3-letter); If using for a multi-stop flight each city in a flight can be provided in a comma-separated list.",
-                    "type": "string"
-                  },
-                  "itineraryId": {
-                    "title": "Itinerary ID",
-                    "description": "Booking itinerary ID.",
-                    "type": "string"
-                  },
-                  "minimumStayDuration": {
-                    "title": "Minimum Stay Duration",
-                    "description": "Minimum stay duration required in days.",
-                    "type": "number"
-                  },
-                  "originCity": {
-                    "title": "Origin City",
-                    "description": "Customer service origin city name (New York City, Ottawa, Los Angeles, etc...). If originCity is provided, originState is also provided",
-                    "type": "string"
-                  },
-                  "originCountry": {
-                    "title": "Origin Country",
-                    "description": "Customer service origin country code per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
-                    "type": "string"
-                  },
-                  "originState": {
-                    "title": "Origin State",
-                    "description": "Customer service origin state/province code per ISO 3166-2 country subdivision standards (Alaska would be \"or_state=US-AK\", Bangkok would be \"or_state=TH-10\").",
-                    "type": "string"
-                  },
-                  "paidAtBookingPostTax": {
-                    "title": "Paid at Booking (Post-Tax)",
-                    "description": "Amount paid at booking after taxes.",
-                    "type": "number"
-                  },
-                  "paidAtBookingPreTax": {
-                    "title": "Paid at Booking (Pre-Tax)",
-                    "description": "Amount paid at booking before taxes.",
-                    "type": "number"
-                  },
-                  "pickupIata": {
-                    "title": "Pickup IATA",
-                    "description": "Origin location IATA code.",
-                    "type": "string"
-                  },
-                  "pickupId": {
-                    "title": "Pickup ID",
-                    "description": "Advertiser ID for origin location.",
-                    "type": "string"
-                  },
-                  "port": {
-                    "title": "Port",
-                    "description": "Departure port city (for cruises).",
-                    "type": "string"
-                  },
-                  "roomType": {
-                    "title": "Room Type",
-                    "description": "Room type booked. If using the same values listed for \"class\" parameter, use that parameter instead.",
-                    "type": "string"
-                  },
-                  "rooms": {
-                    "title": "Rooms",
-                    "description": "Number of rooms booked.",
-                    "type": "integer"
-                  },
-                  "shipName": {
-                    "title": "Ship Name",
-                    "description": "Name of the cruise ship.",
-                    "type": "string"
-                  },
-                  "travelType": {
-                    "title": "Travel Type",
-                    "description": "\tType of travel being booked. If you want access to standardized benchmark reporting, you must pass a value from the following list.",
-                    "type": "string",
-                    "enum": [
-                      "ACTIVITIES",
-                      "AIR",
-                      "CAR",
-                      "CRUISE",
-                      "EVENTS",
-                      "HOTEL",
-                      "OTHER",
-                      "PACKAGE",
-                      "RESTAURANTS",
-                      "TRAVEL_GUIDES",
-                      "VACATION_RENTAL"
-                    ]
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "bookingDate": {
+              "label": "Booking Date",
+              "description": "Date the booking was made.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "bookingStatus": {
+              "label": "Booking Status",
+              "description": "Booking status at the time of tag firing.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "bookingValuePostTax": {
+              "label": "Booking Value Post-Tax",
+              "description": "Value of booking after taxes.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "bookingValuePreTax": {
+              "label": "Booking Value Pre-Tax",
+              "description": "Value of booking before taxes.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "carOptions": {
+              "label": "Car Options",
+              "description": "Other items added to the reservation beyond the vehicle itself (e.g. \"insurance\", \"GPS\", \"Car Seat\").",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "class": {
+              "label": "Class",
+              "description": "Class of item (flight, hotel, car, or cruise specific classes).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Flight - first",
+                  "value": "first"
+                },
+                {
+                  "label": "Flight - business",
+                  "value": "business"
+                },
+                {
+                  "label": "Flight - premium economy",
+                  "value": "premiumeconomy"
+                },
+                {
+                  "label": "Flight - economy",
+                  "value": "economy"
+                },
+                {
+                  "label": "Flight - basic economy",
+                  "value": "basiceconomy"
+                },
+                {
+                  "label": "Hotel - standard",
+                  "value": "standard"
+                },
+                {
+                  "label": "Hotel - deluxe",
+                  "value": "deluxe"
+                },
+                {
+                  "label": "Hotel - junior suite",
+                  "value": "junior_suite"
+                },
+                {
+                  "label": "Hotel - suite",
+                  "value": "suite"
+                },
+                {
+                  "label": "Car - economy",
+                  "value": "economy"
+                },
+                {
+                  "label": "Car - compact",
+                  "value": "compact"
+                },
+                {
+                  "label": "Car - mid size",
+                  "value": "mid_size"
+                },
+                {
+                  "label": "Car - full size",
+                  "value": "full_size"
+                },
+                {
+                  "label": "Car - premium",
+                  "value": "premium"
+                },
+                {
+                  "label": "Car - luxury",
+                  "value": "luxury"
+                },
+                {
+                  "label": "Car - mini van",
+                  "value": "mini_van"
+                },
+                {
+                  "label": "Car - convertible",
+                  "value": "convertible"
+                },
+                {
+                  "label": "Car - mid size SUV",
+                  "value": "mid_size_suv"
+                },
+                {
+                  "label": "Car - standard SUV",
+                  "value": "standard_suv"
+                },
+                {
+                  "label": "Car - full size SUV",
+                  "value": "full_size_suv"
+                },
+                {
+                  "label": "Car - full size van",
+                  "value": "full_size_van"
+                },
+                {
+                  "label": "Cruise - interior",
+                  "value": "interior"
+                },
+                {
+                  "label": "Cruise - ocean view",
+                  "value": "ocean_view"
+                },
+                {
+                  "label": "Cruise - suite",
+                  "value": "suite"
+                },
+                {
+                  "label": "Cruise - balcony",
+                  "value": "balcony"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "cruiseType": {
+              "label": "Cruise Type",
+              "description": "Type of cruise (Alaskan, Caribbean, etc...).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "destinationCity": {
+              "label": "Destination City",
+              "description": "Customer service destination city name (New York City, Boston, Atlanta, etc...). If destinationCity is provided, destinationState must also be provided. If there is no Origin/Destination combo, but needs to indicate a location of service (network service, event) use 'destination' set of parameters.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "destinationCountry": {
+              "label": "Destination Country",
+              "description": "Customer service destination country code, per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "destinationState": {
+              "label": "Destination State",
+              "description": "Customer service destination state/province code. ISO 3166-2 country subdivision standards. e.g. US-NY, US-CA, US-FL, US-TX",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "domestic": {
+              "label": "Domestic Travel",
+              "description": "Indicates whether the travel is domestic (Yes) or international (No).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "YES",
+                  "value": "YES"
+                },
+                {
+                  "label": "NO",
+                  "value": "NO"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "dropoffIata": {
+              "label": "Dropoff IATA",
+              "description": "Destination location IATA code. 3 letter IATA code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "dropoffId": {
+              "label": "Dropoff ID",
+              "description": "Advertiser ID for destination location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "flightFareType": {
+              "label": "Flight Fare Type",
+              "description": "Type of flight fare (e.g. gotta get away).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "flightOptions": {
+              "label": "Flight Options",
+              "description": "Other items added to the reservation (e.g. Wi-Fi).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "flightType": {
+              "label": "Flight Type",
+              "description": "Type of flight (e.g. direct, layover, overnight).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Multi City",
+                  "value": "MULTI_CITY"
+                },
+                {
+                  "label": "One Way",
+                  "value": "ONE_WAY"
+                },
+                {
+                  "label": "Round Trip",
+                  "value": "ROUND_TRIP"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "flyerMiles": {
+              "label": "Flyer Miles",
+              "description": "Flyer miles earned from this flight.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "guests": {
+              "label": "Guests",
+              "description": "Number of guests.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "iata": {
+              "label": "IATA",
+              "description": "IATA code (3-letter); If using for a multi-stop flight each city in a flight can be provided in a comma-separated list.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "itineraryId": {
+              "label": "Itinerary ID",
+              "description": "Booking itinerary ID.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "minimumStayDuration": {
+              "label": "Minimum Stay Duration",
+              "description": "Minimum stay duration required in days.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "originCity": {
+              "label": "Origin City",
+              "description": "Customer service origin city name (New York City, Ottawa, Los Angeles, etc...). If originCity is provided, originState is also provided",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "originCountry": {
+              "label": "Origin Country",
+              "description": "Customer service origin country code per ISO 3166-1 alpha 3 country code (USA, GBR, SWE, etc...).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "originState": {
+              "label": "Origin State",
+              "description": "Customer service origin state/province code per ISO 3166-2 country subdivision standards (Alaska would be \"or_state=US-AK\", Bangkok would be \"or_state=TH-10\").",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "paidAtBookingPostTax": {
+              "label": "Paid at Booking (Post-Tax)",
+              "description": "Amount paid at booking after taxes.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "paidAtBookingPreTax": {
+              "label": "Paid at Booking (Pre-Tax)",
+              "description": "Amount paid at booking before taxes.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "pickupIata": {
+              "label": "Pickup IATA",
+              "description": "Origin location IATA code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "pickupId": {
+              "label": "Pickup ID",
+              "description": "Advertiser ID for origin location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "port": {
+              "label": "Port",
+              "description": "Departure port city (for cruises).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "roomType": {
+              "label": "Room Type",
+              "description": "Room type booked. If using the same values listed for \"class\" parameter, use that parameter instead.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "rooms": {
+              "label": "Rooms",
+              "description": "Number of rooms booked.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "shipName": {
+              "label": "Ship Name",
+              "description": "Name of the cruise ship.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "travelType": {
+              "label": "Travel Type",
+              "description": "\tType of travel being booked. If you want access to standardized benchmark reporting, you must pass a value from the following list.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Activities",
+                  "value": "ACTIVITIES"
+                },
+                {
+                  "label": "Air",
+                  "value": "AIR"
+                },
+                {
+                  "label": "Car",
+                  "value": "CAR"
+                },
+                {
+                  "label": "Cruise",
+                  "value": "CRUISE"
+                },
+                {
+                  "label": "Events",
+                  "value": "EVENTS"
+                },
+                {
+                  "label": "Hotel",
+                  "value": "HOTEL"
+                },
+                {
+                  "label": "Other",
+                  "value": "OTHER"
+                },
+                {
+                  "label": "Package",
+                  "value": "PACKAGE"
+                },
+                {
+                  "label": "Restaurants",
+                  "value": "RESTAURANTS"
+                },
+                {
+                  "label": "Travel Guides",
+                  "value": "TRAVEL_GUIDES"
+                },
+                {
+                  "label": "Vacation Rental",
+                  "value": "VACATION_RENTAL"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "financeVerticals",
-          "type": "object",
+        "financeVerticals": {
           "label": "Finance Verticals",
           "description": "This field is used to pass additional parameters specific to the finance vertical.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "annualFee": {
               "@path": "$.properties.annual_fee"
             },
@@ -1482,165 +3596,565 @@
               "@path": "$.properties.transfer_fee"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "financeVerticals": {
-                "title": "Finance Verticals",
-                "description": "This field is used to pass additional parameters specific to the finance vertical.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "annualFee": {
-                    "title": "Annual Fee",
-                    "description": "Amount of the annual fee.",
-                    "type": "number"
-                  },
-                  "applicationStatus": {
-                    "title": "Application Status",
-                    "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
-                    "type": "string",
-                    "enum": [
-                      "instant_approved",
-                      "instant_declined",
-                      "pended",
-                      "approved",
-                      "declined",
-                      "declined_counter"
-                    ]
-                  },
-                  "apr": {
-                    "title": "APR",
-                    "description": "APR at time of application approval.",
-                    "type": "number"
-                  },
-                  "aprTransfer": {
-                    "title": "APR Transfer",
-                    "description": "APR for transfers.",
-                    "type": "number"
-                  },
-                  "aprTransferTime": {
-                    "title": "APR Transfer Time",
-                    "description": "If transfer APR is only for a certain period of time, pass the number of months here.",
-                    "type": "integer"
-                  },
-                  "cardCategory": {
-                    "title": "Card Category",
-                    "description": "Category of the card.",
-                    "type": "string",
-                    "enum": [
-                      "BALANCE_TRANSFER_CARDS",
-                      "CASH_BACK_REWARD_CARDS",
-                      "CHARGE_CARDS",
-                      "CLICKS",
-                      "MILITARY_AFFILIATE",
-                      "OTHER",
-                      "REWARD_POINTS_CARDS",
-                      "CREDIT_BUILDING_CARDS",
-                      "STUDENT_CARDS",
-                      "TRAVEL_REWARD_CARDS",
-                      "UNKNOWN_PRODUCT",
-                      "LOW_APR_CARDS"
-                    ]
-                  },
-                  "cashAdvanceFee": {
-                    "title": "Cash Advance Fee",
-                    "description": "Amount of the fee associated with the cash advance.",
-                    "type": "number"
-                  },
-                  "contractLength": {
-                    "title": "Contract Length",
-                    "description": "Contract length, in months.",
-                    "type": "number"
-                  },
-                  "contractType": {
-                    "title": "Contract Type",
-                    "description": "Advertiser-specific contract description.",
-                    "type": "string"
-                  },
-                  "creditReport": {
-                    "title": "Credit Report",
-                    "description": "Indicates if the customer received a credit report and if it was purchased.",
-                    "type": "string",
-                    "enum": ["purchase", "free", "trial"]
-                  },
-                  "creditLine": {
-                    "title": "Credit Line",
-                    "description": "Amount of credit extended through product.",
-                    "type": "number"
-                  },
-                  "creditQuality": {
-                    "title": "Credit Quality",
-                    "description": "Minimum credit tier required for product approval. (300-579=Very Poor, 580-669=Fair, 670-739=Good,740-799=Very Good, 800-850=Exceptional).",
-                    "type": "string",
-                    "enum": ["Very Poor", "Fair", "Good", "Very Good", "Exceptional"]
-                  },
-                  "fundedAmount": {
-                    "title": "Funded Amount",
-                    "description": "Indicates the amount of funding added to the account at the time of transaction.",
-                    "type": "number"
-                  },
-                  "fundedCurrency": {
-                    "title": "Funded Currency",
-                    "description": "Currency of the funding provided for the new account.",
-                    "type": "number"
-                  },
-                  "introductoryApr": {
-                    "title": "Introductory APR",
-                    "description": "The introductory APR amount. (If the intro APR is not different than overall APR, use the \"APR\" parameter).",
-                    "type": "number"
-                  },
-                  "introductoryAprTime": {
-                    "title": "Introductory APR Time",
-                    "description": "The number of months the intro APR applies for.",
-                    "type": "integer"
-                  },
-                  "minimumBalance": {
-                    "title": "Minimum Balance",
-                    "description": "Value of the minimum cash balance requirement for the account.",
-                    "type": "number"
-                  },
-                  "minimumDeposit": {
-                    "title": "Minimum Deposit",
-                    "description": "Indicates the value if a minimum deposit is required.",
-                    "type": "number"
-                  },
-                  "prequalify": {
-                    "title": "Prequalify",
-                    "description": "Indicates if the applicant was pre-qualified for the card.",
-                    "type": "string",
-                    "enum": ["Yes", "No"]
-                  },
-                  "transferFee": {
-                    "title": "Transfer Fee",
-                    "description": "The transfer fee amount (i.e. for a credit card).",
-                    "type": "number"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "annualFee": {
+              "label": "Annual Fee",
+              "description": "Amount of the annual fee.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "applicationStatus": {
+              "label": "Application Status",
+              "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Instant Approved",
+                  "value": "instant_approved"
+                },
+                {
+                  "label": "Instant Declined",
+                  "value": "instant_declined"
+                },
+                {
+                  "label": "Pended",
+                  "value": "pended"
+                },
+                {
+                  "label": "Approved",
+                  "value": "approved"
+                },
+                {
+                  "label": "Declined",
+                  "value": "declined"
+                },
+                {
+                  "label": "Declined Counter",
+                  "value": "declined_counter"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "apr": {
+              "label": "APR",
+              "description": "APR at time of application approval.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "aprTransfer": {
+              "label": "APR Transfer",
+              "description": "APR for transfers.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "aprTransferTime": {
+              "label": "APR Transfer Time",
+              "description": "If transfer APR is only for a certain period of time, pass the number of months here.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "cardCategory": {
+              "label": "Card Category",
+              "description": "Category of the card.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Balance Transfer Cards",
+                  "value": "BALANCE_TRANSFER_CARDS"
+                },
+                {
+                  "label": "Cash Back Reward Cards",
+                  "value": "CASH_BACK_REWARD_CARDS"
+                },
+                {
+                  "label": "Charge Cards",
+                  "value": "CHARGE_CARDS"
+                },
+                {
+                  "label": "Clicks",
+                  "value": "CLICKS"
+                },
+                {
+                  "label": "Military Affiliate",
+                  "value": "MILITARY_AFFILIATE"
+                },
+                {
+                  "label": "Other",
+                  "value": "OTHER"
+                },
+                {
+                  "label": "Reward Points Cards",
+                  "value": "REWARD_POINTS_CARDS"
+                },
+                {
+                  "label": "Credit Building Cards",
+                  "value": "CREDIT_BUILDING_CARDS"
+                },
+                {
+                  "label": "Student Cards",
+                  "value": "STUDENT_CARDS"
+                },
+                {
+                  "label": "Travel Reward Cards",
+                  "value": "TRAVEL_REWARD_CARDS"
+                },
+                {
+                  "label": "Unknown Product",
+                  "value": "UNKNOWN_PRODUCT"
+                },
+                {
+                  "label": "Low APR Cards",
+                  "value": "LOW_APR_CARDS"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "cashAdvanceFee": {
+              "label": "Cash Advance Fee",
+              "description": "Amount of the fee associated with the cash advance.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "contractLength": {
+              "label": "Contract Length",
+              "description": "Contract length, in months.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "contractType": {
+              "label": "Contract Type",
+              "description": "Advertiser-specific contract description.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creditReport": {
+              "label": "Credit Report",
+              "description": "Indicates if the customer received a credit report and if it was purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Purchase",
+                  "value": "purchase"
+                },
+                {
+                  "label": "Free",
+                  "value": "free"
+                },
+                {
+                  "label": "Trial",
+                  "value": "trial"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creditLine": {
+              "label": "Credit Line",
+              "description": "Amount of credit extended through product.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creditQuality": {
+              "label": "Credit Quality",
+              "description": "Minimum credit tier required for product approval. (300-579=Very Poor, 580-669=Fair, 670-739=Good,740-799=Very Good, 800-850=Exceptional).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Very Poor",
+                  "value": "Very Poor"
+                },
+                {
+                  "label": "Fair",
+                  "value": "Fair"
+                },
+                {
+                  "label": "Good",
+                  "value": "Good"
+                },
+                {
+                  "label": "Very Good",
+                  "value": "Very Good"
+                },
+                {
+                  "label": "Exceptional",
+                  "value": "Exceptional"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fundedAmount": {
+              "label": "Funded Amount",
+              "description": "Indicates the amount of funding added to the account at the time of transaction.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fundedCurrency": {
+              "label": "Funded Currency",
+              "description": "Currency of the funding provided for the new account.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "introductoryApr": {
+              "label": "Introductory APR",
+              "description": "The introductory APR amount. (If the intro APR is not different than overall APR, use the \"APR\" parameter).",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "introductoryAprTime": {
+              "label": "Introductory APR Time",
+              "description": "The number of months the intro APR applies for.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "minimumBalance": {
+              "label": "Minimum Balance",
+              "description": "Value of the minimum cash balance requirement for the account.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "minimumDeposit": {
+              "label": "Minimum Deposit",
+              "description": "Indicates the value if a minimum deposit is required.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "prequalify": {
+              "label": "Prequalify",
+              "description": "Indicates if the applicant was pre-qualified for the card.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Yes",
+                  "value": "Yes"
+                },
+                {
+                  "label": "No",
+                  "value": "No"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "transferFee": {
+              "label": "Transfer Fee",
+              "description": "The transfer fee amount (i.e. for a credit card).",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "networkServicesVerticals",
-          "type": "object",
+        "networkServicesVerticals": {
           "label": "Network Services Verticals",
           "description": "This field is used to pass additional parameters specific to the network services vertical.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "annualFee": {
               "@path": "$.properties.annual_fee"
             },
@@ -1654,395 +4168,130 @@
               "@path": "$.properties.contract_type"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
+          "placeholder": null,
+          "properties": {
+            "annualFee": {
+              "label": "Annual Fee",
+              "description": "Amount of the annual fee.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "applicationStatus": {
+              "label": "Application Status",
+              "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Instant Approved",
+                  "value": "instant_approved"
+                },
+                {
+                  "label": "Instant Declined",
+                  "value": "instant_declined"
+                },
+                {
+                  "label": "Pended",
+                  "value": "pended"
+                },
+                {
+                  "label": "Approved",
+                  "value": "approved"
+                },
+                {
+                  "label": "Declined",
+                  "value": "declined"
+                },
+                {
+                  "label": "Declined Counter",
+                  "value": "declined_counter"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "contractLength": {
+              "label": "Contract Length",
+              "description": "Contract length, in months.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "contractType": {
+              "label": "Contract Type",
+              "description": "Advertiser-specific contract description.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "networkServicesVerticals": {
-                "title": "Network Services Verticals",
-                "description": "This field is used to pass additional parameters specific to the network services vertical.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "annualFee": {
-                    "title": "Annual Fee",
-                    "description": "Amount of the annual fee.",
-                    "type": "number"
-                  },
-                  "applicationStatus": {
-                    "title": "Application Status",
-                    "description": "Identifies the status of the application at the time the transaction is sent to CJ.",
-                    "type": "string",
-                    "enum": [
-                      "instant_approved",
-                      "instant_declined",
-                      "pended",
-                      "approved",
-                      "declined",
-                      "declined_counter"
-                    ]
-                  },
-                  "contractLength": {
-                    "title": "Contract Length",
-                    "description": "Contract length, in months.",
-                    "type": "number"
-                  },
-                  "contractType": {
-                    "title": "Contract Type",
-                    "description": "Advertiser-specific contract description.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
-    },
-    {
-      "slug": "sitePage",
-      "name": "Site Page",
-      "description": "Send site page data to CJ.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique ID assigned by you to the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique ID assigned by you to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "enterpriseId",
-          "type": "number",
-          "label": "Enterprise ID",
-          "description": "Your CJ Enterprise ID.",
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enterpriseId": {
-                "title": "Enterprise ID",
-                "description": "Your CJ Enterprise ID.",
-                "type": "number"
-              }
-            },
-            "required": ["enterpriseId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "pageType",
-          "type": "string",
-          "label": "Page Type",
-          "description": "Page type to be sent to CJ.",
-          "required": true,
-          "multiple": false,
-          "choices": [
-            {
-              "label": "Account Center",
-              "value": "accountCenter"
-            },
-            {
-              "label": "Account Signup",
-              "value": "accountSignup"
-            },
-            {
-              "label": "Application Start",
-              "value": "applicationStart"
-            },
-            {
-              "label": "Branch Locator",
-              "value": "branchLocator"
-            },
-            {
-              "label": "Cart",
-              "value": "cart"
-            },
-            {
-              "label": "Category",
-              "value": "category"
-            },
-            {
-              "label": "Conversion Confirmation",
-              "value": "conversionConfirmation"
-            },
-            {
-              "label": "Department",
-              "value": "department"
-            },
-            {
-              "label": "Homepage",
-              "value": "homepage"
-            },
-            {
-              "label": "Information",
-              "value": "information"
-            },
-            {
-              "label": "Product Detail",
-              "value": "productDetail"
-            },
-            {
-              "label": "Property Detail",
-              "value": "propertyDetail"
-            },
-            {
-              "label": "Property Results",
-              "value": "propertyResults"
-            },
-            {
-              "label": "Search Results",
-              "value": "searchResults"
-            },
-            {
-              "label": "Store Locator",
-              "value": "storeLocator"
-            },
-            {
-              "label": "Sub Category",
-              "value": "subCategory"
-            }
-          ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "pageType": {
-                "title": "Page Type",
-                "description": "Page type to be sent to CJ.",
-                "type": "string",
-                "enum": [
-                  "accountCenter",
-                  "accountSignup",
-                  "applicationStart",
-                  "branchLocator",
-                  "cart",
-                  "category",
-                  "conversionConfirmation",
-                  "department",
-                  "homepage",
-                  "information",
-                  "productDetail",
-                  "propertyDetail",
-                  "propertyResults",
-                  "searchResults",
-                  "storeLocator",
-                  "subCategory"
-                ]
-              }
-            },
-            "required": ["pageType"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "referringChannel",
-          "type": "string",
-          "label": "Referring Channel",
-          "description": "The referring channel to be sent to CJ.",
-          "required": false,
-          "multiple": false,
-          "choices": [
-            {
-              "label": "Affiliate",
-              "value": "Affiliate"
-            },
-            {
-              "label": "Display",
-              "value": "Display"
-            },
-            {
-              "label": "Social",
-              "value": "Social"
-            },
-            {
-              "label": "Search",
-              "value": "Search"
-            },
-            {
-              "label": "Email",
-              "value": "Email"
-            },
-            {
-              "label": "Direct Navigation",
-              "value": "Direct_Navigation"
-            }
-          ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "referringChannel": {
-                "title": "Referring Channel",
-                "description": "The referring channel to be sent to CJ.",
-                "type": "string",
-                "enum": ["Affiliate", "Display", "Social", "Search", "Email", "Direct_Navigation"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "cartSubtotal",
-          "type": "number",
-          "label": "Cart Subtotal",
-          "description": "The cart subtotal to be sent to CJ.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "cartSubtotal": {
-                "title": "Cart Subtotal",
-                "description": "The cart subtotal to be sent to CJ.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Items",
-          "description": "The items to be sent to CJ.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "unitPrice": {
-                  "@path": "$.price"
-                },
-                "itemId": {
-                  "@path": "$.id"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                },
-                "discount": {
-                  "@path": "$.discount"
-                }
-              }
-            ]
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "items": {
-                "title": "Items",
-                "description": "The items to be sent to CJ.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "unitPrice": {
-                      "title": "Unit Price",
-                      "description": "the price of the item before tax and discount.",
-                      "type": "number"
-                    },
-                    "itemId": {
-                      "title": "Item ID",
-                      "description": "The item sku.",
-                      "type": "string"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "The quantity of the item.",
-                      "type": "number"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "The discount applied to the item.",
-                      "type": "number"
-                    }
-                  },
-                  "required": ["unitPrice", "itemId", "quantity"]
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/commandbar/metadata.json
+++ b/packages/browser-destinations/destinations/commandbar/metadata.json
@@ -10,16 +10,20 @@
         "description": "The ID of your CommandBar organization.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "deploy": {
         "label": "Deploy via Segment",
         "description": "If enabled, CommandBar will be deployed to your site automatically and you can remove the snippet from your source code.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -33,7 +37,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -56,7 +60,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "hmac": {
           "label": "HMAC",
@@ -79,7 +85,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "formFactor": {
           "label": "Event Metadata",
@@ -102,7 +110,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -125,7 +135,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -137,7 +149,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -160,7 +172,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_metadata": {
           "label": "Event Metadata",
@@ -183,7 +197,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/commandbar/metadata.json
+++ b/packages/browser-destinations/destinations/commandbar/metadata.json
@@ -1,0 +1,283 @@
+{
+  "name": "CommandBar",
+  "basicOptions": ["orgId", "deploy"],
+  "options": {
+    "orgId": {
+      "tags": [],
+      "default": "",
+      "description": "The ID of your CommandBar organization.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Organization ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The orgId property is required."]],
+      "uIMetadata": null
+    },
+    "deploy": {
+      "tags": [],
+      "default": false,
+      "description": "If enabled, CommandBar will be deployed to your site automatically and you can remove the snippet from your source code.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Deploy via Segment",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Set attributes for the user in CommandBar. If \"Deploy via Segment\" is enabled, then also boot CommandBar for the user, which makes CommandBar available to the user.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The user's id",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The user's id",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "hmac",
+          "type": "string",
+          "label": "HMAC",
+          "description": "Identify users with an HMAC of their user ID; this enables end user customizable shortcuts and other features. [Learn about identity verification](https://app.commandbar.com/identity-verification).",
+          "defaultValue": {
+            "@path": "$.context.CommandBar.hmac"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hmac": {
+                "title": "HMAC",
+                "description": "Identify users with an HMAC of their user ID; this enables end user customizable shortcuts and other features. [Learn about identity verification](https://app.commandbar.com/identity-verification).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "formFactor",
+          "type": "object",
+          "label": "Event Metadata",
+          "description": "Configures the way the bar is displayed. An 'inline' bar is always visible and hosted within an element on your page. A 'modal' bar will display in a modal dialog when open.",
+          "defaultValue": {
+            "@path": "$.context.CommandBar.formFactor"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "formFactor": {
+                "title": "Event Metadata",
+                "description": "Configures the way the bar is displayed. An 'inline' bar is always visible and hosted within an element on your page. A 'modal' bar will display in a modal dialog when open.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to CommandBar",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to CommandBar",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Submit an event's properties as CommandBar metaData.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_metadata",
+          "type": "object",
+          "label": "Event Metadata",
+          "description": "Optional metadata describing the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_metadata": {
+                "title": "Event Metadata",
+                "description": "Optional metadata describing the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "hmac": {
+          "@path": "$.context.CommandBar.hmac"
+        },
+        "formFactor": {
+          "@path": "$.context.CommandBar.formFactor"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "event_metadata": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/commandbar/metadata.json
+++ b/packages/browser-destinations/destinations/commandbar/metadata.json
@@ -1,253 +1,213 @@
 {
+  "slug": "actions-commandbar",
   "name": "CommandBar",
-  "basicOptions": ["orgId", "deploy"],
-  "options": {
-    "orgId": {
-      "tags": [],
-      "default": "",
-      "description": "The ID of your CommandBar organization.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Organization ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The orgId property is required."]],
-      "uIMetadata": null
-    },
-    "deploy": {
-      "tags": [],
-      "default": false,
-      "description": "If enabled, CommandBar will be deployed to your site automatically and you can remove the snippet from your source code.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Deploy via Segment",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "orgId": {
+        "label": "Organization ID",
+        "description": "The ID of your CommandBar organization.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "deploy": {
+        "label": "Deploy via Segment",
+        "description": "If enabled, CommandBar will be deployed to your site automatically and you can remove the snippet from your source code.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Set attributes for the user in CommandBar. If \"Deploy via Segment\" is enabled, then also boot CommandBar for the user, which makes CommandBar available to the user.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The user's id",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The user's id",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "hmac",
-          "type": "string",
+        "hmac": {
           "label": "HMAC",
           "description": "Identify users with an HMAC of their user ID; this enables end user customizable shortcuts and other features. [Learn about identity verification](https://app.commandbar.com/identity-verification).",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.context.CommandBar.hmac"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "hmac": {
-                "title": "HMAC",
-                "description": "Identify users with an HMAC of their user ID; this enables end user customizable shortcuts and other features. [Learn about identity verification](https://app.commandbar.com/identity-verification).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "formFactor",
-          "type": "object",
+        "formFactor": {
           "label": "Event Metadata",
           "description": "Configures the way the bar is displayed. An 'inline' bar is always visible and hosted within an element on your page. A 'modal' bar will display in a modal dialog when open.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.context.CommandBar.formFactor"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "formFactor": {
-                "title": "Event Metadata",
-                "description": "Configures the way the bar is displayed. An 'inline' bar is always visible and hosted within an element on your page. A 'modal' bar will display in a modal dialog when open.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "Traits",
           "description": "The Segment traits to be forwarded to CommandBar",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to CommandBar",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Submit an event's properties as CommandBar metaData.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
           "label": "Event Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["event_name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event_metadata",
-          "type": "object",
+        "event_metadata": {
           "label": "Event Metadata",
           "description": "Optional metadata describing the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_metadata": {
-                "title": "Event Metadata",
-                "description": "Optional metadata describing the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "event_metadata": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -263,21 +223,7 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "event_name": {
-          "@path": "$.event"
-        },
-        "event_metadata": {
-          "@path": "$.properties"
-        }
-      },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/contentstack-web/metadata.json
+++ b/packages/browser-destinations/destinations/contentstack-web/metadata.json
@@ -1,0 +1,199 @@
+{
+  "name": "Contentstack Web",
+  "description": "Sync web event and user profile data from Segment to Contentstack",
+  "basicOptions": ["personalizeProjectId", "personalizeEdgeApiBaseUrl"],
+  "options": {
+    "personalizeProjectId": {
+      "tags": [],
+      "default": "",
+      "description": "Your Personalize project ID to which Segment's data should be synced.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Personalize project ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The personalizeProjectId property is required."]],
+      "uIMetadata": null
+    },
+    "personalizeEdgeApiBaseUrl": {
+      "tags": [],
+      "default": "",
+      "description": "Your region-based personalize-edge API base URL.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Personalize Edge API base URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The personalizeEdgeApiBaseUrl property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "customAttributesSync",
+      "name": "Custom Attributes Sync",
+      "description": "Sync Custom Attributes to your Contentstack Experience.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" or type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User traits",
+          "description": "User Profile traits to send to Contentstack",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits"
+              },
+              "then": {
+                "@path": "$.traits"
+              },
+              "else": {
+                "@path": "$.context.traits"
+              }
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User traits",
+                "description": "User Profile traits to send to Contentstack",
+                "type": "object"
+              }
+            },
+            "required": ["traits"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "ID for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "ID for the user",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "eventsSync",
+      "name": "Events Sync",
+      "description": "Sync Events to your Contentstack Experience.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "ID for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "ID for the user",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "User Event",
+          "description": "User Event",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "User Event",
+                "description": "User Event",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/contentstack-web/metadata.json
+++ b/packages/browser-destinations/destinations/contentstack-web/metadata.json
@@ -11,16 +11,20 @@
         "description": "Your Personalize project ID to which Segment's data should be synced.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "personalizeEdgeApiBaseUrl": {
         "label": "Personalize Edge API base URL",
         "description": "Your region-based personalize-edge API base URL.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -34,7 +38,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "traits": {
           "label": "User traits",
@@ -67,7 +71,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -90,7 +96,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -102,7 +110,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -125,7 +133,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event": {
           "label": "User Event",
@@ -148,7 +158,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/contentstack-web/metadata.json
+++ b/packages/browser-destinations/destinations/contentstack-web/metadata.json
@@ -1,63 +1,50 @@
 {
+  "slug": "contentstack-web",
   "name": "Contentstack Web",
+  "mode": "device",
   "description": "Sync web event and user profile data from Segment to Contentstack",
-  "basicOptions": ["personalizeProjectId", "personalizeEdgeApiBaseUrl"],
-  "options": {
-    "personalizeProjectId": {
-      "tags": [],
-      "default": "",
-      "description": "Your Personalize project ID to which Segment's data should be synced.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Personalize project ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The personalizeProjectId property is required."]],
-      "uIMetadata": null
-    },
-    "personalizeEdgeApiBaseUrl": {
-      "tags": [],
-      "default": "",
-      "description": "Your region-based personalize-edge API base URL.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Personalize Edge API base URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The personalizeEdgeApiBaseUrl property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "personalizeProjectId": {
+        "label": "Personalize project ID",
+        "description": "Your Personalize project ID to which Segment's data should be synced.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "personalizeEdgeApiBaseUrl": {
+        "label": "Personalize Edge API base URL",
+        "description": "Your region-based personalize-edge API base URL.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "customAttributesSync",
-      "name": "Custom Attributes Sync",
+  "audienceConfig": null,
+  "actions": {
+    "customAttributesSync": {
+      "title": "Custom Attributes Sync",
       "description": "Sync Custom Attributes to your Contentstack Experience.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" or type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" or type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "traits",
-          "type": "object",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "traits": {
           "label": "User traits",
           "description": "User Profile traits to send to Contentstack",
-          "defaultValue": {
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.traits"
@@ -70,130 +57,101 @@
               }
             }
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User traits",
-                "description": "User Profile traits to send to Contentstack",
-                "type": "object"
-              }
-            },
-            "required": ["traits"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "ID for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "ID for the user",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "eventsSync",
-      "name": "Events Sync",
+    "eventsSync": {
+      "title": "Events Sync",
       "description": "Sync Events to your Contentstack Experience.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "ID for the user",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "ID for the user",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event",
-          "type": "string",
+        "event": {
           "label": "User Event",
           "description": "User Event",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "User Event",
-                "description": "User Event",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/evolv-ai/metadata.json
+++ b/packages/browser-destinations/destinations/evolv-ai/metadata.json
@@ -1,0 +1,354 @@
+{
+  "name": "Evolv AI Web Mode (Actions)",
+  "basicOptions": [
+    "environment",
+    "useSegmentId",
+    "evolvTimeout",
+    "useCookies",
+    "receiveConfirmations",
+    "receiveUniqueConfirmations"
+  ],
+  "options": {
+    "environment": {
+      "tags": [],
+      "default": "",
+      "description": "To load the Evolv AI snippet via Segment, include your Environment API Key found in the Evolv AI Manager. This option should only be used if you are not already loading the Evolv AI snippet on your site.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Evolv AI Environment Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "useSegmentId": {
+      "tags": [],
+      "default": false,
+      "description": "When using this option, Evolv AI will levarage the Segment Anonymous ID instead of generating a new user id.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Use Segment's Anonymous ID as the Evolv user id",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "environment",
+            "operator": "is_not",
+            "value": ""
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "evolvTimeout": {
+      "tags": [],
+      "default": 10000,
+      "description": "If you want to ignore users who take too long to apply the optimization changes, then you can use this configuration to limit how long Evolv AI should wait till the page renders.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Evolv Timeout",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "environment",
+            "operator": "is_not",
+            "value": ""
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "useCookies": {
+      "tags": [],
+      "default": "",
+      "description": "By default, Evolv AI stores the user id in localStorage. Since localStorage cannot be read across subdomains (e.g. domain1.example.com to domain2.example.com), you will need to specify a cookie domain (for example .example.com) in order to track users across subdomains.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie domain name to store Evolv AI user id",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "environment",
+            "operator": "is_not",
+            "value": ""
+          },
+          {
+            "fieldKey": "useSegmentId",
+            "operator": "is",
+            "value": false
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "receiveConfirmations": {
+      "tags": [],
+      "default": true,
+      "description": "When set, all Evolv AI confirmations for each project will be sent to Segment.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Receive all Evolv AI project confirmations",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "receiveUniqueConfirmations": {
+      "tags": [],
+      "default": false,
+      "description": "When set, only unique confirmations (once per project per session) will be sent to Segment.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Receive unique project confirmations only",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "receiveConfirmations",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Send Segment user traits to Evolv AI",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "Attributes",
+          "description": "Object containing additional attributes associated with the user.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributes": {
+                "title": "Attributes",
+                "description": "Object containing additional attributes associated with the user.",
+                "type": "object"
+              }
+            },
+            "required": ["attributes"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send Segment track event to Evolv AI",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Name",
+          "description": "Name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Name",
+                "description": "Name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["eventName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "JSON object containing additional properties associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "JSON object containing additional properties associated with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "attributes": {
+          "@path": "$.traits"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/evolv-ai/metadata.json
+++ b/packages/browser-destinations/destinations/evolv-ai/metadata.json
@@ -1,327 +1,222 @@
 {
+  "slug": "actions-evolv-ai-web",
   "name": "Evolv AI Web Mode (Actions)",
-  "basicOptions": [
-    "environment",
-    "useSegmentId",
-    "evolvTimeout",
-    "useCookies",
-    "receiveConfirmations",
-    "receiveUniqueConfirmations"
-  ],
-  "options": {
-    "environment": {
-      "tags": [],
-      "default": "",
-      "description": "To load the Evolv AI snippet via Segment, include your Environment API Key found in the Evolv AI Manager. This option should only be used if you are not already loading the Evolv AI snippet on your site.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Evolv AI Environment Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "useSegmentId": {
-      "tags": [],
-      "default": false,
-      "description": "When using this option, Evolv AI will levarage the Segment Anonymous ID instead of generating a new user id.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Use Segment's Anonymous ID as the Evolv user id",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "environment",
-            "operator": "is_not",
-            "value": ""
-          }
-        ]
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "environment": {
+        "label": "Evolv AI Environment Key",
+        "description": "To load the Evolv AI snippet via Segment, include your Environment API Key found in the Evolv AI Manager. This option should only be used if you are not already loading the Evolv AI snippet on your site.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": ""
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "evolvTimeout": {
-      "tags": [],
-      "default": 10000,
-      "description": "If you want to ignore users who take too long to apply the optimization changes, then you can use this configuration to limit how long Evolv AI should wait till the page renders.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Evolv Timeout",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "environment",
-            "operator": "is_not",
-            "value": ""
-          }
-        ]
+      "useSegmentId": {
+        "label": "Use Segment's Anonymous ID as the Evolv user id",
+        "description": "When using this option, Evolv AI will levarage the Segment Anonymous ID instead of generating a new user id.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "useCookies": {
-      "tags": [],
-      "default": "",
-      "description": "By default, Evolv AI stores the user id in localStorage. Since localStorage cannot be read across subdomains (e.g. domain1.example.com to domain2.example.com), you will need to specify a cookie domain (for example .example.com) in order to track users across subdomains.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie domain name to store Evolv AI user id",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "environment",
-            "operator": "is_not",
-            "value": ""
-          },
-          {
-            "fieldKey": "useSegmentId",
-            "operator": "is",
-            "value": false
-          }
-        ]
+      "evolvTimeout": {
+        "label": "Evolv Timeout",
+        "description": "If you want to ignore users who take too long to apply the optimization changes, then you can use this configuration to limit how long Evolv AI should wait till the page renders.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 10000
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "receiveConfirmations": {
-      "tags": [],
-      "default": true,
-      "description": "When set, all Evolv AI confirmations for each project will be sent to Segment.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Receive all Evolv AI project confirmations",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "receiveUniqueConfirmations": {
-      "tags": [],
-      "default": false,
-      "description": "When set, only unique confirmations (once per project per session) will be sent to Segment.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Receive unique project confirmations only",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "receiveConfirmations",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "useCookies": {
+        "label": "Cookie domain name to store Evolv AI user id",
+        "description": "By default, Evolv AI stores the user id in localStorage. Since localStorage cannot be read across subdomains (e.g. domain1.example.com to domain2.example.com), you will need to specify a cookie domain (for example .example.com) in order to track users across subdomains.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": ""
       },
-      "validators": [],
-      "uIMetadata": null
+      "receiveConfirmations": {
+        "label": "Receive all Evolv AI project confirmations",
+        "description": "When set, all Evolv AI confirmations for each project will be sent to Segment.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "receiveUniqueConfirmations": {
+        "label": "Receive unique project confirmations only",
+        "description": "When set, only unique confirmations (once per project per session) will be sent to Segment.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Send Segment user traits to Evolv AI",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "attributes",
-          "type": "object",
-          "label": "Attributes",
-          "description": "Object containing additional attributes associated with the user.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributes": {
-                "title": "Attributes",
-                "description": "Object containing additional attributes associated with the user.",
-                "type": "object"
-              }
-            },
-            "required": ["attributes"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "Unique identifier for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "Anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Send Segment track event to Evolv AI",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "eventName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventName": {
           "label": "Name",
           "description": "Name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Name",
-                "description": "Name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["eventName"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "JSON object containing additional properties associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "JSON object containing additional properties associated with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Send Segment user traits to Evolv AI",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "attributes": {
+          "label": "Attributes",
+          "description": "Object containing additional attributes associated with the user.",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "attributes": {
@@ -334,21 +229,7 @@
           "@path": "$.anonymousId"
         }
       },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "eventName": {
-          "@path": "$.event"
-        },
-        "properties": {
-          "@path": "$.properties"
-        }
-      },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/evolv-ai/metadata.json
+++ b/packages/browser-destinations/destinations/evolv-ai/metadata.json
@@ -10,48 +10,97 @@
         "description": "To load the Evolv AI snippet via Segment, include your Environment API Key found in the Evolv AI Manager. This option should only be used if you are not already loading the Evolv AI snippet on your site.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": ""
+        "default": "",
+        "depends_on": null
       },
       "useSegmentId": {
         "label": "Use Segment's Anonymous ID as the Evolv user id",
         "description": "When using this option, Evolv AI will levarage the Segment Anonymous ID instead of generating a new user id.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "environment",
+              "operator": "is_not",
+              "value": ""
+            }
+          ]
+        }
       },
       "evolvTimeout": {
         "label": "Evolv Timeout",
         "description": "If you want to ignore users who take too long to apply the optimization changes, then you can use this configuration to limit how long Evolv AI should wait till the page renders.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 10000
+        "default": 10000,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "environment",
+              "operator": "is_not",
+              "value": ""
+            }
+          ]
+        }
       },
       "useCookies": {
         "label": "Cookie domain name to store Evolv AI user id",
         "description": "By default, Evolv AI stores the user id in localStorage. Since localStorage cannot be read across subdomains (e.g. domain1.example.com to domain2.example.com), you will need to specify a cookie domain (for example .example.com) in order to track users across subdomains.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": ""
+        "default": "",
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "environment",
+              "operator": "is_not",
+              "value": ""
+            },
+            {
+              "fieldKey": "useSegmentId",
+              "operator": "is",
+              "value": false
+            }
+          ]
+        }
       },
       "receiveConfirmations": {
         "label": "Receive all Evolv AI project confirmations",
         "description": "When set, all Evolv AI confirmations for each project will be sent to Segment.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "receiveUniqueConfirmations": {
         "label": "Receive unique project confirmations only",
         "description": "When set, only unique confirmations (once per project per session) will be sent to Segment.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "receiveConfirmations",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       }
     }
   },
@@ -65,7 +114,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventName": {
           "label": "Name",
@@ -88,7 +137,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -111,7 +162,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -123,7 +176,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "attributes": {
           "label": "Attributes",
@@ -146,7 +199,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -169,7 +224,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -192,7 +249,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
+++ b/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
@@ -11,46 +11,57 @@
         "description": "The Pixel ID associated with your Facebook Pixel.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "disablePushState": {
         "label": "Disable Push State",
         "description": "If set to true, prevents Facebook Pixel from sending PageView events on history state changes. Set to true if you want to trigger PageView events manually via the pageView Action.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "disableAutoConfig": {
         "label": "Disable Auto Config",
         "description": "Control whether Facebook’s Meta Pixel automatically collects additional page and button data to optimize ads and measurement. When this toggle is on, Auto Config is disabled and only basic pixel tracking will occur. Turning it off enables Auto Config, allowing the Pixel to automatically send page metadata and button interactions to improve ad delivery and reporting.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "disableFirstPartyCookies": {
         "label": "Disable First Party Cookies",
         "description": "Control whether Facebook’s Meta Pixel uses first-party cookies. When this toggle is on, first-party cookies are disabled, enhancing user privacy. Turning it off enables the use of first-party cookies for more accurate tracking.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "agent": {
         "label": "Agent",
         "description": "Specifies the agent to use when sending events.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "segment"
+        "default": "segment",
+        "depends_on": null
       },
       "ldu": {
         "label": "Limited Data User (LDU)",
         "description": "Specify if and how Limited Data Use should apply.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "LDU disabled",
@@ -109,15 +120,18 @@
             "value": "Minnesota"
           }
         ],
-        "default": "Disabled"
+        "default": "Disabled",
+        "depends_on": null
       },
       "formatUserDataWithParamBuilder": {
         "label": "Format User Data with Parameter Builder",
         "description": "If enabled, uses Facebook’s Parameter Builder library to help ensure that User Data values are properly formatted before being sent to Facebook.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       }
     }
   },
@@ -131,7 +145,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_config": {
           "label": "Event Configuration",
@@ -247,7 +261,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "custom_event_name": {
               "label": "Custom Event Name",
@@ -277,7 +293,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "show_fields": {
               "label": "Show all fields",
@@ -298,7 +316,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -308,7 +328,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_category": {
           "label": "Content Category",
@@ -355,7 +377,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_ids": {
           "label": "Content IDs",
@@ -422,7 +446,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_name": {
           "label": "Content Name",
@@ -469,7 +495,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_type": {
           "label": "Content Type",
@@ -528,7 +556,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "contents": {
           "label": "Contents",
@@ -576,7 +606,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -597,7 +629,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_price": {
               "label": "Item Price",
@@ -618,7 +652,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -672,7 +708,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "currency": {
           "label": "Currency",
@@ -1476,7 +1514,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "delivery_category": {
           "label": "Delivery Category",
@@ -1529,7 +1569,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "num_items": {
           "label": "Number of Items",
@@ -1561,7 +1603,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "predicted_ltv": {
           "label": "Predicted LTV",
@@ -1621,7 +1665,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "net_revenue": {
           "label": "Net Revenue",
@@ -1653,7 +1699,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "search_string": {
           "label": "Search String",
@@ -1685,7 +1733,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "status": {
           "label": "Registration Status",
@@ -1715,7 +1765,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -1802,7 +1854,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "custom_data": {
           "label": "Custom Data",
@@ -1823,7 +1877,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "eventID": {
           "label": "Event ID",
@@ -1846,7 +1902,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "eventSourceUrl": {
           "label": "Event Source URL",
@@ -1869,7 +1927,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userData": {
           "label": "User Data",
@@ -1945,7 +2005,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "em": {
               "label": "Email",
@@ -1966,7 +2028,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "ph": {
               "label": "Phone Number",
@@ -1987,7 +2051,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fn": {
               "label": "First Name",
@@ -2008,7 +2074,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "ln": {
               "label": "Last Name",
@@ -2029,7 +2097,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "ge": {
               "label": "Gender",
@@ -2059,7 +2129,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "db": {
               "label": "Date of Birth",
@@ -2080,7 +2152,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "ct": {
               "label": "City",
@@ -2101,7 +2175,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "st": {
               "label": "State",
@@ -2122,7 +2198,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "zp": {
               "label": "ZIP/Postal Code",
@@ -2143,7 +2221,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "country": {
               "label": "Country",
@@ -2164,7 +2244,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fbp": {
               "label": "FBP",
@@ -2185,7 +2267,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fbc": {
               "label": "FBC",
@@ -2206,7 +2290,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2216,7 +2302,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
+++ b/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
@@ -1,317 +1,331 @@
 {
+  "slug": "actions-facebook-conversions-api-web",
   "name": "Facebook Conversions Api Web",
+  "mode": "device",
   "description": "Send events to Facebook Conversions API from the browser.",
-  "basicOptions": [
-    "pixelId",
-    "disablePushState",
-    "disableAutoConfig",
-    "disableFirstPartyCookies",
-    "agent",
-    "ldu",
-    "formatUserDataWithParamBuilder"
-  ],
-  "options": {
-    "pixelId": {
-      "tags": [],
-      "default": "",
-      "description": "The Pixel ID associated with your Facebook Pixel.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Pixel ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The pixelId property is required."]],
-      "uIMetadata": null
-    },
-    "disablePushState": {
-      "tags": [],
-      "default": false,
-      "description": "If set to true, prevents Facebook Pixel from sending PageView events on history state changes. Set to true if you want to trigger PageView events manually via the pageView Action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Push State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableAutoConfig": {
-      "tags": [],
-      "default": true,
-      "description": "Control whether Facebook’s Meta Pixel automatically collects additional page and button data to optimize ads and measurement. When this toggle is on, Auto Config is disabled and only basic pixel tracking will occur. Turning it off enables Auto Config, allowing the Pixel to automatically send page metadata and button interactions to improve ad delivery and reporting.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Auto Config",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableFirstPartyCookies": {
-      "tags": [],
-      "default": false,
-      "description": "Control whether Facebook’s Meta Pixel uses first-party cookies. When this toggle is on, first-party cookies are disabled, enhancing user privacy. Turning it off enables the use of first-party cookies for more accurate tracking.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable First Party Cookies",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "agent": {
-      "tags": [],
-      "default": "segment",
-      "description": "Specifies the agent to use when sending events.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Agent",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "ldu": {
-      "tags": [],
-      "default": "Disabled",
-      "description": "Specify if and how Limited Data Use should apply.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Limited Data User (LDU)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "Disabled",
-          "label": "LDU disabled",
-          "text": "LDU disabled"
-        },
-        {
-          "value": "GeolocationLogic",
-          "label": "LDU enabled - Use Meta Geolocation Logic",
-          "text": "LDU enabled - Use Meta Geolocation Logic"
-        },
-        {
-          "value": "California",
-          "label": "LDU enabled - California only",
-          "text": "LDU enabled - California only"
-        },
-        {
-          "value": "Colorado",
-          "label": "LDU enabled - Colorado only",
-          "text": "LDU enabled - Colorado only"
-        },
-        {
-          "value": "Connecticut",
-          "label": "LDU enabled - Connecticut only",
-          "text": "LDU enabled - Connecticut only"
-        },
-        {
-          "value": "Florida",
-          "label": "LDU enabled - Florida only",
-          "text": "LDU enabled - Florida only"
-        },
-        {
-          "value": "Oregon",
-          "label": "LDU enabled - Oregon only",
-          "text": "LDU enabled - Oregon only"
-        },
-        {
-          "value": "Texas",
-          "label": "LDU enabled - Texas only",
-          "text": "LDU enabled - Texas only"
-        },
-        {
-          "value": "Montana",
-          "label": "LDU enabled - Montana only",
-          "text": "LDU enabled - Montana only"
-        },
-        {
-          "value": "Delaware",
-          "label": "LDU enabled - Delaware only",
-          "text": "LDU enabled - Delaware only"
-        },
-        {
-          "value": "Nebraska",
-          "label": "LDU enabled - Nebraska only",
-          "text": "LDU enabled - Nebraska only"
-        },
-        {
-          "value": "NewHampshire",
-          "label": "LDU enabled - New Hampshire only",
-          "text": "LDU enabled - New Hampshire only"
-        },
-        {
-          "value": "NewJersey",
-          "label": "LDU enabled - New Jersey only",
-          "text": "LDU enabled - New Jersey only"
-        },
-        {
-          "value": "Minnesota",
-          "label": "LDU enabled - Minnesota only",
-          "text": "LDU enabled - Minnesota only"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The ldu property is required."]],
-      "uIMetadata": null
-    },
-    "formatUserDataWithParamBuilder": {
-      "tags": [],
-      "default": true,
-      "description": "If enabled, uses Facebook’s Parameter Builder library to help ensure that User Data values are properly formatted before being sent to Facebook.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Format User Data with Parameter Builder",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "pixelId": {
+        "label": "Pixel ID",
+        "description": "The Pixel ID associated with your Facebook Pixel.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "disablePushState": {
+        "label": "Disable Push State",
+        "description": "If set to true, prevents Facebook Pixel from sending PageView events on history state changes. Set to true if you want to trigger PageView events manually via the pageView Action.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "disableAutoConfig": {
+        "label": "Disable Auto Config",
+        "description": "Control whether Facebook’s Meta Pixel automatically collects additional page and button data to optimize ads and measurement. When this toggle is on, Auto Config is disabled and only basic pixel tracking will occur. Turning it off enables Auto Config, allowing the Pixel to automatically send page metadata and button interactions to improve ad delivery and reporting.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "disableFirstPartyCookies": {
+        "label": "Disable First Party Cookies",
+        "description": "Control whether Facebook’s Meta Pixel uses first-party cookies. When this toggle is on, first-party cookies are disabled, enhancing user privacy. Turning it off enables the use of first-party cookies for more accurate tracking.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "agent": {
+        "label": "Agent",
+        "description": "Specifies the agent to use when sending events.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "segment"
+      },
+      "ldu": {
+        "label": "Limited Data User (LDU)",
+        "description": "Specify if and how Limited Data Use should apply.",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "label": "LDU disabled",
+            "value": "Disabled"
+          },
+          {
+            "label": "LDU enabled - Use Meta Geolocation Logic",
+            "value": "GeolocationLogic"
+          },
+          {
+            "label": "LDU enabled - California only",
+            "value": "California"
+          },
+          {
+            "label": "LDU enabled - Colorado only",
+            "value": "Colorado"
+          },
+          {
+            "label": "LDU enabled - Connecticut only",
+            "value": "Connecticut"
+          },
+          {
+            "label": "LDU enabled - Florida only",
+            "value": "Florida"
+          },
+          {
+            "label": "LDU enabled - Oregon only",
+            "value": "Oregon"
+          },
+          {
+            "label": "LDU enabled - Texas only",
+            "value": "Texas"
+          },
+          {
+            "label": "LDU enabled - Montana only",
+            "value": "Montana"
+          },
+          {
+            "label": "LDU enabled - Delaware only",
+            "value": "Delaware"
+          },
+          {
+            "label": "LDU enabled - Nebraska only",
+            "value": "Nebraska"
+          },
+          {
+            "label": "LDU enabled - New Hampshire only",
+            "value": "NewHampshire"
+          },
+          {
+            "label": "LDU enabled - New Jersey only",
+            "value": "NewJersey"
+          },
+          {
+            "label": "LDU enabled - Minnesota only",
+            "value": "Minnesota"
+          }
+        ],
+        "default": "Disabled"
+      },
+      "formatUserDataWithParamBuilder": {
+        "label": "Format User Data with Parameter Builder",
+        "description": "If enabled, uses Facebook’s Parameter Builder library to help ensure that User Data values are properly formatted before being sent to Facebook.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "send",
-      "name": "Send Event",
+  "audienceConfig": null,
+  "actions": {
+    "send": {
+      "title": "Send Event",
       "description": "Send a Standard or Custom Event to Facebook Conversions API.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_config",
-          "type": "object",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_config": {
           "label": "Event Configuration",
           "description": "Specify the type of Facebook Conversions API event to send.",
-          "defaultValue": {
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "event_name": "CustomEvent",
             "custom_event_name": {
               "@path": "$.event"
             },
             "show_fields": false
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_config": {
-                "title": "Event Configuration",
-                "description": "Specify the type of Facebook Conversions API event to send.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "event_name": {
-                    "title": "Event Name",
-                    "description": "Facebook Conversions API Event Name to send. Select 'Custom Event' to send a non standard event.",
-                    "type": "string",
-                    "enum": [
-                      "CustomEvent",
-                      "PageView",
-                      "AddPaymentInfo",
-                      "AddToCart",
-                      "AddToWishlist",
-                      "CompleteRegistration",
-                      "Contact",
-                      "CustomizeProduct",
-                      "Donate",
-                      "FindLocation",
-                      "InitiateCheckout",
-                      "Lead",
-                      "Purchase",
-                      "Schedule",
-                      "Search",
-                      "StartTrial",
-                      "SubmitApplication",
-                      "Subscribe",
-                      "ViewContent"
-                    ]
-                  },
-                  "custom_event_name": {
-                    "title": "Custom Event Name",
-                    "description": "Custom event name to send to Facebook",
-                    "type": "string"
-                  },
-                  "show_fields": {
-                    "title": "Show all fields",
-                    "description": "Show all fields, even those which are not relevant to the selected Event Name.",
-                    "type": "boolean",
-                    "default": false
-                  }
+          "placeholder": null,
+          "properties": {
+            "event_name": {
+              "label": "Event Name",
+              "description": "Facebook Conversions API Event Name to send. Select 'Custom Event' to send a non standard event.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Custom Event",
+                  "value": "CustomEvent"
                 },
-                "required": ["event_name"]
-              }
+                {
+                  "label": "Page View",
+                  "value": "PageView"
+                },
+                {
+                  "label": "Add Payment Info",
+                  "value": "AddPaymentInfo"
+                },
+                {
+                  "label": "Add To Cart",
+                  "value": "AddToCart"
+                },
+                {
+                  "label": "Add To Wishlist",
+                  "value": "AddToWishlist"
+                },
+                {
+                  "label": "Complete Registration",
+                  "value": "CompleteRegistration"
+                },
+                {
+                  "label": "Contact",
+                  "value": "Contact"
+                },
+                {
+                  "label": "Customize Product",
+                  "value": "CustomizeProduct"
+                },
+                {
+                  "label": "Donate",
+                  "value": "Donate"
+                },
+                {
+                  "label": "Find Location",
+                  "value": "FindLocation"
+                },
+                {
+                  "label": "Initiate Checkout",
+                  "value": "InitiateCheckout"
+                },
+                {
+                  "label": "Lead",
+                  "value": "Lead"
+                },
+                {
+                  "label": "Purchase",
+                  "value": "Purchase"
+                },
+                {
+                  "label": "Schedule",
+                  "value": "Schedule"
+                },
+                {
+                  "label": "Search",
+                  "value": "Search"
+                },
+                {
+                  "label": "Start Trial",
+                  "value": "StartTrial"
+                },
+                {
+                  "label": "Submit Application",
+                  "value": "SubmitApplication"
+                },
+                {
+                  "label": "Subscribe",
+                  "value": "Subscribe"
+                },
+                {
+                  "label": "View Content",
+                  "value": "ViewContent"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": ["event_config"]
+            "custom_event_name": {
+              "label": "Custom Event Name",
+              "description": "Custom event name to send to Facebook",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": {
+                "match": "any",
+                "conditions": [
+                  {
+                    "fieldKey": "event_config.show_fields",
+                    "operator": "is",
+                    "value": "true"
+                  }
+                ]
+              },
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "show_fields": {
+              "label": "Show all fields",
+              "description": "Show all fields, even those which are not relevant to the selected Event Name.",
+              "type": "boolean",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": false,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_category",
-          "type": "string",
+        "content_category": {
           "label": "Content Category",
           "description": "The category of the content associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.category"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_category": {
-                "title": "Content Category",
-                "description": "The category of the content associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.category"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -336,39 +350,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_ids",
-          "type": "string",
+        "content_ids": {
           "label": "Content IDs",
           "description": "Product IDs associated with the event, such as SKUs (e.g. ['ABC123', 'XYZ789']). Accepts a single string value or array of strings.",
-          "defaultValue": {
-            "@liquid": "{{ properties.products | map: 'product_id' }}"
-          },
+          "type": "string",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_ids": {
-                "title": "Content IDs",
-                "description": "Product IDs associated with the event, such as SKUs (e.g. ['ABC123', 'XYZ789']). Accepts a single string value or array of strings.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@liquid": "{{ properties.products | map: 'product_id' }}"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -413,36 +417,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_name",
-          "type": "string",
+        "content_name": {
           "label": "Content Name",
           "description": "The name of the page or product associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.name"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_name": {
-                "title": "Content Name",
-                "description": "The name of the page or product associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.name"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -467,16 +464,22 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_type",
-          "type": "string",
+        "content_type": {
           "label": "Content Type",
           "description": "If the IDs being passed in content_ids or contents parameter are IDs of products, then the value should be product. If product group IDs are being passed, then the value should be product_group. If no content_type is provided, Meta will match the event to every item that has the same ID, independent of its type.",
-          "defaultValue": "product",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "product",
           "choices": [
             {
               "value": "product",
@@ -487,24 +490,10 @@
               "label": "Product Group"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_type": {
-                "title": "Content Type",
-                "description": "If the IDs being passed in content_ids or contents parameter are IDs of products, then the value should be product. If product group IDs are being passed, then the value should be product_group. If no content_type is provided, Meta will match the event to every item that has the same ID, independent of its type.",
-                "type": "string",
-                "enum": ["product", "product_group"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -534,14 +523,22 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "contents",
-          "type": "object",
+        "contents": {
           "label": "Contents",
           "description": "A list of JSON objects that contain the product IDs associated with the event plus information about the products. ID and quantity are required fields.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -557,50 +554,75 @@
               }
             ]
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "contents": {
-                "title": "Contents",
-                "description": "A list of JSON objects that contain the product IDs associated with the event plus information about the products. ID and quantity are required fields.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "id": {
-                      "title": "ID",
-                      "description": "The product ID of the purchased item.",
-                      "type": "string"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "The number of items purchased.",
-                      "type": "integer"
-                    },
-                    "item_price": {
-                      "title": "Item Price",
-                      "description": "The price of the item.",
-                      "type": "number"
-                    }
-                  },
-                  "required": ["id", "quantity"]
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "id": {
+              "label": "ID",
+              "description": "The product ID of the purchased item.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "quantity": {
+              "label": "Quantity",
+              "description": "The number of items purchased.",
+              "type": "integer",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_price": {
+              "label": "Item Price",
+              "description": "The price of the item.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": {
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -645,18 +667,24 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "currency",
-          "type": "string",
+        "currency": {
           "label": "Currency",
           "description": "The currency for the value specified. Currency must be a valid ISO 4217 three-digit currency code.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
           "choices": [
             {
               "value": "AED",
@@ -1375,224 +1403,10 @@
               "label": "ZWC"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "The currency for the value specified. Currency must be a valid ISO 4217 three-digit currency code.",
-                "type": "string",
-                "enum": [
-                  "AED",
-                  "AFN",
-                  "ALL",
-                  "AMD",
-                  "ANG",
-                  "AOA",
-                  "ARS",
-                  "AUD",
-                  "AWG",
-                  "AZN",
-                  "BAM",
-                  "BBD",
-                  "BDT",
-                  "BGN",
-                  "BHD",
-                  "BIF",
-                  "BMD",
-                  "BND",
-                  "BOB",
-                  "BOV",
-                  "BRL",
-                  "BSD",
-                  "BTN",
-                  "BWP",
-                  "BYN",
-                  "BZD",
-                  "CAD",
-                  "CDF",
-                  "CHE",
-                  "CHF",
-                  "CHW",
-                  "CLF",
-                  "CLP",
-                  "CNY",
-                  "COP",
-                  "COU",
-                  "CRC",
-                  "CUC",
-                  "CUP",
-                  "CVE",
-                  "CZK",
-                  "DJF",
-                  "DKK",
-                  "DOP",
-                  "DZD",
-                  "EGP",
-                  "ERN",
-                  "ETB",
-                  "EUR",
-                  "FJD",
-                  "FKP",
-                  "GBP",
-                  "GEL",
-                  "GHS",
-                  "GIP",
-                  "GMD",
-                  "GNF",
-                  "GTQ",
-                  "GYD",
-                  "HKD",
-                  "HNL",
-                  "HRK",
-                  "HTG",
-                  "HUF",
-                  "IDR",
-                  "ILS",
-                  "INR",
-                  "IQD",
-                  "IRR",
-                  "ISK",
-                  "JMD",
-                  "JOD",
-                  "JPY",
-                  "KES",
-                  "KGS",
-                  "KHR",
-                  "KMF",
-                  "KPW",
-                  "KRW",
-                  "KWD",
-                  "KYD",
-                  "KZT",
-                  "LAK",
-                  "LBP",
-                  "LKR",
-                  "LRD",
-                  "LSL",
-                  "LYD",
-                  "MAD",
-                  "MDL",
-                  "MGA",
-                  "MKD",
-                  "MMK",
-                  "MNT",
-                  "MOP",
-                  "MRU",
-                  "MUR",
-                  "MVR",
-                  "MWK",
-                  "MXN",
-                  "MXV",
-                  "MYR",
-                  "MZN",
-                  "NAD",
-                  "NGN",
-                  "NIO",
-                  "NOK",
-                  "NPR",
-                  "NZD",
-                  "OMR",
-                  "PAB",
-                  "PEN",
-                  "PGK",
-                  "PHP",
-                  "PKR",
-                  "PLN",
-                  "PYG",
-                  "QAR",
-                  "RON",
-                  "RSD",
-                  "RUB",
-                  "RWF",
-                  "SAR",
-                  "SBD",
-                  "SCR",
-                  "SDG",
-                  "SEK",
-                  "SGD",
-                  "SHP",
-                  "SLL",
-                  "SOS",
-                  "SRD",
-                  "SSP",
-                  "STN",
-                  "SVC",
-                  "SYP",
-                  "SZL",
-                  "THB",
-                  "TJS",
-                  "TMT",
-                  "TND",
-                  "TOP",
-                  "TRY",
-                  "TTD",
-                  "TWD",
-                  "TZS",
-                  "UAH",
-                  "UGX",
-                  "USD",
-                  "USN",
-                  "UYI",
-                  "UYU",
-                  "UYW",
-                  "UZS",
-                  "VES",
-                  "VND",
-                  "VUV",
-                  "WST",
-                  "XAF",
-                  "XAG",
-                  "XAU",
-                  "XBA",
-                  "XBB",
-                  "XBC",
-                  "XBD",
-                  "XCD",
-                  "XDR",
-                  "XOF",
-                  "XPD",
-                  "XPF",
-                  "XPT",
-                  "XSU",
-                  "XTS",
-                  "XUA",
-                  "XXX",
-                  "YER",
-                  "ZAR",
-                  "ZMW",
-                  "ZWC"
-                ]
-              }
-            },
-            "required": [],
-            "allOf": [
-              {
-                "if": {
-                  "properties": {
-                    "event_config": {
-                      "properties": {
-                        "event_name": {
-                          "const": "Purchase"
-                        }
-                      },
-                      "required": ["event_name"]
-                    }
-                  },
-                  "required": ["event_config"]
-                },
-                "then": {
-                  "required": ["currency"]
-                }
-              }
-            ]
-          },
-          "dependsOn": {
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1657,26 +1471,22 @@
               }
             ]
           },
-          "displayMetadata": {
-            "conditionallyRequired": {
-              "match": "all",
-              "conditions": [
-                {
-                  "fieldKey": "event_config.event_name",
-                  "operator": "is",
-                  "value": "Purchase"
-                }
-              ]
-            }
-          }
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "delivery_category",
-          "type": "string",
+        "delivery_category": {
           "label": "Delivery Category",
           "description": "Category of the delivery",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "value": "in_store",
@@ -1691,24 +1501,10 @@
               "label": "Home Delivery"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "delivery_category": {
-                "title": "Delivery Category",
-                "description": "Category of the delivery",
-                "type": "string",
-                "enum": ["in_store", "curbside", "home_delivery"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1728,36 +1524,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "num_items",
-          "type": "integer",
+        "num_items": {
           "label": "Number of Items",
           "description": "The number of items when checkout was initiated.",
-          "defaultValue": {
-            "@path": "$.properties.num_items"
-          },
+          "type": "integer",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "num_items": {
-                "title": "Number of Items",
-                "description": "The number of items when checkout was initiated.",
-                "type": "integer"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.num_items"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1767,33 +1556,27 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "predicted_ltv",
-          "type": "number",
+        "predicted_ltv": {
           "label": "Predicted LTV",
           "description": "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value.",
+          "type": "number",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "predicted_ltv": {
-                "title": "Predicted LTV",
-                "description": "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1833,36 +1616,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "net_revenue",
-          "type": "number",
+        "net_revenue": {
           "label": "Net Revenue",
           "description": "The net revenue associated with the purchase.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.net_revenue"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "net_revenue": {
-                "title": "Net Revenue",
-                "description": "The net revenue associated with the purchase.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1872,36 +1648,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "search_string",
-          "type": "string",
+        "search_string": {
           "label": "Search String",
           "description": "The string entered by the user for the search.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.query"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "search_string": {
-                "title": "Search String",
-                "description": "The string entered by the user for the search.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1911,33 +1680,27 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "status",
-          "type": "boolean",
+        "status": {
           "label": "Registration Status",
           "description": "The status of the registration. true for completed registrations, false otherwise.",
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "status": {
-                "title": "Registration Status",
-                "description": "The status of the registration. true for completed registrations, false otherwise.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": {
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -1947,56 +1710,29 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "value",
-          "type": "number",
+        "value": {
           "label": "Value",
           "description": "A numeric value associated with this event. This could be a monetary value or a value in some other metric.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
+          "type": "number",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "A numeric value associated with this event. This could be a monetary value or a value in some other metric.",
-                "type": "number"
-              }
-            },
-            "required": [],
-            "allOf": [
-              {
-                "if": {
-                  "properties": {
-                    "event_config": {
-                      "properties": {
-                        "event_name": {
-                          "const": "Purchase"
-                        }
-                      },
-                      "required": ["event_name"]
-                    }
-                  },
-                  "required": ["event_config"]
-                },
-                "then": {
-                  "required": ["value"]
-                }
-              }
-            ]
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -2061,113 +1797,89 @@
               }
             ]
           },
-          "displayMetadata": {
-            "conditionallyRequired": {
-              "match": "all",
-              "conditions": [
-                {
-                  "fieldKey": "event_config.event_name",
-                  "operator": "is",
-                  "value": "Purchase"
-                }
-              ]
-            }
-          }
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "custom_data",
-          "type": "object",
+        "custom_data": {
           "label": "Custom Data",
           "description": "The custom data object can be used to pass custom properties.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "custom_data": {
-                "title": "Custom Data",
-                "description": "The custom data object can be used to pass custom properties.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "eventID",
-          "type": "string",
+        "eventID": {
           "label": "Event ID",
           "description": "This ID can be any unique string. Event ID is used to deduplicate events sent both the server side Conversions API and the browser Pixel.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.messageId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventID": {
-                "title": "Event ID",
-                "description": "This ID can be any unique string. Event ID is used to deduplicate events sent both the server side Conversions API and the browser Pixel.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "eventSourceUrl",
-          "type": "string",
+        "eventSourceUrl": {
           "label": "Event Source URL",
           "description": "The URL of the page where the event occurred. Can be used to override the default URL taken from the current page.",
-          "defaultValue": {
-            "@path": "$.context.page.url"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventSourceUrl": {
-                "title": "Event Source URL",
-                "description": "The URL of the page where the event occurred. Can be used to override the default URL taken from the current page.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.page.url"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userData",
-          "type": "object",
+        "userData": {
           "label": "User Data",
           "description": "User data to be sent with the event. This can include hashed identifiers like email, phone number, etc.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "external_id": {
               "@path": "$.userId"
             },
@@ -2211,109 +1923,309 @@
               "@path": "$.context.traits.client_ip_address"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userData": {
-                "title": "User Data",
-                "description": "User data to be sent with the event. This can include hashed identifiers like email, phone number, etc.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "external_id": {
-                    "title": "External ID",
-                    "description": "A unique identifier for the user from your system",
-                    "type": "string"
-                  },
-                  "em": {
-                    "title": "Email",
-                    "description": "Email address of the user",
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "ph": {
-                    "title": "Phone Number",
-                    "description": "Phone number of the user. Make sure to include the country code. For example, \"15551234567\" for a US number.",
-                    "type": "string"
-                  },
-                  "fn": {
-                    "title": "First Name",
-                    "description": "First name of the user",
-                    "type": "string"
-                  },
-                  "ln": {
-                    "title": "Last Name",
-                    "description": "Last name of the user",
-                    "type": "string"
-                  },
-                  "ge": {
-                    "title": "Gender",
-                    "description": "Gender of the user. If unknown leave blank.",
-                    "type": "string",
-                    "enum": ["m", "f"]
-                  },
-                  "db": {
-                    "title": "Date of Birth",
-                    "description": "Date of birth of the user",
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "ct": {
-                    "title": "City",
-                    "description": "City of the user",
-                    "type": "string"
-                  },
-                  "st": {
-                    "title": "State",
-                    "description": "State of the user. Facebook expects the 2-letter abbreviation for US states. For example, \"CA\" for California, or \"NY\" for New York.",
-                    "type": "string"
-                  },
-                  "zp": {
-                    "title": "ZIP/Postal Code",
-                    "description": "ZIP or postal code of the user. For example, U.S zip code: 94035, Australia zip code: 1987, France zip code: 75018, UK zip code: m11ae.",
-                    "type": "string"
-                  },
-                  "country": {
-                    "title": "Country",
-                    "description": "The country of the user. Facebook expects the 2-letter ISO 3166-1 alpha-2 country code. For example, \"US\" for the United States, or \"GB\" for the United Kingdom.",
-                    "type": "string"
-                  },
-                  "fbp": {
-                    "title": "FBP",
-                    "description": "Use this field to pass the Facebook browser cookie value (_fbp) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbp cookie.",
-                    "type": "string"
-                  },
-                  "fbc": {
-                    "title": "FBC",
-                    "description": "Use this field to pass The Facebook browser cookie value (_fbc) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbc cookie.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "external_id": {
+              "label": "External ID",
+              "description": "A unique identifier for the user from your system",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "em": {
+              "label": "Email",
+              "description": "Email address of the user",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "ph": {
+              "label": "Phone Number",
+              "description": "Phone number of the user. Make sure to include the country code. For example, \"15551234567\" for a US number.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fn": {
+              "label": "First Name",
+              "description": "First name of the user",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "ln": {
+              "label": "Last Name",
+              "description": "Last name of the user",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "ge": {
+              "label": "Gender",
+              "description": "Gender of the user. If unknown leave blank.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "Male",
+                  "value": "m"
+                },
+                {
+                  "label": "Female",
+                  "value": "f"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "db": {
+              "label": "Date of Birth",
+              "description": "Date of birth of the user",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "ct": {
+              "label": "City",
+              "description": "City of the user",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "st": {
+              "label": "State",
+              "description": "State of the user. Facebook expects the 2-letter abbreviation for US states. For example, \"CA\" for California, or \"NY\" for New York.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "zp": {
+              "label": "ZIP/Postal Code",
+              "description": "ZIP or postal code of the user. For example, U.S zip code: 94035, Australia zip code: 1987, France zip code: 75018, UK zip code: m11ae.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "country": {
+              "label": "Country",
+              "description": "The country of the user. Facebook expects the 2-letter ISO 3166-1 alpha-2 country code. For example, \"US\" for the United States, or \"GB\" for the United Kingdom.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fbp": {
+              "label": "FBP",
+              "description": "Use this field to pass the Facebook browser cookie value (_fbp) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbp cookie.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fbc": {
+              "label": "FBC",
+              "description": "Use this field to pass The Facebook browser cookie value (_fbc) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbc cookie.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "send",
       "name": "AddPaymentInfo",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Payment Info Entered\"",
       "mapping": {
         "event_config": {
@@ -2412,11 +2324,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "AddToCart",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Product Added\"",
       "mapping": {
         "event_config": {
@@ -2510,11 +2423,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "AddToWishlist",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Product Added To Wishlist\"",
       "mapping": {
         "event_config": {
@@ -2608,11 +2522,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "CompleteRegistration",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Signed Up\"",
       "mapping": {
         "event_config": {
@@ -2711,11 +2626,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "InitiateCheckout",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Checkout Started\"",
       "mapping": {
         "event_config": {
@@ -2814,11 +2730,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "PageView",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "type = \"page\"",
       "mapping": {
         "event_config": {
@@ -2917,11 +2834,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "Purchase",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Order Completed\"",
       "mapping": {
         "event_config": {
@@ -3025,11 +2943,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "Search",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Products Searched\"",
       "mapping": {
         "event_config": {
@@ -3123,11 +3042,12 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "send",
       "name": "ViewContent",
+      "type": "automatic",
+      "partnerAction": "send",
       "subscribe": "event = \"Product Viewed\"",
       "mapping": {
         "event_config": {
@@ -3221,7 +3141,7 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
+++ b/packages/browser-destinations/destinations/facebook-conversions-api-web/metadata.json
@@ -1,0 +1,3227 @@
+{
+  "name": "Facebook Conversions Api Web",
+  "description": "Send events to Facebook Conversions API from the browser.",
+  "basicOptions": [
+    "pixelId",
+    "disablePushState",
+    "disableAutoConfig",
+    "disableFirstPartyCookies",
+    "agent",
+    "ldu",
+    "formatUserDataWithParamBuilder"
+  ],
+  "options": {
+    "pixelId": {
+      "tags": [],
+      "default": "",
+      "description": "The Pixel ID associated with your Facebook Pixel.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Pixel ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The pixelId property is required."]],
+      "uIMetadata": null
+    },
+    "disablePushState": {
+      "tags": [],
+      "default": false,
+      "description": "If set to true, prevents Facebook Pixel from sending PageView events on history state changes. Set to true if you want to trigger PageView events manually via the pageView Action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Push State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableAutoConfig": {
+      "tags": [],
+      "default": true,
+      "description": "Control whether Facebook’s Meta Pixel automatically collects additional page and button data to optimize ads and measurement. When this toggle is on, Auto Config is disabled and only basic pixel tracking will occur. Turning it off enables Auto Config, allowing the Pixel to automatically send page metadata and button interactions to improve ad delivery and reporting.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Auto Config",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableFirstPartyCookies": {
+      "tags": [],
+      "default": false,
+      "description": "Control whether Facebook’s Meta Pixel uses first-party cookies. When this toggle is on, first-party cookies are disabled, enhancing user privacy. Turning it off enables the use of first-party cookies for more accurate tracking.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable First Party Cookies",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "agent": {
+      "tags": [],
+      "default": "segment",
+      "description": "Specifies the agent to use when sending events.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Agent",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "ldu": {
+      "tags": [],
+      "default": "Disabled",
+      "description": "Specify if and how Limited Data Use should apply.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Limited Data User (LDU)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "Disabled",
+          "label": "LDU disabled",
+          "text": "LDU disabled"
+        },
+        {
+          "value": "GeolocationLogic",
+          "label": "LDU enabled - Use Meta Geolocation Logic",
+          "text": "LDU enabled - Use Meta Geolocation Logic"
+        },
+        {
+          "value": "California",
+          "label": "LDU enabled - California only",
+          "text": "LDU enabled - California only"
+        },
+        {
+          "value": "Colorado",
+          "label": "LDU enabled - Colorado only",
+          "text": "LDU enabled - Colorado only"
+        },
+        {
+          "value": "Connecticut",
+          "label": "LDU enabled - Connecticut only",
+          "text": "LDU enabled - Connecticut only"
+        },
+        {
+          "value": "Florida",
+          "label": "LDU enabled - Florida only",
+          "text": "LDU enabled - Florida only"
+        },
+        {
+          "value": "Oregon",
+          "label": "LDU enabled - Oregon only",
+          "text": "LDU enabled - Oregon only"
+        },
+        {
+          "value": "Texas",
+          "label": "LDU enabled - Texas only",
+          "text": "LDU enabled - Texas only"
+        },
+        {
+          "value": "Montana",
+          "label": "LDU enabled - Montana only",
+          "text": "LDU enabled - Montana only"
+        },
+        {
+          "value": "Delaware",
+          "label": "LDU enabled - Delaware only",
+          "text": "LDU enabled - Delaware only"
+        },
+        {
+          "value": "Nebraska",
+          "label": "LDU enabled - Nebraska only",
+          "text": "LDU enabled - Nebraska only"
+        },
+        {
+          "value": "NewHampshire",
+          "label": "LDU enabled - New Hampshire only",
+          "text": "LDU enabled - New Hampshire only"
+        },
+        {
+          "value": "NewJersey",
+          "label": "LDU enabled - New Jersey only",
+          "text": "LDU enabled - New Jersey only"
+        },
+        {
+          "value": "Minnesota",
+          "label": "LDU enabled - Minnesota only",
+          "text": "LDU enabled - Minnesota only"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The ldu property is required."]],
+      "uIMetadata": null
+    },
+    "formatUserDataWithParamBuilder": {
+      "tags": [],
+      "default": true,
+      "description": "If enabled, uses Facebook’s Parameter Builder library to help ensure that User Data values are properly formatted before being sent to Facebook.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Format User Data with Parameter Builder",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "send",
+      "name": "Send Event",
+      "description": "Send a Standard or Custom Event to Facebook Conversions API.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_config",
+          "type": "object",
+          "label": "Event Configuration",
+          "description": "Specify the type of Facebook Conversions API event to send.",
+          "defaultValue": {
+            "event_name": "CustomEvent",
+            "custom_event_name": {
+              "@path": "$.event"
+            },
+            "show_fields": false
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_config": {
+                "title": "Event Configuration",
+                "description": "Specify the type of Facebook Conversions API event to send.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "event_name": {
+                    "title": "Event Name",
+                    "description": "Facebook Conversions API Event Name to send. Select 'Custom Event' to send a non standard event.",
+                    "type": "string",
+                    "enum": [
+                      "CustomEvent",
+                      "PageView",
+                      "AddPaymentInfo",
+                      "AddToCart",
+                      "AddToWishlist",
+                      "CompleteRegistration",
+                      "Contact",
+                      "CustomizeProduct",
+                      "Donate",
+                      "FindLocation",
+                      "InitiateCheckout",
+                      "Lead",
+                      "Purchase",
+                      "Schedule",
+                      "Search",
+                      "StartTrial",
+                      "SubmitApplication",
+                      "Subscribe",
+                      "ViewContent"
+                    ]
+                  },
+                  "custom_event_name": {
+                    "title": "Custom Event Name",
+                    "description": "Custom event name to send to Facebook",
+                    "type": "string"
+                  },
+                  "show_fields": {
+                    "title": "Show all fields",
+                    "description": "Show all fields, even those which are not relevant to the selected Event Name.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": ["event_name"]
+              }
+            },
+            "required": ["event_config"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_category",
+          "type": "string",
+          "label": "Content Category",
+          "description": "The category of the content associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.category"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_category": {
+                "title": "Content Category",
+                "description": "The category of the content associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "PageView"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_ids",
+          "type": "string",
+          "label": "Content IDs",
+          "description": "Product IDs associated with the event, such as SKUs (e.g. ['ABC123', 'XYZ789']). Accepts a single string value or array of strings.",
+          "defaultValue": {
+            "@liquid": "{{ properties.products | map: 'product_id' }}"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_ids": {
+                "title": "Content IDs",
+                "description": "Product IDs associated with the event, such as SKUs (e.g. ['ABC123', 'XYZ789']). Accepts a single string value or array of strings.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddPaymentInfo"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "InitiateCheckout"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_name",
+          "type": "string",
+          "label": "Content Name",
+          "description": "The name of the page or product associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_name": {
+                "title": "Content Name",
+                "description": "The name of the page or product associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "PageView"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_type",
+          "type": "string",
+          "label": "Content Type",
+          "description": "If the IDs being passed in content_ids or contents parameter are IDs of products, then the value should be product. If product group IDs are being passed, then the value should be product_group. If no content_type is provided, Meta will match the event to every item that has the same ID, independent of its type.",
+          "defaultValue": "product",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "product",
+              "label": "Product"
+            },
+            {
+              "value": "product_group",
+              "label": "Product Group"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_type": {
+                "title": "Content Type",
+                "description": "If the IDs being passed in content_ids or contents parameter are IDs of products, then the value should be product. If product group IDs are being passed, then the value should be product_group. If no content_type is provided, Meta will match the event to every item that has the same ID, independent of its type.",
+                "type": "string",
+                "enum": ["product", "product_group"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "contents",
+          "type": "object",
+          "label": "Contents",
+          "description": "A list of JSON objects that contain the product IDs associated with the event plus information about the products. ID and quantity are required fields.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "id": {
+                  "@path": "$.product_id"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                },
+                "item_price": {
+                  "@path": "$.price"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "contents": {
+                "title": "Contents",
+                "description": "A list of JSON objects that contain the product IDs associated with the event plus information about the products. ID and quantity are required fields.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "id": {
+                      "title": "ID",
+                      "description": "The product ID of the purchased item.",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "The number of items purchased.",
+                      "type": "integer"
+                    },
+                    "item_price": {
+                      "title": "Item Price",
+                      "description": "The price of the item.",
+                      "type": "number"
+                    }
+                  },
+                  "required": ["id", "quantity"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddPaymentInfo"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "InitiateCheckout"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "The currency for the value specified. Currency must be a valid ISO 4217 three-digit currency code.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "AED",
+              "label": "AED"
+            },
+            {
+              "value": "AFN",
+              "label": "AFN"
+            },
+            {
+              "value": "ALL",
+              "label": "ALL"
+            },
+            {
+              "value": "AMD",
+              "label": "AMD"
+            },
+            {
+              "value": "ANG",
+              "label": "ANG"
+            },
+            {
+              "value": "AOA",
+              "label": "AOA"
+            },
+            {
+              "value": "ARS",
+              "label": "ARS"
+            },
+            {
+              "value": "AUD",
+              "label": "AUD"
+            },
+            {
+              "value": "AWG",
+              "label": "AWG"
+            },
+            {
+              "value": "AZN",
+              "label": "AZN"
+            },
+            {
+              "value": "BAM",
+              "label": "BAM"
+            },
+            {
+              "value": "BBD",
+              "label": "BBD"
+            },
+            {
+              "value": "BDT",
+              "label": "BDT"
+            },
+            {
+              "value": "BGN",
+              "label": "BGN"
+            },
+            {
+              "value": "BHD",
+              "label": "BHD"
+            },
+            {
+              "value": "BIF",
+              "label": "BIF"
+            },
+            {
+              "value": "BMD",
+              "label": "BMD"
+            },
+            {
+              "value": "BND",
+              "label": "BND"
+            },
+            {
+              "value": "BOB",
+              "label": "BOB"
+            },
+            {
+              "value": "BOV",
+              "label": "BOV"
+            },
+            {
+              "value": "BRL",
+              "label": "BRL"
+            },
+            {
+              "value": "BSD",
+              "label": "BSD"
+            },
+            {
+              "value": "BTN",
+              "label": "BTN"
+            },
+            {
+              "value": "BWP",
+              "label": "BWP"
+            },
+            {
+              "value": "BYN",
+              "label": "BYN"
+            },
+            {
+              "value": "BZD",
+              "label": "BZD"
+            },
+            {
+              "value": "CAD",
+              "label": "CAD"
+            },
+            {
+              "value": "CDF",
+              "label": "CDF"
+            },
+            {
+              "value": "CHE",
+              "label": "CHE"
+            },
+            {
+              "value": "CHF",
+              "label": "CHF"
+            },
+            {
+              "value": "CHW",
+              "label": "CHW"
+            },
+            {
+              "value": "CLF",
+              "label": "CLF"
+            },
+            {
+              "value": "CLP",
+              "label": "CLP"
+            },
+            {
+              "value": "CNY",
+              "label": "CNY"
+            },
+            {
+              "value": "COP",
+              "label": "COP"
+            },
+            {
+              "value": "COU",
+              "label": "COU"
+            },
+            {
+              "value": "CRC",
+              "label": "CRC"
+            },
+            {
+              "value": "CUC",
+              "label": "CUC"
+            },
+            {
+              "value": "CUP",
+              "label": "CUP"
+            },
+            {
+              "value": "CVE",
+              "label": "CVE"
+            },
+            {
+              "value": "CZK",
+              "label": "CZK"
+            },
+            {
+              "value": "DJF",
+              "label": "DJF"
+            },
+            {
+              "value": "DKK",
+              "label": "DKK"
+            },
+            {
+              "value": "DOP",
+              "label": "DOP"
+            },
+            {
+              "value": "DZD",
+              "label": "DZD"
+            },
+            {
+              "value": "EGP",
+              "label": "EGP"
+            },
+            {
+              "value": "ERN",
+              "label": "ERN"
+            },
+            {
+              "value": "ETB",
+              "label": "ETB"
+            },
+            {
+              "value": "EUR",
+              "label": "EUR"
+            },
+            {
+              "value": "FJD",
+              "label": "FJD"
+            },
+            {
+              "value": "FKP",
+              "label": "FKP"
+            },
+            {
+              "value": "GBP",
+              "label": "GBP"
+            },
+            {
+              "value": "GEL",
+              "label": "GEL"
+            },
+            {
+              "value": "GHS",
+              "label": "GHS"
+            },
+            {
+              "value": "GIP",
+              "label": "GIP"
+            },
+            {
+              "value": "GMD",
+              "label": "GMD"
+            },
+            {
+              "value": "GNF",
+              "label": "GNF"
+            },
+            {
+              "value": "GTQ",
+              "label": "GTQ"
+            },
+            {
+              "value": "GYD",
+              "label": "GYD"
+            },
+            {
+              "value": "HKD",
+              "label": "HKD"
+            },
+            {
+              "value": "HNL",
+              "label": "HNL"
+            },
+            {
+              "value": "HRK",
+              "label": "HRK"
+            },
+            {
+              "value": "HTG",
+              "label": "HTG"
+            },
+            {
+              "value": "HUF",
+              "label": "HUF"
+            },
+            {
+              "value": "IDR",
+              "label": "IDR"
+            },
+            {
+              "value": "ILS",
+              "label": "ILS"
+            },
+            {
+              "value": "INR",
+              "label": "INR"
+            },
+            {
+              "value": "IQD",
+              "label": "IQD"
+            },
+            {
+              "value": "IRR",
+              "label": "IRR"
+            },
+            {
+              "value": "ISK",
+              "label": "ISK"
+            },
+            {
+              "value": "JMD",
+              "label": "JMD"
+            },
+            {
+              "value": "JOD",
+              "label": "JOD"
+            },
+            {
+              "value": "JPY",
+              "label": "JPY"
+            },
+            {
+              "value": "KES",
+              "label": "KES"
+            },
+            {
+              "value": "KGS",
+              "label": "KGS"
+            },
+            {
+              "value": "KHR",
+              "label": "KHR"
+            },
+            {
+              "value": "KMF",
+              "label": "KMF"
+            },
+            {
+              "value": "KPW",
+              "label": "KPW"
+            },
+            {
+              "value": "KRW",
+              "label": "KRW"
+            },
+            {
+              "value": "KWD",
+              "label": "KWD"
+            },
+            {
+              "value": "KYD",
+              "label": "KYD"
+            },
+            {
+              "value": "KZT",
+              "label": "KZT"
+            },
+            {
+              "value": "LAK",
+              "label": "LAK"
+            },
+            {
+              "value": "LBP",
+              "label": "LBP"
+            },
+            {
+              "value": "LKR",
+              "label": "LKR"
+            },
+            {
+              "value": "LRD",
+              "label": "LRD"
+            },
+            {
+              "value": "LSL",
+              "label": "LSL"
+            },
+            {
+              "value": "LYD",
+              "label": "LYD"
+            },
+            {
+              "value": "MAD",
+              "label": "MAD"
+            },
+            {
+              "value": "MDL",
+              "label": "MDL"
+            },
+            {
+              "value": "MGA",
+              "label": "MGA"
+            },
+            {
+              "value": "MKD",
+              "label": "MKD"
+            },
+            {
+              "value": "MMK",
+              "label": "MMK"
+            },
+            {
+              "value": "MNT",
+              "label": "MNT"
+            },
+            {
+              "value": "MOP",
+              "label": "MOP"
+            },
+            {
+              "value": "MRU",
+              "label": "MRU"
+            },
+            {
+              "value": "MUR",
+              "label": "MUR"
+            },
+            {
+              "value": "MVR",
+              "label": "MVR"
+            },
+            {
+              "value": "MWK",
+              "label": "MWK"
+            },
+            {
+              "value": "MXN",
+              "label": "MXN"
+            },
+            {
+              "value": "MXV",
+              "label": "MXV"
+            },
+            {
+              "value": "MYR",
+              "label": "MYR"
+            },
+            {
+              "value": "MZN",
+              "label": "MZN"
+            },
+            {
+              "value": "NAD",
+              "label": "NAD"
+            },
+            {
+              "value": "NGN",
+              "label": "NGN"
+            },
+            {
+              "value": "NIO",
+              "label": "NIO"
+            },
+            {
+              "value": "NOK",
+              "label": "NOK"
+            },
+            {
+              "value": "NPR",
+              "label": "NPR"
+            },
+            {
+              "value": "NZD",
+              "label": "NZD"
+            },
+            {
+              "value": "OMR",
+              "label": "OMR"
+            },
+            {
+              "value": "PAB",
+              "label": "PAB"
+            },
+            {
+              "value": "PEN",
+              "label": "PEN"
+            },
+            {
+              "value": "PGK",
+              "label": "PGK"
+            },
+            {
+              "value": "PHP",
+              "label": "PHP"
+            },
+            {
+              "value": "PKR",
+              "label": "PKR"
+            },
+            {
+              "value": "PLN",
+              "label": "PLN"
+            },
+            {
+              "value": "PYG",
+              "label": "PYG"
+            },
+            {
+              "value": "QAR",
+              "label": "QAR"
+            },
+            {
+              "value": "RON",
+              "label": "RON"
+            },
+            {
+              "value": "RSD",
+              "label": "RSD"
+            },
+            {
+              "value": "RUB",
+              "label": "RUB"
+            },
+            {
+              "value": "RWF",
+              "label": "RWF"
+            },
+            {
+              "value": "SAR",
+              "label": "SAR"
+            },
+            {
+              "value": "SBD",
+              "label": "SBD"
+            },
+            {
+              "value": "SCR",
+              "label": "SCR"
+            },
+            {
+              "value": "SDG",
+              "label": "SDG"
+            },
+            {
+              "value": "SEK",
+              "label": "SEK"
+            },
+            {
+              "value": "SGD",
+              "label": "SGD"
+            },
+            {
+              "value": "SHP",
+              "label": "SHP"
+            },
+            {
+              "value": "SLL",
+              "label": "SLL"
+            },
+            {
+              "value": "SOS",
+              "label": "SOS"
+            },
+            {
+              "value": "SRD",
+              "label": "SRD"
+            },
+            {
+              "value": "SSP",
+              "label": "SSP"
+            },
+            {
+              "value": "STN",
+              "label": "STN"
+            },
+            {
+              "value": "SVC",
+              "label": "SVC"
+            },
+            {
+              "value": "SYP",
+              "label": "SYP"
+            },
+            {
+              "value": "SZL",
+              "label": "SZL"
+            },
+            {
+              "value": "THB",
+              "label": "THB"
+            },
+            {
+              "value": "TJS",
+              "label": "TJS"
+            },
+            {
+              "value": "TMT",
+              "label": "TMT"
+            },
+            {
+              "value": "TND",
+              "label": "TND"
+            },
+            {
+              "value": "TOP",
+              "label": "TOP"
+            },
+            {
+              "value": "TRY",
+              "label": "TRY"
+            },
+            {
+              "value": "TTD",
+              "label": "TTD"
+            },
+            {
+              "value": "TWD",
+              "label": "TWD"
+            },
+            {
+              "value": "TZS",
+              "label": "TZS"
+            },
+            {
+              "value": "UAH",
+              "label": "UAH"
+            },
+            {
+              "value": "UGX",
+              "label": "UGX"
+            },
+            {
+              "value": "USD",
+              "label": "USD"
+            },
+            {
+              "value": "USN",
+              "label": "USN"
+            },
+            {
+              "value": "UYI",
+              "label": "UYI"
+            },
+            {
+              "value": "UYU",
+              "label": "UYU"
+            },
+            {
+              "value": "UYW",
+              "label": "UYW"
+            },
+            {
+              "value": "UZS",
+              "label": "UZS"
+            },
+            {
+              "value": "VES",
+              "label": "VES"
+            },
+            {
+              "value": "VND",
+              "label": "VND"
+            },
+            {
+              "value": "VUV",
+              "label": "VUV"
+            },
+            {
+              "value": "WST",
+              "label": "WST"
+            },
+            {
+              "value": "XAF",
+              "label": "XAF"
+            },
+            {
+              "value": "XAG",
+              "label": "XAG"
+            },
+            {
+              "value": "XAU",
+              "label": "XAU"
+            },
+            {
+              "value": "XBA",
+              "label": "XBA"
+            },
+            {
+              "value": "XBB",
+              "label": "XBB"
+            },
+            {
+              "value": "XBC",
+              "label": "XBC"
+            },
+            {
+              "value": "XBD",
+              "label": "XBD"
+            },
+            {
+              "value": "XCD",
+              "label": "XCD"
+            },
+            {
+              "value": "XDR",
+              "label": "XDR"
+            },
+            {
+              "value": "XOF",
+              "label": "XOF"
+            },
+            {
+              "value": "XPD",
+              "label": "XPD"
+            },
+            {
+              "value": "XPF",
+              "label": "XPF"
+            },
+            {
+              "value": "XPT",
+              "label": "XPT"
+            },
+            {
+              "value": "XSU",
+              "label": "XSU"
+            },
+            {
+              "value": "XTS",
+              "label": "XTS"
+            },
+            {
+              "value": "XUA",
+              "label": "XUA"
+            },
+            {
+              "value": "XXX",
+              "label": "XXX"
+            },
+            {
+              "value": "YER",
+              "label": "YER"
+            },
+            {
+              "value": "ZAR",
+              "label": "ZAR"
+            },
+            {
+              "value": "ZMW",
+              "label": "ZMW"
+            },
+            {
+              "value": "ZWC",
+              "label": "ZWC"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "The currency for the value specified. Currency must be a valid ISO 4217 three-digit currency code.",
+                "type": "string",
+                "enum": [
+                  "AED",
+                  "AFN",
+                  "ALL",
+                  "AMD",
+                  "ANG",
+                  "AOA",
+                  "ARS",
+                  "AUD",
+                  "AWG",
+                  "AZN",
+                  "BAM",
+                  "BBD",
+                  "BDT",
+                  "BGN",
+                  "BHD",
+                  "BIF",
+                  "BMD",
+                  "BND",
+                  "BOB",
+                  "BOV",
+                  "BRL",
+                  "BSD",
+                  "BTN",
+                  "BWP",
+                  "BYN",
+                  "BZD",
+                  "CAD",
+                  "CDF",
+                  "CHE",
+                  "CHF",
+                  "CHW",
+                  "CLF",
+                  "CLP",
+                  "CNY",
+                  "COP",
+                  "COU",
+                  "CRC",
+                  "CUC",
+                  "CUP",
+                  "CVE",
+                  "CZK",
+                  "DJF",
+                  "DKK",
+                  "DOP",
+                  "DZD",
+                  "EGP",
+                  "ERN",
+                  "ETB",
+                  "EUR",
+                  "FJD",
+                  "FKP",
+                  "GBP",
+                  "GEL",
+                  "GHS",
+                  "GIP",
+                  "GMD",
+                  "GNF",
+                  "GTQ",
+                  "GYD",
+                  "HKD",
+                  "HNL",
+                  "HRK",
+                  "HTG",
+                  "HUF",
+                  "IDR",
+                  "ILS",
+                  "INR",
+                  "IQD",
+                  "IRR",
+                  "ISK",
+                  "JMD",
+                  "JOD",
+                  "JPY",
+                  "KES",
+                  "KGS",
+                  "KHR",
+                  "KMF",
+                  "KPW",
+                  "KRW",
+                  "KWD",
+                  "KYD",
+                  "KZT",
+                  "LAK",
+                  "LBP",
+                  "LKR",
+                  "LRD",
+                  "LSL",
+                  "LYD",
+                  "MAD",
+                  "MDL",
+                  "MGA",
+                  "MKD",
+                  "MMK",
+                  "MNT",
+                  "MOP",
+                  "MRU",
+                  "MUR",
+                  "MVR",
+                  "MWK",
+                  "MXN",
+                  "MXV",
+                  "MYR",
+                  "MZN",
+                  "NAD",
+                  "NGN",
+                  "NIO",
+                  "NOK",
+                  "NPR",
+                  "NZD",
+                  "OMR",
+                  "PAB",
+                  "PEN",
+                  "PGK",
+                  "PHP",
+                  "PKR",
+                  "PLN",
+                  "PYG",
+                  "QAR",
+                  "RON",
+                  "RSD",
+                  "RUB",
+                  "RWF",
+                  "SAR",
+                  "SBD",
+                  "SCR",
+                  "SDG",
+                  "SEK",
+                  "SGD",
+                  "SHP",
+                  "SLL",
+                  "SOS",
+                  "SRD",
+                  "SSP",
+                  "STN",
+                  "SVC",
+                  "SYP",
+                  "SZL",
+                  "THB",
+                  "TJS",
+                  "TMT",
+                  "TND",
+                  "TOP",
+                  "TRY",
+                  "TTD",
+                  "TWD",
+                  "TZS",
+                  "UAH",
+                  "UGX",
+                  "USD",
+                  "USN",
+                  "UYI",
+                  "UYU",
+                  "UYW",
+                  "UZS",
+                  "VES",
+                  "VND",
+                  "VUV",
+                  "WST",
+                  "XAF",
+                  "XAG",
+                  "XAU",
+                  "XBA",
+                  "XBB",
+                  "XBC",
+                  "XBD",
+                  "XCD",
+                  "XDR",
+                  "XOF",
+                  "XPD",
+                  "XPF",
+                  "XPT",
+                  "XSU",
+                  "XTS",
+                  "XUA",
+                  "XXX",
+                  "YER",
+                  "ZAR",
+                  "ZMW",
+                  "ZWC"
+                ]
+              }
+            },
+            "required": [],
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "event_config": {
+                      "properties": {
+                        "event_name": {
+                          "const": "Purchase"
+                        }
+                      },
+                      "required": ["event_name"]
+                    }
+                  },
+                  "required": ["event_config"]
+                },
+                "then": {
+                  "required": ["currency"]
+                }
+              }
+            ]
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddPaymentInfo"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "CompleteRegistration"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "InitiateCheckout"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Lead"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "StartTrial"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Subscribe"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              }
+            ]
+          },
+          "displayMetadata": {
+            "conditionallyRequired": {
+              "match": "all",
+              "conditions": [
+                {
+                  "fieldKey": "event_config.event_name",
+                  "operator": "is",
+                  "value": "Purchase"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "fieldKey": "delivery_category",
+          "type": "string",
+          "label": "Delivery Category",
+          "description": "Category of the delivery",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "in_store",
+              "label": "In Store"
+            },
+            {
+              "value": "curbside",
+              "label": "Curbside"
+            },
+            {
+              "value": "home_delivery",
+              "label": "Home Delivery"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "delivery_category": {
+                "title": "Delivery Category",
+                "description": "Category of the delivery",
+                "type": "string",
+                "enum": ["in_store", "curbside", "home_delivery"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "InitiateCheckout"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "num_items",
+          "type": "integer",
+          "label": "Number of Items",
+          "description": "The number of items when checkout was initiated.",
+          "defaultValue": {
+            "@path": "$.properties.num_items"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "num_items": {
+                "title": "Number of Items",
+                "description": "The number of items when checkout was initiated.",
+                "type": "integer"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "predicted_ltv",
+          "type": "number",
+          "label": "Predicted LTV",
+          "description": "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "predicted_ltv": {
+                "title": "Predicted LTV",
+                "description": "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Subscribe"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "StartTrial"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "CompleteRegistration"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddPaymentInfo"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "CustomEvent"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "net_revenue",
+          "type": "number",
+          "label": "Net Revenue",
+          "description": "The net revenue associated with the purchase.",
+          "defaultValue": {
+            "@path": "$.properties.net_revenue"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "net_revenue": {
+                "title": "Net Revenue",
+                "description": "The net revenue associated with the purchase.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "search_string",
+          "type": "string",
+          "label": "Search String",
+          "description": "The string entered by the user for the search.",
+          "defaultValue": {
+            "@path": "$.properties.query"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "search_string": {
+                "title": "Search String",
+                "description": "The string entered by the user for the search.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "status",
+          "type": "boolean",
+          "label": "Registration Status",
+          "description": "The status of the registration. true for completed registrations, false otherwise.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "title": "Registration Status",
+                "description": "The status of the registration. true for completed registrations, false otherwise.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "A numeric value associated with this event. This could be a monetary value or a value in some other metric.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "A numeric value associated with this event. This could be a monetary value or a value in some other metric.",
+                "type": "number"
+              }
+            },
+            "required": [],
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "event_config": {
+                      "properties": {
+                        "event_name": {
+                          "const": "Purchase"
+                        }
+                      },
+                      "required": ["event_name"]
+                    }
+                  },
+                  "required": ["event_config"]
+                },
+                "then": {
+                  "required": ["value"]
+                }
+              }
+            ]
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "event_config.show_fields",
+                "operator": "is",
+                "value": "true"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddPaymentInfo"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "CompleteRegistration"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "InitiateCheckout"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Lead"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Search"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "StartTrial"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "Subscribe"
+              },
+              {
+                "fieldKey": "event_config.event_name",
+                "operator": "is",
+                "value": "ViewContent"
+              }
+            ]
+          },
+          "displayMetadata": {
+            "conditionallyRequired": {
+              "match": "all",
+              "conditions": [
+                {
+                  "fieldKey": "event_config.event_name",
+                  "operator": "is",
+                  "value": "Purchase"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "fieldKey": "custom_data",
+          "type": "object",
+          "label": "Custom Data",
+          "description": "The custom data object can be used to pass custom properties.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "custom_data": {
+                "title": "Custom Data",
+                "description": "The custom data object can be used to pass custom properties.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventID",
+          "type": "string",
+          "label": "Event ID",
+          "description": "This ID can be any unique string. Event ID is used to deduplicate events sent both the server side Conversions API and the browser Pixel.",
+          "defaultValue": {
+            "@path": "$.messageId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventID": {
+                "title": "Event ID",
+                "description": "This ID can be any unique string. Event ID is used to deduplicate events sent both the server side Conversions API and the browser Pixel.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventSourceUrl",
+          "type": "string",
+          "label": "Event Source URL",
+          "description": "The URL of the page where the event occurred. Can be used to override the default URL taken from the current page.",
+          "defaultValue": {
+            "@path": "$.context.page.url"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventSourceUrl": {
+                "title": "Event Source URL",
+                "description": "The URL of the page where the event occurred. Can be used to override the default URL taken from the current page.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userData",
+          "type": "object",
+          "label": "User Data",
+          "description": "User data to be sent with the event. This can include hashed identifiers like email, phone number, etc.",
+          "defaultValue": {
+            "external_id": {
+              "@path": "$.userId"
+            },
+            "em": {
+              "@path": "$.context.traits.email"
+            },
+            "ph": {
+              "@path": "$.context.traits.phone"
+            },
+            "fn": {
+              "@path": "$.context.traits.first_name"
+            },
+            "ln": {
+              "@path": "$.context.traits.last_name"
+            },
+            "ge": {
+              "@path": "$.context.traits.gender"
+            },
+            "db": {
+              "@path": "$.context.traits.birthday"
+            },
+            "ct": {
+              "@path": "$.context.traits.address.city"
+            },
+            "st": {
+              "@path": "$.context.traits.address.state"
+            },
+            "zp": {
+              "@path": "$.context.traits.address.postal_code"
+            },
+            "country": {
+              "@path": "$.context.traits.address.country"
+            },
+            "fbp": {
+              "@path": "$.context.traits.fbp"
+            },
+            "fbc": {
+              "@path": "$.context.traits.fbc"
+            },
+            "client_ip_address": {
+              "@path": "$.context.traits.client_ip_address"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userData": {
+                "title": "User Data",
+                "description": "User data to be sent with the event. This can include hashed identifiers like email, phone number, etc.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "external_id": {
+                    "title": "External ID",
+                    "description": "A unique identifier for the user from your system",
+                    "type": "string"
+                  },
+                  "em": {
+                    "title": "Email",
+                    "description": "Email address of the user",
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "ph": {
+                    "title": "Phone Number",
+                    "description": "Phone number of the user. Make sure to include the country code. For example, \"15551234567\" for a US number.",
+                    "type": "string"
+                  },
+                  "fn": {
+                    "title": "First Name",
+                    "description": "First name of the user",
+                    "type": "string"
+                  },
+                  "ln": {
+                    "title": "Last Name",
+                    "description": "Last name of the user",
+                    "type": "string"
+                  },
+                  "ge": {
+                    "title": "Gender",
+                    "description": "Gender of the user. If unknown leave blank.",
+                    "type": "string",
+                    "enum": ["m", "f"]
+                  },
+                  "db": {
+                    "title": "Date of Birth",
+                    "description": "Date of birth of the user",
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "ct": {
+                    "title": "City",
+                    "description": "City of the user",
+                    "type": "string"
+                  },
+                  "st": {
+                    "title": "State",
+                    "description": "State of the user. Facebook expects the 2-letter abbreviation for US states. For example, \"CA\" for California, or \"NY\" for New York.",
+                    "type": "string"
+                  },
+                  "zp": {
+                    "title": "ZIP/Postal Code",
+                    "description": "ZIP or postal code of the user. For example, U.S zip code: 94035, Australia zip code: 1987, France zip code: 75018, UK zip code: m11ae.",
+                    "type": "string"
+                  },
+                  "country": {
+                    "title": "Country",
+                    "description": "The country of the user. Facebook expects the 2-letter ISO 3166-1 alpha-2 country code. For example, \"US\" for the United States, or \"GB\" for the United Kingdom.",
+                    "type": "string"
+                  },
+                  "fbp": {
+                    "title": "FBP",
+                    "description": "Use this field to pass the Facebook browser cookie value (_fbp) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbp cookie.",
+                    "type": "string"
+                  },
+                  "fbc": {
+                    "title": "FBC",
+                    "description": "Use this field to pass The Facebook browser cookie value (_fbc) associated with the user. If the \"Format User Data with Parameter Builder\" setting is enabled, Segment will automatically capture this value from the _fbc cookie.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "send",
+      "name": "AddPaymentInfo",
+      "subscribe": "event = \"Payment Info Entered\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "AddPaymentInfo",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@liquid": "{{ properties.products | map: 'product_id' }}"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "id": {
+                "@path": "$.product_id"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "item_price": {
+                "@path": "$.price"
+              }
+            }
+          ]
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.value"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "AddToCart",
+      "subscribe": "event = \"Product Added\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "AddToCart",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@path": "$.properties.product_id"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "id": {
+            "@path": "$.properties.product_id"
+          },
+          "quantity": {
+            "@path": "$.properties.quantity"
+          },
+          "item_price": {
+            "@path": "$.properties.price"
+          }
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.price"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "AddToWishlist",
+      "subscribe": "event = \"Product Added To Wishlist\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "AddToWishlist",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@path": "$.properties.product_id"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "id": {
+            "@path": "$.properties.product_id"
+          },
+          "quantity": {
+            "@path": "$.properties.quantity"
+          },
+          "item_price": {
+            "@path": "$.properties.price"
+          }
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.price"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "CompleteRegistration",
+      "subscribe": "event = \"Signed Up\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "CompleteRegistration",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@liquid": "{{ properties.products | map: 'product_id' }}"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "id": {
+                "@path": "$.product_id"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "item_price": {
+                "@path": "$.price"
+              }
+            }
+          ]
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.value"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "InitiateCheckout",
+      "subscribe": "event = \"Checkout Started\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "InitiateCheckout",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@liquid": "{{ properties.products | map: 'product_id' }}"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "id": {
+                "@path": "$.product_id"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "item_price": {
+                "@path": "$.price"
+              }
+            }
+          ]
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.value"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "PageView",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "PageView",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.category"
+        },
+        "content_ids": {
+          "@liquid": "{{ properties.products | map: 'product_id' }}"
+        },
+        "content_name": {
+          "@path": "$.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "id": {
+                "@path": "$.product_id"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "item_price": {
+                "@path": "$.price"
+              }
+            }
+          ]
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.value"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "Purchase",
+      "subscribe": "event = \"Order Completed\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "Purchase",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@liquid": "{{ properties.products | map: 'product_id' }}"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "id": {
+                "@path": "$.product_id"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "item_price": {
+                "@path": "$.price"
+              }
+            }
+          ]
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.revenue"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        },
+        "custom_data": {
+          "order_id": {
+            "@path": "$.properties.order_id"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "Search",
+      "subscribe": "event = \"Products Searched\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "Search",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@path": "$.properties.product_id"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "id": {
+            "@path": "$.properties.product_id"
+          },
+          "quantity": {
+            "@path": "$.properties.quantity"
+          },
+          "item_price": {
+            "@path": "$.properties.price"
+          }
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.value"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "send",
+      "name": "ViewContent",
+      "subscribe": "event = \"Product Viewed\"",
+      "mapping": {
+        "event_config": {
+          "event_name": "ViewContent",
+          "show_fields": false
+        },
+        "content_category": {
+          "@path": "$.properties.category"
+        },
+        "content_ids": {
+          "@path": "$.properties.product_id"
+        },
+        "content_name": {
+          "@path": "$.properties.name"
+        },
+        "content_type": "product",
+        "contents": {
+          "id": {
+            "@path": "$.properties.product_id"
+          },
+          "quantity": {
+            "@path": "$.properties.quantity"
+          },
+          "item_price": {
+            "@path": "$.properties.price"
+          }
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "net_revenue": {
+          "@path": "$.properties.net_revenue"
+        },
+        "search_string": {
+          "@path": "$.properties.query"
+        },
+        "value": {
+          "@path": "$.properties.price"
+        },
+        "eventID": {
+          "@path": "$.messageId"
+        },
+        "eventSourceUrl": {
+          "@path": "$.context.page.url"
+        },
+        "userData": {
+          "external_id": {
+            "@path": "$.userId"
+          },
+          "em": {
+            "@path": "$.context.traits.email"
+          },
+          "ph": {
+            "@path": "$.context.traits.phone"
+          },
+          "fn": {
+            "@path": "$.context.traits.first_name"
+          },
+          "ln": {
+            "@path": "$.context.traits.last_name"
+          },
+          "ge": {
+            "@path": "$.context.traits.gender"
+          },
+          "db": {
+            "@path": "$.context.traits.birthday"
+          },
+          "ct": {
+            "@path": "$.context.traits.address.city"
+          },
+          "st": {
+            "@path": "$.context.traits.address.state"
+          },
+          "zp": {
+            "@path": "$.context.traits.address.postal_code"
+          },
+          "country": {
+            "@path": "$.context.traits.address.country"
+          },
+          "fbp": {
+            "@path": "$.context.traits.fbp"
+          },
+          "fbc": {
+            "@path": "$.context.traits.fbc"
+          },
+          "client_ip_address": {
+            "@path": "$.context.traits.client_ip_address"
+          }
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/friendbuy/metadata.json
+++ b/packages/browser-destinations/destinations/friendbuy/metadata.json
@@ -1,1152 +1,789 @@
 {
+  "slug": "actions-friendbuy",
   "name": "Friendbuy (Actions)",
-  "basicOptions": ["merchantId"],
-  "options": {
-    "merchantId": {
-      "tags": [],
-      "default": "",
-      "description": "Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Friendbuy Merchant ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The merchantId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "merchantId": {
+        "label": "Friendbuy Merchant ID",
+        "description": "Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "trackCustomEvent",
-      "name": "Track Custom Event",
-      "description": "Record when a customer completes any custom event that you define.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": null,
-      "fields": [
-        {
-          "fieldKey": "eventType",
-          "type": "string",
-          "label": "Event Type",
-          "description": "The type of the event to track.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventType": {
-                "title": "Event Type",
-                "description": "The type of the event to track.",
-                "type": "string"
-              }
-            },
-            "required": ["eventType"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "eventProperties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Object containing the properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventProperties": {
-                "title": "Event Properties",
-                "description": "Object containing the properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.",
-                "type": "object"
-              }
-            },
-            "required": ["eventProperties"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "deduplicationId",
-          "type": "string",
-          "label": "Event ID",
-          "description": "An identifier for the event being tracked to prevent the same event from being rewarded more than once.",
-          "defaultValue": {
-            "@path": "$.properties.deduplicationId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "deduplicationId": {
-                "title": "Event ID",
-                "description": "An identifier for the event being tracked to prevent the same event from being rewarded more than once.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "customerId",
-          "type": "string",
-          "label": "Customer ID",
-          "description": "The user's customer ID.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.customerId"
-              },
-              "then": {
-                "@path": "$.properties.customerId"
-              },
-              "else": {
-                "@path": "$.userId"
-              }
-            }
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "customerId": {
-                "title": "Customer ID",
-                "description": "The user's customer ID.",
-                "type": "string"
-              }
-            },
-            "required": ["customerId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "The user's anonymous id",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "email",
-          "type": "string",
-          "label": "Email",
-          "description": "The user's email address.",
-          "defaultValue": {
-            "@path": "$.properties.email"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email address.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackCustomer",
-      "name": "Track Customer",
+  "audienceConfig": null,
+  "actions": {
+    "trackCustomer": {
+      "title": "Track Customer",
       "description": "Create a new customer profile or update an existing customer profile.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "customerId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "customerId": {
           "label": "Customer ID",
           "description": "The user's customer ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "customerId": {
-                "title": "Customer ID",
-                "description": "The user's customer ID.",
-                "type": "string"
-              }
-            },
-            "required": ["customerId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous id.",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous id.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email address.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.email"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email address.",
-                "type": "string"
-              }
-            },
-            "required": ["email"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "firstName",
-          "type": "string",
+        "firstName": {
           "label": "First Name",
           "description": "The user's given name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.firstName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "firstName": {
-                "title": "First Name",
-                "description": "The user's given name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "lastName",
-          "type": "string",
+        "lastName": {
           "label": "Last Name",
           "description": "The user's surname.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.lastName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "lastName": {
-                "title": "Last Name",
-                "description": "The user's surname.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "name",
-          "type": "string",
+        "name": {
           "label": "Name",
           "description": "The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "age",
-          "type": "number",
+        "age": {
           "label": "Age",
           "description": "The user's age.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.age"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "age": {
-                "title": "Age",
-                "description": "The user's age.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "birthday",
-          "type": "string",
+        "birthday": {
           "label": "Birthday",
           "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.birthday"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "birthday": {
-                "title": "Birthday",
-                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-                "type": "string",
-                "format": "date"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "language",
-          "type": "string",
+        "language": {
           "label": "Language",
           "description": "The user's language.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.language"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "language": {
-                "title": "Language",
-                "description": "The user's language.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "addressCountry",
-          "type": "string",
+        "addressCountry": {
           "label": "Country",
           "description": "The user's country.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.country"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "addressCountry": {
-                "title": "Country",
-                "description": "The user's country.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "addressState",
-          "type": "string",
+        "addressState": {
           "label": "State",
           "description": "The user's state.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.state"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "addressState": {
-                "title": "State",
-                "description": "The user's state.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "addressCity",
-          "type": "string",
+        "addressCity": {
           "label": "City",
           "description": "The user's city.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.city"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "addressCity": {
-                "title": "City",
-                "description": "The user's city.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "addressPostalCode",
-          "type": "string",
+        "addressPostalCode": {
           "label": "State",
           "description": "The user's postal code.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.postalCode"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "addressPostalCode": {
-                "title": "State",
-                "description": "The user's postal code.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "customerSince",
-          "type": "string",
+        "customerSince": {
           "label": "Customer Since",
           "description": "The date the user became a customer.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.customerSince"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "customerSince": {
-                "title": "Customer Since",
-                "description": "The date the user became a customer.",
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "loyaltyStatus",
-          "type": "string",
+        "loyaltyStatus": {
           "label": "Loyalty Status",
           "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.loyaltyStatus"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "loyaltyStatus": {
-                "title": "Loyalty Status",
-                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "isNewCustomer",
-          "type": "boolean",
+        "isNewCustomer": {
           "label": "New Customer Flag",
           "description": "Flag to indicate whether the user is a new customer.",
-          "defaultValue": {
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.isNewCustomer"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "isNewCustomer": {
-                "title": "New Customer Flag",
-                "description": "Flag to indicate whether the user is a new customer.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "friendbuyAttributes",
-          "type": "object",
+        "friendbuyAttributes": {
           "label": "Custom Attributes",
           "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.friendbuyAttributes"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "friendbuyAttributes": {
-                "title": "Custom Attributes",
-                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackPage",
-      "name": "Track Page",
-      "description": "Record when a customer visits a new page. Allow Friendbuy widget targeting by Page Name instead of URL.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Page Name",
-          "description": "The page name.",
-          "defaultValue": {
-            "@path": "$.name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Page Name",
-                "description": "The page name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "category",
-          "type": "string",
-          "label": "Page Category",
-          "description": "The page category.",
-          "defaultValue": {
-            "@path": "$.category"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "category": {
-                "title": "Page Category",
-                "description": "The page category.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "title",
-          "type": "string",
-          "label": "Page Title",
-          "description": "The page title.",
-          "defaultValue": {
-            "@path": "$.properties.title"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "title": {
-                "title": "Page Title",
-                "description": "The page title.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackPurchase",
-      "name": "Track Purchase",
+    "trackPurchase": {
+      "title": "Track Purchase",
       "description": "Record when a customer makes a purchase.",
       "platform": "web",
+      "defaultSubscription": "event = \"Order Completed\"",
       "hidden": false,
-      "defaultTrigger": "event = \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "orderId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "orderId": {
           "label": "Order ID",
           "description": "The order ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.order_id"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "orderId": {
-                "title": "Order ID",
-                "description": "The order ID.",
-                "type": "string"
-              }
-            },
-            "required": ["orderId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "amount",
-          "type": "number",
+        "amount": {
           "label": "Purchase Amount",
           "description": "Purchase amount to be considered when evaluating reward rules.",
-          "defaultValue": {
+          "type": "number",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.total"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "amount": {
-                "title": "Purchase Amount",
-                "description": "Purchase amount to be considered when evaluating reward rules.",
-                "type": "number"
-              }
-            },
-            "required": ["amount"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "currency",
-          "type": "string",
+        "currency": {
           "label": "Currency",
           "description": "The currency of the purchase amount.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.currency"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "The currency of the purchase amount.",
-                "type": "string"
-              }
-            },
-            "required": ["currency"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
+        "coupon": {
           "label": "Coupon",
           "description": "The coupon code of any coupon redeemed with the order.",
-          "defaultValue": {
-            "@path": "$.properties.coupon"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "The coupon code of any coupon redeemed with the order.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.coupon"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "attributionId",
-          "type": "string",
+        "attributionId": {
           "label": "Friendbuy Attribution ID",
           "description": "Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.",
-          "defaultValue": {
-            "@path": "$.properties.attributionId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributionId": {
-                "title": "Friendbuy Attribution ID",
-                "description": "Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.attributionId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "referralCode",
-          "type": "string",
+        "referralCode": {
           "label": "Friendbuy Referral ID",
           "description": "Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.",
-          "defaultValue": {
-            "@path": "$.properties.referralCode"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "referralCode": {
-                "title": "Friendbuy Referral ID",
-                "description": "Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.referralCode"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "giftCardCodes",
-          "type": "string",
+        "giftCardCodes": {
           "label": "Gift Card Codes",
           "description": "An array of gift card codes applied to the order.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.giftCardCodes"
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "giftCardCodes": {
-                "title": "Gift Card Codes",
-                "description": "An array of gift card codes applied to the order.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "products",
-          "type": "object",
+        "products": {
           "label": "Products",
           "description": "Products purchased.",
-          "defaultValue": {
-            "@path": "$.properties.products"
-          },
+          "type": "object",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "products": {
-                "title": "Products",
-                "description": "Products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "sku": {
-                      "title": "Product SKU",
-                      "type": "string"
-                    },
-                    "name": {
-                      "title": "Product Name",
-                      "type": "string"
-                    },
-                    "quantity": {
-                      "title": "Quantity (default 1)",
-                      "type": "integer"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "type": "number"
-                    },
-                    "description": {
-                      "title": "Product Description",
-                      "type": "string"
-                    },
-                    "category": {
-                      "title": "Product Category",
-                      "type": "string"
-                    },
-                    "url": {
-                      "title": "Product URL",
-                      "type": "string"
-                    },
-                    "image_url": {
-                      "title": "Product Image URL",
-                      "type": "string"
-                    }
-                  },
-                  "required": ["price"]
-                }
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.products"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "sku": {
+              "label": "Product SKU",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "name": {
+              "label": "Product Name",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity (default 1)",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "type": "number",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "description": {
+              "label": "Product Description",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "category": {
+              "label": "Product Category",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "url": {
+              "label": "Product URL",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "image_url": {
+              "label": "Product Image URL",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "customerId",
-          "type": "string",
+        "customerId": {
           "label": "Customer ID",
           "description": "The user's customer ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.customerId"
@@ -1159,345 +796,269 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "customerId": {
-                "title": "Customer ID",
-                "description": "The user's customer ID.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous ID.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email address.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.email"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email address.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "isNewCustomer",
-          "type": "boolean",
+        "isNewCustomer": {
           "label": "New Customer Flag",
           "description": "Flag to indicate whether the user is a new customer.",
-          "defaultValue": {
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.isNewCustomer"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "isNewCustomer": {
-                "title": "New Customer Flag",
-                "description": "Flag to indicate whether the user is a new customer.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "loyaltyStatus",
-          "type": "string",
+        "loyaltyStatus": {
           "label": "Loyalty Program Status",
           "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.loyaltyStatus"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "loyaltyStatus": {
-                "title": "Loyalty Program Status",
-                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "firstName",
-          "type": "string",
+        "firstName": {
           "label": "First Name",
           "description": "The user's given name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.firstName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "firstName": {
-                "title": "First Name",
-                "description": "The user's given name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "lastName",
-          "type": "string",
+        "lastName": {
           "label": "Last Name",
           "description": "The user's surname.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.lastName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "lastName": {
-                "title": "Last Name",
-                "description": "The user's surname.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "name",
-          "type": "string",
+        "name": {
           "label": "Name",
           "description": "The user's full name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The user's full name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "age",
-          "type": "number",
+        "age": {
           "label": "Age",
           "description": "The user's age.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.age"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "age": {
-                "title": "Age",
-                "description": "The user's age.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "birthday",
-          "type": "string",
+        "birthday": {
           "label": "Birthday",
           "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.birthday"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "birthday": {
-                "title": "Birthday",
-                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-                "type": "string",
-                "format": "date"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "friendbuyAttributes",
-          "type": "object",
+        "friendbuyAttributes": {
           "label": "Custom Attributes",
           "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-          "defaultValue": {
-            "@path": "$.properties.friendbuyAttributes"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "friendbuyAttributes": {
-                "title": "Custom Attributes",
-                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.friendbuyAttributes"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackSignUp",
-      "name": "Track Sign Up",
+    "trackSignUp": {
+      "title": "Track Sign Up",
       "description": "Record when a customer signs up for a service.",
       "platform": "web",
+      "defaultSubscription": "event = \"Signed Up\"",
       "hidden": false,
-      "defaultTrigger": "event = \"Signed Up\"",
-      "fields": [
-        {
-          "fieldKey": "customerId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "customerId": {
           "label": "Customer ID",
           "description": "The user's customer ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.customerId"
@@ -1510,426 +1071,566 @@
               }
             }
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "customerId": {
-                "title": "Customer ID",
-                "description": "The user's customer ID.",
-                "type": "string"
-              }
-            },
-            "required": ["customerId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous ID.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email address.",
-          "defaultValue": {
-            "@path": "$.properties.email"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email address.",
-                "type": "string"
-              }
-            },
-            "required": ["email"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.email"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "isNewCustomer",
-          "type": "boolean",
+        "isNewCustomer": {
           "label": "New Customer Flag",
           "description": "Flag to indicate whether the user is a new customer.",
-          "defaultValue": {
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.isNewCustomer"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "isNewCustomer": {
-                "title": "New Customer Flag",
-                "description": "Flag to indicate whether the user is a new customer.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "loyaltyStatus",
-          "type": "string",
+        "loyaltyStatus": {
           "label": "Loyalty Program Status",
           "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.loyaltyStatus"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "loyaltyStatus": {
-                "title": "Loyalty Program Status",
-                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "firstName",
-          "type": "string",
+        "firstName": {
           "label": "First Name",
           "description": "The user's given name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.firstName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "firstName": {
-                "title": "First Name",
-                "description": "The user's given name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "lastName",
-          "type": "string",
+        "lastName": {
           "label": "Last Name",
           "description": "The user's surname.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.lastName"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "lastName": {
-                "title": "Last Name",
-                "description": "The user's surname.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "name",
-          "type": "string",
+        "name": {
           "label": "Name",
           "description": "The user's full name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The user's full name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "age",
-          "type": "number",
+        "age": {
           "label": "Age",
           "description": "The user's age.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.age"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "age": {
-                "title": "Age",
-                "description": "The user's age.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "birthday",
-          "type": "string",
+        "birthday": {
           "label": "Birthday",
           "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.birthday"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "birthday": {
-                "title": "Birthday",
-                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
-                "type": "string",
-                "format": "date"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
+        "coupon": {
           "label": "Coupon Code",
           "description": "Coupon code that customer supplied when they signed up.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.coupon"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon Code",
-                "description": "Coupon code that customer supplied when they signed up.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "attributionId",
-          "type": "string",
+        "attributionId": {
           "label": "Friendbuy Attribution ID",
           "description": "Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.attributionId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributionId": {
-                "title": "Friendbuy Attribution ID",
-                "description": "Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "referralCode",
-          "type": "string",
+        "referralCode": {
           "label": "Friendbuy Referral ID",
           "description": "Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.referralCode"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "referralCode": {
-                "title": "Friendbuy Referral ID",
-                "description": "Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "friendbuyAttributes",
-          "type": "object",
+        "friendbuyAttributes": {
           "label": "Custom Attributes",
           "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-          "defaultValue": {
-            "@path": "$.properties.friendbuyAttributes"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "friendbuyAttributes": {
-                "title": "Custom Attributes",
-                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.friendbuyAttributes"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "trackPage": {
+      "title": "Track Page",
+      "description": "Record when a customer visits a new page. Allow Friendbuy widget targeting by Page Name instead of URL.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Page Name",
+          "description": "The page name.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "category": {
+          "label": "Page Category",
+          "description": "The page category.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.category"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "title": {
+          "label": "Page Title",
+          "description": "The page title.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.title"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "trackCustomEvent": {
+      "title": "Track Custom Event",
+      "description": "Record when a customer completes any custom event that you define.",
+      "platform": "web",
+      "defaultSubscription": null,
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventType": {
+          "label": "Event Type",
+          "description": "The type of the event to track.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "eventProperties": {
+          "label": "Event Properties",
+          "description": "Object containing the properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "deduplicationId": {
+          "label": "Event ID",
+          "description": "An identifier for the event being tracked to prevent the same event from being rewarded more than once.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.deduplicationId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "customerId": {
+          "label": "Customer ID",
+          "description": "The user's customer ID.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.customerId"
+              },
+              "then": {
+                "@path": "$.properties.customerId"
+              },
+              "else": {
+                "@path": "$.userId"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "email": {
+          "label": "Email",
+          "description": "The user's email address.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.email"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "trackCustomer",
       "name": "Track Customer",
+      "type": "automatic",
+      "partnerAction": "trackCustomer",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "customerId": {
@@ -1984,28 +1685,12 @@
           "@path": "$.traits.friendbuyAttributes"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackPage",
-      "name": "Track Page",
-      "subscribe": "type = \"page\"",
-      "mapping": {
-        "name": {
-          "@path": "$.name"
-        },
-        "category": {
-          "@path": "$.category"
-        },
-        "title": {
-          "@path": "$.properties.title"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackPurchase",
       "name": "Track Purchase",
+      "type": "automatic",
+      "partnerAction": "trackPurchase",
       "subscribe": "event = \"Order Completed\"",
       "mapping": {
         "orderId": {
@@ -2076,11 +1761,12 @@
           "@path": "$.properties.friendbuyAttributes"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackSignUp",
       "name": "Track Sign Up",
+      "type": "automatic",
+      "partnerAction": "trackSignUp",
       "subscribe": "event = \"Signed Up\"",
       "mapping": {
         "customerId": {
@@ -2136,7 +1822,25 @@
           "@path": "$.properties.friendbuyAttributes"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Track Page",
+      "type": "automatic",
+      "partnerAction": "trackPage",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "name": {
+          "@path": "$.name"
+        },
+        "category": {
+          "@path": "$.category"
+        },
+        "title": {
+          "@path": "$.properties.title"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/friendbuy/metadata.json
+++ b/packages/browser-destinations/destinations/friendbuy/metadata.json
@@ -1,0 +1,2142 @@
+{
+  "name": "Friendbuy (Actions)",
+  "basicOptions": ["merchantId"],
+  "options": {
+    "merchantId": {
+      "tags": [],
+      "default": "",
+      "description": "Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Friendbuy Merchant ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The merchantId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "trackCustomEvent",
+      "name": "Track Custom Event",
+      "description": "Record when a customer completes any custom event that you define.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": null,
+      "fields": [
+        {
+          "fieldKey": "eventType",
+          "type": "string",
+          "label": "Event Type",
+          "description": "The type of the event to track.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventType": {
+                "title": "Event Type",
+                "description": "The type of the event to track.",
+                "type": "string"
+              }
+            },
+            "required": ["eventType"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventProperties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Object containing the properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventProperties": {
+                "title": "Event Properties",
+                "description": "Object containing the properties for the event being tracked. All of the fields in this object will be sent in the root of the Friendbuy track event.",
+                "type": "object"
+              }
+            },
+            "required": ["eventProperties"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "deduplicationId",
+          "type": "string",
+          "label": "Event ID",
+          "description": "An identifier for the event being tracked to prevent the same event from being rewarded more than once.",
+          "defaultValue": {
+            "@path": "$.properties.deduplicationId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "deduplicationId": {
+                "title": "Event ID",
+                "description": "An identifier for the event being tracked to prevent the same event from being rewarded more than once.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "customerId",
+          "type": "string",
+          "label": "Customer ID",
+          "description": "The user's customer ID.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.customerId"
+              },
+              "then": {
+                "@path": "$.properties.customerId"
+              },
+              "else": {
+                "@path": "$.userId"
+              }
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "customerId": {
+                "title": "Customer ID",
+                "description": "The user's customer ID.",
+                "type": "string"
+              }
+            },
+            "required": ["customerId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email address.",
+          "defaultValue": {
+            "@path": "$.properties.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email address.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackCustomer",
+      "name": "Track Customer",
+      "description": "Create a new customer profile or update an existing customer profile.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "customerId",
+          "type": "string",
+          "label": "Customer ID",
+          "description": "The user's customer ID.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "customerId": {
+                "title": "Customer ID",
+                "description": "The user's customer ID.",
+                "type": "string"
+              }
+            },
+            "required": ["customerId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous id.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email address.",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email address.",
+                "type": "string"
+              }
+            },
+            "required": ["email"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "firstName",
+          "type": "string",
+          "label": "First Name",
+          "description": "The user's given name.",
+          "defaultValue": {
+            "@path": "$.traits.firstName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "firstName": {
+                "title": "First Name",
+                "description": "The user's given name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "lastName",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The user's surname.",
+          "defaultValue": {
+            "@path": "$.traits.lastName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "lastName": {
+                "title": "Last Name",
+                "description": "The user's surname.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.",
+          "defaultValue": {
+            "@path": "$.traits.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The user's full name. If the name trait doesn't exist then it will be automatically derived from the firstName and lastName traits if they are defined.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "age",
+          "type": "number",
+          "label": "Age",
+          "description": "The user's age.",
+          "defaultValue": {
+            "@path": "$.traits.age"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "age": {
+                "title": "Age",
+                "description": "The user's age.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "birthday",
+          "type": "string",
+          "label": "Birthday",
+          "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+          "defaultValue": {
+            "@path": "$.traits.birthday"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "birthday": {
+                "title": "Birthday",
+                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+                "type": "string",
+                "format": "date"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "language",
+          "type": "string",
+          "label": "Language",
+          "description": "The user's language.",
+          "defaultValue": {
+            "@path": "$.traits.language"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "language": {
+                "title": "Language",
+                "description": "The user's language.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "addressCountry",
+          "type": "string",
+          "label": "Country",
+          "description": "The user's country.",
+          "defaultValue": {
+            "@path": "$.traits.address.country"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "addressCountry": {
+                "title": "Country",
+                "description": "The user's country.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "addressState",
+          "type": "string",
+          "label": "State",
+          "description": "The user's state.",
+          "defaultValue": {
+            "@path": "$.traits.address.state"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "addressState": {
+                "title": "State",
+                "description": "The user's state.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "addressCity",
+          "type": "string",
+          "label": "City",
+          "description": "The user's city.",
+          "defaultValue": {
+            "@path": "$.traits.address.city"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "addressCity": {
+                "title": "City",
+                "description": "The user's city.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "addressPostalCode",
+          "type": "string",
+          "label": "State",
+          "description": "The user's postal code.",
+          "defaultValue": {
+            "@path": "$.traits.address.postalCode"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "addressPostalCode": {
+                "title": "State",
+                "description": "The user's postal code.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "customerSince",
+          "type": "string",
+          "label": "Customer Since",
+          "description": "The date the user became a customer.",
+          "defaultValue": {
+            "@path": "$.traits.customerSince"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "customerSince": {
+                "title": "Customer Since",
+                "description": "The date the user became a customer.",
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "loyaltyStatus",
+          "type": "string",
+          "label": "Loyalty Status",
+          "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+          "defaultValue": {
+            "@path": "$.traits.loyaltyStatus"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "loyaltyStatus": {
+                "title": "Loyalty Status",
+                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "isNewCustomer",
+          "type": "boolean",
+          "label": "New Customer Flag",
+          "description": "Flag to indicate whether the user is a new customer.",
+          "defaultValue": {
+            "@path": "$.traits.isNewCustomer"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "isNewCustomer": {
+                "title": "New Customer Flag",
+                "description": "Flag to indicate whether the user is a new customer.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "friendbuyAttributes",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+          "defaultValue": {
+            "@path": "$.traits.friendbuyAttributes"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "friendbuyAttributes": {
+                "title": "Custom Attributes",
+                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPage",
+      "name": "Track Page",
+      "description": "Record when a customer visits a new page. Allow Friendbuy widget targeting by Page Name instead of URL.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Page Name",
+          "description": "The page name.",
+          "defaultValue": {
+            "@path": "$.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Page Name",
+                "description": "The page name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "category",
+          "type": "string",
+          "label": "Page Category",
+          "description": "The page category.",
+          "defaultValue": {
+            "@path": "$.category"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "category": {
+                "title": "Page Category",
+                "description": "The page category.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "title",
+          "type": "string",
+          "label": "Page Title",
+          "description": "The page title.",
+          "defaultValue": {
+            "@path": "$.properties.title"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "title": "Page Title",
+                "description": "The page title.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPurchase",
+      "name": "Track Purchase",
+      "description": "Record when a customer makes a purchase.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "event = \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "orderId",
+          "type": "string",
+          "label": "Order ID",
+          "description": "The order ID.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "orderId": {
+                "title": "Order ID",
+                "description": "The order ID.",
+                "type": "string"
+              }
+            },
+            "required": ["orderId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "amount",
+          "type": "number",
+          "label": "Purchase Amount",
+          "description": "Purchase amount to be considered when evaluating reward rules.",
+          "defaultValue": {
+            "@path": "$.properties.total"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "title": "Purchase Amount",
+                "description": "Purchase amount to be considered when evaluating reward rules.",
+                "type": "number"
+              }
+            },
+            "required": ["amount"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "The currency of the purchase amount.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "The currency of the purchase amount.",
+                "type": "string"
+              }
+            },
+            "required": ["currency"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "The coupon code of any coupon redeemed with the order.",
+          "defaultValue": {
+            "@path": "$.properties.coupon"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "The coupon code of any coupon redeemed with the order.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributionId",
+          "type": "string",
+          "label": "Friendbuy Attribution ID",
+          "description": "Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.",
+          "defaultValue": {
+            "@path": "$.properties.attributionId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributionId": {
+                "title": "Friendbuy Attribution ID",
+                "description": "Friendbuy attribution ID that associates the purchase with the advocate who referred the purchaser.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "referralCode",
+          "type": "string",
+          "label": "Friendbuy Referral ID",
+          "description": "Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.",
+          "defaultValue": {
+            "@path": "$.properties.referralCode"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "referralCode": {
+                "title": "Friendbuy Referral ID",
+                "description": "Friendbuy referral code that associates the purchase with the advocate who referred the purchaser.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "giftCardCodes",
+          "type": "string",
+          "label": "Gift Card Codes",
+          "description": "An array of gift card codes applied to the order.",
+          "defaultValue": {
+            "@path": "$.properties.giftCardCodes"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "giftCardCodes": {
+                "title": "Gift Card Codes",
+                "description": "An array of gift card codes applied to the order.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "products",
+          "type": "object",
+          "label": "Products",
+          "description": "Products purchased.",
+          "defaultValue": {
+            "@path": "$.properties.products"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "products": {
+                "title": "Products",
+                "description": "Products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sku": {
+                      "title": "Product SKU",
+                      "type": "string"
+                    },
+                    "name": {
+                      "title": "Product Name",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "title": "Quantity (default 1)",
+                      "type": "integer"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "type": "number"
+                    },
+                    "description": {
+                      "title": "Product Description",
+                      "type": "string"
+                    },
+                    "category": {
+                      "title": "Product Category",
+                      "type": "string"
+                    },
+                    "url": {
+                      "title": "Product URL",
+                      "type": "string"
+                    },
+                    "image_url": {
+                      "title": "Product Image URL",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["price"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "customerId",
+          "type": "string",
+          "label": "Customer ID",
+          "description": "The user's customer ID.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.customerId"
+              },
+              "then": {
+                "@path": "$.properties.customerId"
+              },
+              "else": {
+                "@path": "$.userId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "customerId": {
+                "title": "Customer ID",
+                "description": "The user's customer ID.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous ID.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous ID.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email address.",
+          "defaultValue": {
+            "@path": "$.properties.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email address.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "isNewCustomer",
+          "type": "boolean",
+          "label": "New Customer Flag",
+          "description": "Flag to indicate whether the user is a new customer.",
+          "defaultValue": {
+            "@path": "$.properties.isNewCustomer"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "isNewCustomer": {
+                "title": "New Customer Flag",
+                "description": "Flag to indicate whether the user is a new customer.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "loyaltyStatus",
+          "type": "string",
+          "label": "Loyalty Program Status",
+          "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+          "defaultValue": {
+            "@path": "$.properties.loyaltyStatus"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "loyaltyStatus": {
+                "title": "Loyalty Program Status",
+                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "firstName",
+          "type": "string",
+          "label": "First Name",
+          "description": "The user's given name.",
+          "defaultValue": {
+            "@path": "$.properties.firstName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "firstName": {
+                "title": "First Name",
+                "description": "The user's given name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "lastName",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The user's surname.",
+          "defaultValue": {
+            "@path": "$.properties.lastName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "lastName": {
+                "title": "Last Name",
+                "description": "The user's surname.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The user's full name.",
+          "defaultValue": {
+            "@path": "$.properties.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The user's full name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "age",
+          "type": "number",
+          "label": "Age",
+          "description": "The user's age.",
+          "defaultValue": {
+            "@path": "$.properties.age"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "age": {
+                "title": "Age",
+                "description": "The user's age.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "birthday",
+          "type": "string",
+          "label": "Birthday",
+          "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+          "defaultValue": {
+            "@path": "$.properties.birthday"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "birthday": {
+                "title": "Birthday",
+                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+                "type": "string",
+                "format": "date"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "friendbuyAttributes",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+          "defaultValue": {
+            "@path": "$.properties.friendbuyAttributes"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "friendbuyAttributes": {
+                "title": "Custom Attributes",
+                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackSignUp",
+      "name": "Track Sign Up",
+      "description": "Record when a customer signs up for a service.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "event = \"Signed Up\"",
+      "fields": [
+        {
+          "fieldKey": "customerId",
+          "type": "string",
+          "label": "Customer ID",
+          "description": "The user's customer ID.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.customerId"
+              },
+              "then": {
+                "@path": "$.properties.customerId"
+              },
+              "else": {
+                "@path": "$.userId"
+              }
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "customerId": {
+                "title": "Customer ID",
+                "description": "The user's customer ID.",
+                "type": "string"
+              }
+            },
+            "required": ["customerId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous ID.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous ID.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email address.",
+          "defaultValue": {
+            "@path": "$.properties.email"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email address.",
+                "type": "string"
+              }
+            },
+            "required": ["email"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "isNewCustomer",
+          "type": "boolean",
+          "label": "New Customer Flag",
+          "description": "Flag to indicate whether the user is a new customer.",
+          "defaultValue": {
+            "@path": "$.properties.isNewCustomer"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "isNewCustomer": {
+                "title": "New Customer Flag",
+                "description": "Flag to indicate whether the user is a new customer.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "loyaltyStatus",
+          "type": "string",
+          "label": "Loyalty Program Status",
+          "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+          "defaultValue": {
+            "@path": "$.properties.loyaltyStatus"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "loyaltyStatus": {
+                "title": "Loyalty Program Status",
+                "description": "The status of the user in your loyalty program. Valid values are \"in\", \"out\", or \"blocked\".",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "firstName",
+          "type": "string",
+          "label": "First Name",
+          "description": "The user's given name.",
+          "defaultValue": {
+            "@path": "$.properties.firstName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "firstName": {
+                "title": "First Name",
+                "description": "The user's given name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "lastName",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The user's surname.",
+          "defaultValue": {
+            "@path": "$.properties.lastName"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "lastName": {
+                "title": "Last Name",
+                "description": "The user's surname.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The user's full name.",
+          "defaultValue": {
+            "@path": "$.properties.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The user's full name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "age",
+          "type": "number",
+          "label": "Age",
+          "description": "The user's age.",
+          "defaultValue": {
+            "@path": "$.properties.age"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "age": {
+                "title": "Age",
+                "description": "The user's age.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "birthday",
+          "type": "string",
+          "label": "Birthday",
+          "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+          "defaultValue": {
+            "@path": "$.properties.birthday"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "birthday": {
+                "title": "Birthday",
+                "description": "The user's birthday in the format \"YYYY-MM-DD\", or \"0000-MM-DD\" to omit the year.",
+                "type": "string",
+                "format": "date"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon Code",
+          "description": "Coupon code that customer supplied when they signed up.",
+          "defaultValue": {
+            "@path": "$.properties.coupon"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon Code",
+                "description": "Coupon code that customer supplied when they signed up.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributionId",
+          "type": "string",
+          "label": "Friendbuy Attribution ID",
+          "description": "Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.",
+          "defaultValue": {
+            "@path": "$.properties.attributionId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributionId": {
+                "title": "Friendbuy Attribution ID",
+                "description": "Friendbuy attribution ID that associates the customer who is signing up with the advocate who referred them.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "referralCode",
+          "type": "string",
+          "label": "Friendbuy Referral ID",
+          "description": "Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.",
+          "defaultValue": {
+            "@path": "$.properties.referralCode"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "referralCode": {
+                "title": "Friendbuy Referral ID",
+                "description": "Friendbuy referral code that associates the customer who is signing up with the advocate who referred them.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "friendbuyAttributes",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+          "defaultValue": {
+            "@path": "$.properties.friendbuyAttributes"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "friendbuyAttributes": {
+                "title": "Custom Attributes",
+                "description": "Custom attributes to send to Friendbuy. You should pass an object whose keys are the names of the custom attributes and whose values are strings. Non-string-valued attributes will be dropped.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "trackCustomer",
+      "name": "Track Customer",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "customerId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "firstName": {
+          "@path": "$.traits.firstName"
+        },
+        "lastName": {
+          "@path": "$.traits.lastName"
+        },
+        "name": {
+          "@path": "$.traits.name"
+        },
+        "age": {
+          "@path": "$.traits.age"
+        },
+        "birthday": {
+          "@path": "$.traits.birthday"
+        },
+        "language": {
+          "@path": "$.traits.language"
+        },
+        "addressCountry": {
+          "@path": "$.traits.address.country"
+        },
+        "addressState": {
+          "@path": "$.traits.address.state"
+        },
+        "addressCity": {
+          "@path": "$.traits.address.city"
+        },
+        "addressPostalCode": {
+          "@path": "$.traits.address.postalCode"
+        },
+        "customerSince": {
+          "@path": "$.traits.customerSince"
+        },
+        "loyaltyStatus": {
+          "@path": "$.traits.loyaltyStatus"
+        },
+        "isNewCustomer": {
+          "@path": "$.traits.isNewCustomer"
+        },
+        "friendbuyAttributes": {
+          "@path": "$.traits.friendbuyAttributes"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPage",
+      "name": "Track Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "name": {
+          "@path": "$.name"
+        },
+        "category": {
+          "@path": "$.category"
+        },
+        "title": {
+          "@path": "$.properties.title"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPurchase",
+      "name": "Track Purchase",
+      "subscribe": "event = \"Order Completed\"",
+      "mapping": {
+        "orderId": {
+          "@path": "$.properties.order_id"
+        },
+        "amount": {
+          "@path": "$.properties.total"
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "coupon": {
+          "@path": "$.properties.coupon"
+        },
+        "attributionId": {
+          "@path": "$.properties.attributionId"
+        },
+        "referralCode": {
+          "@path": "$.properties.referralCode"
+        },
+        "giftCardCodes": {
+          "@path": "$.properties.giftCardCodes"
+        },
+        "products": {
+          "@path": "$.properties.products"
+        },
+        "customerId": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.customerId"
+            },
+            "then": {
+              "@path": "$.properties.customerId"
+            },
+            "else": {
+              "@path": "$.userId"
+            }
+          }
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "email": {
+          "@path": "$.properties.email"
+        },
+        "isNewCustomer": {
+          "@path": "$.properties.isNewCustomer"
+        },
+        "loyaltyStatus": {
+          "@path": "$.properties.loyaltyStatus"
+        },
+        "firstName": {
+          "@path": "$.properties.firstName"
+        },
+        "lastName": {
+          "@path": "$.properties.lastName"
+        },
+        "name": {
+          "@path": "$.properties.name"
+        },
+        "age": {
+          "@path": "$.properties.age"
+        },
+        "birthday": {
+          "@path": "$.properties.birthday"
+        },
+        "friendbuyAttributes": {
+          "@path": "$.properties.friendbuyAttributes"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackSignUp",
+      "name": "Track Sign Up",
+      "subscribe": "event = \"Signed Up\"",
+      "mapping": {
+        "customerId": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.customerId"
+            },
+            "then": {
+              "@path": "$.properties.customerId"
+            },
+            "else": {
+              "@path": "$.userId"
+            }
+          }
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "email": {
+          "@path": "$.properties.email"
+        },
+        "isNewCustomer": {
+          "@path": "$.properties.isNewCustomer"
+        },
+        "loyaltyStatus": {
+          "@path": "$.properties.loyaltyStatus"
+        },
+        "firstName": {
+          "@path": "$.properties.firstName"
+        },
+        "lastName": {
+          "@path": "$.properties.lastName"
+        },
+        "name": {
+          "@path": "$.properties.name"
+        },
+        "age": {
+          "@path": "$.properties.age"
+        },
+        "birthday": {
+          "@path": "$.properties.birthday"
+        },
+        "coupon": {
+          "@path": "$.properties.coupon"
+        },
+        "attributionId": {
+          "@path": "$.properties.attributionId"
+        },
+        "referralCode": {
+          "@path": "$.properties.referralCode"
+        },
+        "friendbuyAttributes": {
+          "@path": "$.properties.friendbuyAttributes"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/friendbuy/metadata.json
+++ b/packages/browser-destinations/destinations/friendbuy/metadata.json
@@ -10,8 +10,10 @@
         "description": "Find your Friendbuy Merchant ID by logging in to your [Friendbuy account](https://retailer.friendbuy.io/) and going to Developer Center > Friendbuy Code.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "customerId": {
           "label": "Customer ID",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -94,7 +100,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "firstName": {
           "label": "First Name",
@@ -117,7 +125,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "lastName": {
           "label": "Last Name",
@@ -140,7 +150,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "name": {
           "label": "Name",
@@ -163,7 +175,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "age": {
           "label": "Age",
@@ -186,7 +200,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "birthday": {
           "label": "Birthday",
@@ -209,7 +225,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "language": {
           "label": "Language",
@@ -232,7 +250,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "addressCountry": {
           "label": "Country",
@@ -255,7 +275,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "addressState": {
           "label": "State",
@@ -278,7 +300,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "addressCity": {
           "label": "City",
@@ -301,7 +325,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "addressPostalCode": {
           "label": "State",
@@ -324,7 +350,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "customerSince": {
           "label": "Customer Since",
@@ -347,7 +375,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "loyaltyStatus": {
           "label": "Loyalty Status",
@@ -370,7 +400,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "isNewCustomer": {
           "label": "New Customer Flag",
@@ -393,7 +425,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "friendbuyAttributes": {
           "label": "Custom Attributes",
@@ -416,7 +450,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -428,7 +464,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "orderId": {
           "label": "Order ID",
@@ -451,7 +487,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "amount": {
           "label": "Purchase Amount",
@@ -474,7 +512,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -497,7 +537,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -520,7 +562,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "attributionId": {
           "label": "Friendbuy Attribution ID",
@@ -543,7 +587,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "referralCode": {
           "label": "Friendbuy Referral ID",
@@ -566,7 +612,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "giftCardCodes": {
           "label": "Gift Card Codes",
@@ -589,7 +637,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "products": {
           "label": "Products",
@@ -623,7 +673,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Product Name",
@@ -643,7 +695,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity (default 1)",
@@ -663,7 +717,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -683,7 +739,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "description": {
               "label": "Product Description",
@@ -703,7 +761,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "category": {
               "label": "Product Category",
@@ -723,7 +783,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "url": {
               "label": "Product URL",
@@ -743,7 +805,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "image_url": {
               "label": "Product Image URL",
@@ -763,7 +827,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -773,7 +839,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "customerId": {
           "label": "Customer ID",
@@ -806,7 +874,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -829,7 +899,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -852,7 +924,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "isNewCustomer": {
           "label": "New Customer Flag",
@@ -875,7 +949,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "loyaltyStatus": {
           "label": "Loyalty Program Status",
@@ -898,7 +974,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "firstName": {
           "label": "First Name",
@@ -921,7 +999,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "lastName": {
           "label": "Last Name",
@@ -944,7 +1024,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "name": {
           "label": "Name",
@@ -967,7 +1049,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "age": {
           "label": "Age",
@@ -990,7 +1074,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "birthday": {
           "label": "Birthday",
@@ -1013,7 +1099,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "friendbuyAttributes": {
           "label": "Custom Attributes",
@@ -1036,7 +1124,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1048,7 +1138,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "customerId": {
           "label": "Customer ID",
@@ -1081,7 +1171,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -1104,7 +1196,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -1127,7 +1221,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "isNewCustomer": {
           "label": "New Customer Flag",
@@ -1150,7 +1246,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "loyaltyStatus": {
           "label": "Loyalty Program Status",
@@ -1173,7 +1271,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "firstName": {
           "label": "First Name",
@@ -1196,7 +1296,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "lastName": {
           "label": "Last Name",
@@ -1219,7 +1321,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "name": {
           "label": "Name",
@@ -1242,7 +1346,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "age": {
           "label": "Age",
@@ -1265,7 +1371,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "birthday": {
           "label": "Birthday",
@@ -1288,7 +1396,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon Code",
@@ -1311,7 +1421,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "attributionId": {
           "label": "Friendbuy Attribution ID",
@@ -1334,7 +1446,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "referralCode": {
           "label": "Friendbuy Referral ID",
@@ -1357,7 +1471,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "friendbuyAttributes": {
           "label": "Custom Attributes",
@@ -1380,7 +1496,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1392,7 +1510,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Page Name",
@@ -1415,7 +1533,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "category": {
           "label": "Page Category",
@@ -1438,7 +1558,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "title": {
           "label": "Page Title",
@@ -1461,7 +1583,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1473,7 +1597,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventType": {
           "label": "Event Type",
@@ -1496,7 +1620,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "eventProperties": {
           "label": "Event Properties",
@@ -1519,7 +1645,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "deduplicationId": {
           "label": "Event ID",
@@ -1542,7 +1670,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "customerId": {
           "label": "Customer ID",
@@ -1575,7 +1705,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -1598,7 +1730,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -1621,7 +1755,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/fullsession/metadata.json
+++ b/packages/browser-destinations/destinations/fullsession/metadata.json
@@ -10,8 +10,10 @@
         "description": "Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Traits",
@@ -94,7 +100,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -106,7 +114,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event Name",
@@ -129,7 +137,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -152,7 +162,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -164,7 +176,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "properties": {
           "label": "Page Properties",
@@ -187,7 +199,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/fullsession/metadata.json
+++ b/packages/browser-destinations/destinations/fullsession/metadata.json
@@ -1,248 +1,202 @@
 {
+  "slug": "actions-fullsession",
   "name": "FullSession",
-  "basicOptions": ["customerId"],
-  "options": {
-    "customerId": {
-      "tags": [],
-      "default": "",
-      "description": "Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Customer ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The customerId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "customerId": {
+        "label": "Customer ID",
+        "description": "Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Identify users and set their properties in FullSession.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The user's unique identifier.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The user's unique identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous identifier when no user ID is available.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous identifier when no user ID is available.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "User Traits",
           "description": "User traits and properties to be sent to FullSession.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Traits",
-                "description": "User traits and properties to be sent to FullSession.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "visitPage",
-      "name": "Page View",
-      "description": "Track page views and set page-specific attributes in FullSession for navigation analysis.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Page Properties",
-          "description": "Properties and metadata associated with the page being viewed",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Page Properties",
-                "description": "Properties and metadata associated with the page being viewed",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "recordEvent",
-      "name": "Track Event",
+    "recordEvent": {
+      "title": "Track Event",
       "description": "Track custom events and user interactions in FullSession for behavioral analysis.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event Name",
           "description": "The name of the event being tracked.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event Name",
-                "description": "The name of the event being tracked.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Additional properties and metadata associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Additional properties and metadata associated with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "visitPage": {
+      "title": "Page View",
+      "description": "Track page views and set page-specific attributes in FullSession for navigation analysis.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "properties": {
+          "label": "Page Properties",
+          "description": "Properties and metadata associated with the page being viewed",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -255,11 +209,12 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "recordEvent",
       "name": "Record Event",
+      "type": "automatic",
+      "partnerAction": "recordEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -269,18 +224,19 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "visitPage",
       "name": "Visit Page",
+      "type": "automatic",
+      "partnerAction": "visitPage",
       "subscribe": "type = \"page\"",
       "mapping": {
         "properties": {
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/fullsession/metadata.json
+++ b/packages/browser-destinations/destinations/fullsession/metadata.json
@@ -1,0 +1,286 @@
+{
+  "name": "FullSession",
+  "basicOptions": ["customerId"],
+  "options": {
+    "customerId": {
+      "tags": [],
+      "default": "",
+      "description": "Your FullSession Customer ID. You can find this in your FullSession dashboard under Settings .",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Customer ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The customerId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Identify users and set their properties in FullSession.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The user's unique identifier.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The user's unique identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous identifier when no user ID is available.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous identifier when no user ID is available.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Traits",
+          "description": "User traits and properties to be sent to FullSession.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Traits",
+                "description": "User traits and properties to be sent to FullSession.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "visitPage",
+      "name": "Page View",
+      "description": "Track page views and set page-specific attributes in FullSession for navigation analysis.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Page Properties",
+          "description": "Properties and metadata associated with the page being viewed",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Page Properties",
+                "description": "Properties and metadata associated with the page being viewed",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "recordEvent",
+      "name": "Track Event",
+      "description": "Track custom events and user interactions in FullSession for behavioral analysis.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event being tracked.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event Name",
+                "description": "The name of the event being tracked.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Additional properties and metadata associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Additional properties and metadata associated with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "recordEvent",
+      "name": "Record Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "visitPage",
+      "name": "Visit Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/fullstory/metadata.json
+++ b/packages/browser-destinations/destinations/fullstory/metadata.json
@@ -1,582 +1,451 @@
 {
+  "slug": "actions-fullstory",
   "name": "Fullstory (Actions)",
-  "basicOptions": ["orgId", "debug", "recordOnlyThisIFrame", "host", "appHost", "script"],
-  "options": {
-    "orgId": {
-      "tags": [],
-      "default": "",
-      "description": "The organization ID for FullStory.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "FS Org",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The orgId property is required."]],
-      "uIMetadata": null
-    },
-    "debug": {
-      "tags": [],
-      "default": false,
-      "description": "Enables FullStory debug mode.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Debug mode",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "recordOnlyThisIFrame": {
-      "tags": [],
-      "default": false,
-      "description": "Enables FullStory inside an iframe.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Capture only this iFrame",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "host": {
-      "tags": [],
-      "default": "",
-      "description": "The domain of the web capture server host. Can be set to direct captured events to a [Fullstory Custom Endpoint](https://help.fullstory.com/hc/en-us/articles/18612999473175-How-to-send-captured-traffic-to-your-First-Party-Domain-using-Custom-Endpoints) or a proxy that you host. Defaults to 'fullstory.com'.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Host",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "appHost": {
-      "tags": [],
-      "default": "",
-      "description": "The App Host is used to define the specific base URL for the Fullstory application where session URLs are generated and displayed. Leave blank if using the default value for \"Host\"",
-      "encrypt": false,
-      "hidden": false,
-      "label": "App Host",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "script": {
-      "tags": [],
-      "default": "",
-      "description": "Optionally specify a custom FullStory script URL. Useful if you are using a proxy. The default is 'edge.fullstory.com/s/fs.js'.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Custom Script URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "orgId": {
+        "label": "FS Org",
+        "description": "The organization ID for FullStory.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "debug": {
+        "label": "Debug mode",
+        "description": "Enables FullStory debug mode.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "recordOnlyThisIFrame": {
+        "label": "Capture only this iFrame",
+        "description": "Enables FullStory inside an iframe.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "host": {
+        "label": "Host",
+        "description": "The domain of the web capture server host. Can be set to direct captured events to a [Fullstory Custom Endpoint](https://help.fullstory.com/hc/en-us/articles/18612999473175-How-to-send-captured-traffic-to-your-First-Party-Domain-using-Custom-Endpoints) or a proxy that you host. Defaults to 'fullstory.com'.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "appHost": {
+        "label": "App Host",
+        "description": "The App Host is used to define the specific base URL for the Fullstory application where session URLs are generated and displayed. Leave blank if using the default value for \"Host\"",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "script": {
+        "label": "Custom Script URL",
+        "description": "Optionally specify a custom FullStory script URL. Useful if you are using a proxy. The default is 'edge.fullstory.com/s/fs.js'.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Name",
+          "description": "The name of the event.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "trackEventV2": {
+      "title": "Track Event V2",
+      "description": "Track events",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Name",
+          "description": "The name of the event.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Sets user identity variables",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The user's id",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The user's id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous id",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "displayName",
-          "type": "string",
+        "displayName": {
           "label": "Display Name",
           "description": "The user's display name",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "displayName": {
-                "title": "Display Name",
-                "description": "The user's display name",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.email"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "Traits",
           "description": "The Segment traits to be forwarded to FullStory",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to FullStory",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "identifyUserV2",
-      "name": "Identify User V2",
+    "identifyUserV2": {
+      "title": "Identify User V2",
       "description": "Sets user identity properties",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The user's id",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The user's id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The user's anonymous id",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "displayName",
-          "type": "string",
+        "displayName": {
           "label": "Display Name",
           "description": "The user's display name",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "displayName": {
-                "title": "Display Name",
-                "description": "The user's display name",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The user's email",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.email"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "Traits",
           "description": "The Segment traits to be forwarded to FullStory",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to FullStory",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Track events",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Name",
-          "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Properties",
-          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEventV2",
-      "name": "Track Event V2",
-      "description": "Track events",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Name",
-          "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Properties",
-          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "viewedPage",
-      "name": "Viewed Page",
+    "viewedPage": {
+      "title": "Viewed Page",
       "description": "Sets page properties events",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "pageName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "pageName": {
           "label": "Page Name",
           "description": "The name of the page that was viewed.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.category"
@@ -589,74 +458,62 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "pageName": {
-                "title": "Page Name",
-                "description": "The name of the page that was viewed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "The properties of the page that was viewed.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "The properties of the page that was viewed.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "viewedPageV2",
-      "name": "Viewed Page V2",
+    "viewedPageV2": {
+      "title": "Viewed Page V2",
       "description": "Sets page properties",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "pageName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "pageName": {
           "label": "Page Name",
           "description": "The name of the page that was viewed.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.category"
@@ -669,65 +526,64 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "pageName": {
-                "title": "Page Name",
-                "description": "The name of the page that was viewed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "The properties of the page that was viewed.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "The properties of the page that was viewed.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUserV2",
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEventV2",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUserV2",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -746,25 +602,12 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackEventV2",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "name": {
-          "@path": "$.event"
-        },
-        "properties": {
-          "@path": "$.properties"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "viewedPageV2",
       "name": "Viewed Page",
+      "type": "automatic",
+      "partnerAction": "viewedPageV2",
       "subscribe": "type = \"page\"",
       "mapping": {
         "pageName": {
@@ -784,7 +627,7 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/fullstory/metadata.json
+++ b/packages/browser-destinations/destinations/fullstory/metadata.json
@@ -10,48 +10,60 @@
         "description": "The organization ID for FullStory.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "debug": {
         "label": "Debug mode",
         "description": "Enables FullStory debug mode.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "recordOnlyThisIFrame": {
         "label": "Capture only this iFrame",
         "description": "Enables FullStory inside an iframe.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "host": {
         "label": "Host",
         "description": "The domain of the web capture server host. Can be set to direct captured events to a [Fullstory Custom Endpoint](https://help.fullstory.com/hc/en-us/articles/18612999473175-How-to-send-captured-traffic-to-your-First-Party-Domain-using-Custom-Endpoints) or a proxy that you host. Defaults to 'fullstory.com'.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "appHost": {
         "label": "App Host",
         "description": "The App Host is used to define the specific base URL for the Fullstory application where session URLs are generated and displayed. Leave blank if using the default value for \"Host\"",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "script": {
         "label": "Custom Script URL",
         "description": "Optionally specify a custom FullStory script URL. Useful if you are using a proxy. The default is 'edge.fullstory.com/s/fs.js'.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -65,7 +77,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -88,7 +100,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -111,7 +125,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -123,7 +139,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -146,7 +162,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -169,7 +187,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -181,7 +201,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -204,7 +224,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -227,7 +249,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "displayName": {
           "label": "Display Name",
@@ -250,7 +274,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -273,7 +299,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -296,7 +324,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -308,7 +338,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -331,7 +361,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -354,7 +386,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "displayName": {
           "label": "Display Name",
@@ -377,7 +411,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -400,7 +436,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -423,7 +461,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -435,7 +475,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "pageName": {
           "label": "Page Name",
@@ -468,7 +508,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -491,7 +533,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -503,7 +547,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "pageName": {
           "label": "Page Name",
@@ -536,7 +580,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -559,7 +605,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/fullstory/metadata.json
+++ b/packages/browser-destinations/destinations/fullstory/metadata.json
@@ -1,0 +1,790 @@
+{
+  "name": "Fullstory (Actions)",
+  "basicOptions": ["orgId", "debug", "recordOnlyThisIFrame", "host", "appHost", "script"],
+  "options": {
+    "orgId": {
+      "tags": [],
+      "default": "",
+      "description": "The organization ID for FullStory.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "FS Org",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The orgId property is required."]],
+      "uIMetadata": null
+    },
+    "debug": {
+      "tags": [],
+      "default": false,
+      "description": "Enables FullStory debug mode.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Debug mode",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "recordOnlyThisIFrame": {
+      "tags": [],
+      "default": false,
+      "description": "Enables FullStory inside an iframe.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Capture only this iFrame",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "host": {
+      "tags": [],
+      "default": "",
+      "description": "The domain of the web capture server host. Can be set to direct captured events to a [Fullstory Custom Endpoint](https://help.fullstory.com/hc/en-us/articles/18612999473175-How-to-send-captured-traffic-to-your-First-Party-Domain-using-Custom-Endpoints) or a proxy that you host. Defaults to 'fullstory.com'.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Host",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "appHost": {
+      "tags": [],
+      "default": "",
+      "description": "The App Host is used to define the specific base URL for the Fullstory application where session URLs are generated and displayed. Leave blank if using the default value for \"Host\"",
+      "encrypt": false,
+      "hidden": false,
+      "label": "App Host",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "script": {
+      "tags": [],
+      "default": "",
+      "description": "Optionally specify a custom FullStory script URL. Useful if you are using a proxy. The default is 'edge.fullstory.com/s/fs.js'.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Custom Script URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sets user identity variables",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The user's id",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The user's id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "displayName",
+          "type": "string",
+          "label": "Display Name",
+          "description": "The user's display name",
+          "defaultValue": {
+            "@path": "$.traits.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "displayName": {
+                "title": "Display Name",
+                "description": "The user's display name",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to FullStory",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to FullStory",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identifyUserV2",
+      "name": "Identify User V2",
+      "description": "Sets user identity properties",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The user's id",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The user's id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "displayName",
+          "type": "string",
+          "label": "Display Name",
+          "description": "The user's display name",
+          "defaultValue": {
+            "@path": "$.traits.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "displayName": {
+                "title": "Display Name",
+                "description": "The user's display name",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to FullStory",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to FullStory",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEventV2",
+      "name": "Track Event V2",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing additional information about the event that will be indexed by FullStory.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewedPage",
+      "name": "Viewed Page",
+      "description": "Sets page properties events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "pageName",
+          "type": "string",
+          "label": "Page Name",
+          "description": "The name of the page that was viewed.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.category"
+              },
+              "then": {
+                "@path": "$.category"
+              },
+              "else": {
+                "@path": "$.name"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pageName": {
+                "title": "Page Name",
+                "description": "The name of the page that was viewed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "The properties of the page that was viewed.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "The properties of the page that was viewed.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewedPageV2",
+      "name": "Viewed Page V2",
+      "description": "Sets page properties",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "pageName",
+          "type": "string",
+          "label": "Page Name",
+          "description": "The name of the page that was viewed.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.category"
+              },
+              "then": {
+                "@path": "$.category"
+              },
+              "else": {
+                "@path": "$.name"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "pageName": {
+                "title": "Page Name",
+                "description": "The name of the page that was viewed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "The properties of the page that was viewed.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "The properties of the page that was viewed.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUserV2",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "displayName": {
+          "@path": "$.traits.name"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEventV2",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "viewedPageV2",
+      "name": "Viewed Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "pageName": {
+          "@if": {
+            "exists": {
+              "@path": "$.category"
+            },
+            "then": {
+              "@path": "$.category"
+            },
+            "else": {
+              "@path": "$.name"
+            }
+          }
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
@@ -1,0 +1,6868 @@
+{
+  "name": "Google Analytics 4 Web",
+  "basicOptions": [
+    "measurementID",
+    "allowGoogleSignals",
+    "allowAdPersonalizationSignals",
+    "cookieDomain",
+    "cookieExpirationInSeconds",
+    "cookieFlags",
+    "cookiePath",
+    "cookiePrefix",
+    "cookieUpdate",
+    "enableConsentMode",
+    "defaultAdsStorageConsentState",
+    "defaultAnalyticsStorageConsentState",
+    "adUserDataConsentState",
+    "adPersonalizationConsentState",
+    "waitTimeToUpdateConsentStage",
+    "pageView",
+    "domain"
+  ],
+  "options": {
+    "measurementID": {
+      "tags": [],
+      "default": "",
+      "description": "The measurement ID associated with the web stream. Found in the Google Analytics UI under: Admin > Data Streams > Web > Measurement ID.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Measurement ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The measurementID property is required."]],
+      "uIMetadata": null
+    },
+    "allowGoogleSignals": {
+      "tags": [],
+      "default": true,
+      "description": "Set to false to disable all advertising features. Set to true by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Allow Google Signals",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "allowAdPersonalizationSignals": {
+      "tags": [],
+      "default": true,
+      "description": "Set to false to disable all advertising features. Set to true by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Allow Ad Personalization Signals",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookieDomain": {
+      "tags": [],
+      "default": "auto",
+      "description": "Specifies the domain used to store the analytics cookie. Set to “auto” by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Domain",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookieExpirationInSeconds": {
+      "tags": [],
+      "default": 63072000,
+      "description": "Every time a hit is sent to GA4, the analytics cookie expiration time is updated to be the current time plus the value of this field. The default value is two years (63072000 seconds). Please input the expiration value in seconds. More information in [Google Documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Expiration In Seconds",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookieFlags": {
+      "tags": [],
+      "default": "",
+      "description": "Appends additional flags to the analytics cookie.  See [write a new cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie) for some examples of flags to set.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Flag",
+      "private": false,
+      "scope": "event_destination",
+      "type": "array",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookiePath": {
+      "tags": [],
+      "default": "/",
+      "description": "Specifies the subpath used to store the analytics cookie. We recommend to add a forward slash, / , in the first field as it is the Default Value for GA4.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Path",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookiePrefix": {
+      "tags": [],
+      "default": "",
+      "description": "Specifies a prefix to prepend to the analytics cookie name.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Prefix",
+      "private": false,
+      "scope": "event_destination",
+      "type": "array",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookieUpdate": {
+      "tags": [],
+      "default": true,
+      "description": "Set to false to not update  cookies on each page load. This has the effect of cookie expiration being relative to the first time a user visited. Set to true by default so update cookies on each page load.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Update",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "enableConsentMode": {
+      "tags": [],
+      "default": false,
+      "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Consent Mode",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "defaultAdsStorageConsentState": {
+      "tags": [],
+      "default": "granted",
+      "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Default Ads Storage Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "defaultAnalyticsStorageConsentState": {
+      "tags": [],
+      "default": "granted",
+      "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Default Analytics Storage Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "adUserDataConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Ad User Data Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "adPersonalizationConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Ad Personalization Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "waitTimeToUpdateConsentStage": {
+      "tags": [],
+      "default": 0,
+      "description": "If your CMP loads asynchronously, it might not always run before the Google tag. To handle such situations, specify a millisecond value to control how long to wait before the consent state update is sent. Please input the wait_for_update in milliseconds.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Wait Time to Update Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "pageView": {
+      "tags": [],
+      "default": true,
+      "description": "Set to false to prevent the default snippet from sending page views. Enabled by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Page Views",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "domain": {
+      "tags": [],
+      "default": "www.googletagmanager.com",
+      "description": "A custom domain to load the Google Analytics script from. For more information see [Google's Documentation](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtag&option=cdn).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Google Custom Domain",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "addPaymentInfo",
+      "name": "Add Payment Info",
+      "description": "Send event when a user submits their payment information",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Payment Info Entered\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "Coupon code used for a purchase.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "payment_type",
+          "type": "string",
+          "label": "Payment Type",
+          "description": "The chosen method of payment.",
+          "defaultValue": {
+            "@path": "$.properties.payment_method"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "payment_type": {
+                "title": "Payment Type",
+                "description": "The chosen method of payment.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "addToCart",
+      "name": "Add to Cart",
+      "description": "This event signifies that an item was added to a cart for purchase.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Product Added\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "addToWishlist",
+      "name": "Add to Wishlist",
+      "description": "The event signifies that an item was added to a wishlist. Use this event to identify popular gift items in your app.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Product Added to Wishlist\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "beginCheckout",
+      "name": "Begin Checkout",
+      "description": "This event signifies that a user has begun a checkout.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Checkout Started\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "defaultValue": {
+            "@path": "$.properties.coupon"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "Coupon code used for a purchase.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "customEvent",
+      "name": "Custom Event",
+      "description": "Send any custom event",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event Name",
+                "description": "The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "lowercase",
+          "type": "boolean",
+          "label": "Lowercase Event Name",
+          "description": "If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+          "defaultValue": false,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "lowercase": {
+                "title": "Lowercase Event Name",
+                "description": "If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "generateLead",
+      "name": "Generate Lead",
+      "description": "Log this event when a lead has been generated to understand the efficacy of your re-engagement campaigns.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "login",
+      "name": "Login",
+      "description": "Send event when a user logs in",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Signed In\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "method",
+          "type": "string",
+          "label": "Method",
+          "description": "The method used to login.",
+          "defaultValue": {
+            "@path": "$.properties.method"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "method": {
+                "title": "Method",
+                "description": "The method used to login.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "purchase",
+      "name": "Purchase",
+      "description": "This event signifies when one or more items is purchased by a user.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "defaultValue": {
+            "@path": "$.properties.coupon"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "Coupon code used for a purchase.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": ["currency"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "transaction_id",
+          "type": "string",
+          "label": "Order Id",
+          "description": "The unique identifier of a transaction.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "transaction_id": {
+                "title": "Order Id",
+                "description": "The unique identifier of a transaction.",
+                "type": "string"
+              }
+            },
+            "required": ["transaction_id"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "shipping",
+          "type": "number",
+          "label": "Shipping",
+          "description": "Shipping cost associated with the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.shipping"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "shipping": {
+                "title": "Shipping",
+                "description": "Shipping cost associated with the transaction.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "tax",
+          "type": "number",
+          "label": "Tax",
+          "description": "Total tax associated with the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.tax"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tax": {
+                "title": "Tax",
+                "description": "Total tax associated with the transaction.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.total"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "refund",
+      "name": "Refund",
+      "description": "This event signifies when one or more items is refunded to a user.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Order Refunded\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "transaction_id",
+          "type": "string",
+          "label": "Order Id",
+          "description": "The unique identifier of a transaction.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "transaction_id": {
+                "title": "Order Id",
+                "description": "The unique identifier of a transaction.",
+                "type": "string"
+              }
+            },
+            "required": ["transaction_id"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.total"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "affiliation",
+          "type": "string",
+          "label": "Affiliation",
+          "description": "Store or affiliation from which this transaction occurred (e.g. Google Store).",
+          "defaultValue": {
+            "@path": "$.properties.affiliation"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "affiliation": {
+                "title": "Affiliation",
+                "description": "Store or affiliation from which this transaction occurred (e.g. Google Store).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "coupon",
+          "type": "string",
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "coupon": {
+                "title": "Coupon",
+                "description": "Coupon code used for a purchase.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "shipping",
+          "type": "number",
+          "label": "Shipping",
+          "description": "Shipping cost associated with the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.shipping"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "shipping": {
+                "title": "Shipping",
+                "description": "Shipping cost associated with the transaction.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "tax",
+          "type": "number",
+          "label": "Tax",
+          "description": "Total tax associated with the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.tax"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tax": {
+                "title": "Tax",
+                "description": "Total tax associated with the transaction.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "removeFromCart",
+      "name": "Remove from Cart",
+      "description": "This event signifies that an item was removed from a cart.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Product Removed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "search",
+      "name": "Search",
+      "description": "The term that was searched for.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Products Searched\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "search_term",
+          "type": "string",
+          "label": "Search Term",
+          "description": "The term that was searched for.",
+          "defaultValue": {
+            "@path": "$.properties.query"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "search_term": {
+                "title": "Search Term",
+                "description": "The term that was searched for.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "selectItem",
+      "name": "Select Item",
+      "description": "This event signifies an item was selected from a list.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Product Clicked\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "item_list_name",
+          "type": "string",
+          "label": "Item List Name",
+          "description": "The name of the list in which the item was presented to the user.",
+          "defaultValue": {
+            "@path": "$.properties.item_list_name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "item_list_name": {
+                "title": "Item List Name",
+                "description": "The name of the list in which the item was presented to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "item_list_id",
+          "type": "string",
+          "label": "Item List Id",
+          "description": "The ID of the list in which the item was presented to the user.",
+          "defaultValue": {
+            "@path": "$.properties.item_list_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "item_list_id": {
+                "title": "Item List Id",
+                "description": "The ID of the list in which the item was presented to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "selectPromotion",
+      "name": "Select Promotion",
+      "description": "This event signifies a promotion was selected from a list.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Promotion Clicked\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "creative_name",
+          "type": "string",
+          "label": "Creative Name",
+          "description": "The name of the promotional creative.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "creative_name": {
+                "title": "Creative Name",
+                "description": "The name of the promotional creative.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "creative_slot",
+          "type": "string",
+          "label": "Creative Slot",
+          "description": "The name of the promotional creative slot associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.creative"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "creative_slot": {
+                "title": "Creative Slot",
+                "description": "The name of the promotional creative slot associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "location_id",
+          "type": "string",
+          "label": "Location ID",
+          "description": "The ID of the location.",
+          "defaultValue": {
+            "@path": "$.properties.position"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "location_id": {
+                "title": "Location ID",
+                "description": "The ID of the location.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "promotion_id",
+          "type": "string",
+          "label": "Promotion ID",
+          "description": "The ID of the promotion associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.promotion_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "promotion_id": {
+                "title": "Promotion ID",
+                "description": "The ID of the promotion associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "promotion_name",
+          "type": "string",
+          "label": "Promotion Name",
+          "description": "The name of the promotion associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "promotion_name": {
+                "title": "Promotion Name",
+                "description": "The name of the promotion associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    },
+                    "creative_name": {
+                      "title": "Creative Name",
+                      "description": "The name of the promotional creative.",
+                      "type": "string"
+                    },
+                    "creative_slot": {
+                      "title": "Creative Slot",
+                      "description": "The name of the promotional creative slot associated with the event.",
+                      "type": "string"
+                    },
+                    "promotion_name": {
+                      "title": "Promotion Name",
+                      "description": "The name of the promotion associated with the event.",
+                      "type": "string"
+                    },
+                    "promotion_id": {
+                      "title": "Promotion ID",
+                      "description": "The ID of the promotion associated with the event.",
+                      "type": "string"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "setConfigurationFields",
+      "name": "Set Configuration Fields",
+      "description": "Set custom values for the GA4 configuration fields.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "ads_storage_consent_state",
+          "type": "string",
+          "label": "Ads Storage Consent State",
+          "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Granted",
+              "value": "granted"
+            },
+            {
+              "label": "Denied",
+              "value": "denied"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "ads_storage_consent_state": {
+                "title": "Ads Storage Consent State",
+                "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+                "type": "string",
+                "enum": ["granted", "denied"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "analytics_storage_consent_state",
+          "type": "string",
+          "label": "Analytics Storage Consent State",
+          "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Granted",
+              "value": "granted"
+            },
+            {
+              "label": "Denied",
+              "value": "denied"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "analytics_storage_consent_state": {
+                "title": "Analytics Storage Consent State",
+                "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+                "type": "string",
+                "enum": ["granted", "denied"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "ad_user_data_consent_state",
+          "type": "string",
+          "label": "Ad User Data Consent State",
+          "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Granted",
+              "value": "granted"
+            },
+            {
+              "label": "Denied",
+              "value": "denied"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "ad_user_data_consent_state": {
+                "title": "Ad User Data Consent State",
+                "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+                "type": "string",
+                "enum": ["granted", "denied"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "ad_personalization_consent_state",
+          "type": "string",
+          "label": "Ad Personalization Consent State",
+          "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Granted",
+              "value": "granted"
+            },
+            {
+              "label": "Denied",
+              "value": "denied"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "ad_personalization_consent_state": {
+                "title": "Ad Personalization Consent State",
+                "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+                "type": "string",
+                "enum": ["granted", "denied"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_content",
+          "type": "string",
+          "label": "Campaign Content",
+          "description": "Use campaign content to differentiate ads or links that point to the same URL. Setting this value will override the utm_content query parameter.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_content": {
+                "title": "Campaign Content",
+                "description": "Use campaign content to differentiate ads or links that point to the same URL. Setting this value will override the utm_content query parameter.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_id",
+          "type": "string",
+          "label": "Campaign ID",
+          "description": "Use campaign ID to identify a specific campaign. Setting this value will override the utm_id query parameter. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_id": {
+                "title": "Campaign ID",
+                "description": "Use campaign ID to identify a specific campaign. Setting this value will override the utm_id query parameter. ",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_medium",
+          "type": "string",
+          "label": "Campaign Medium",
+          "description": "Use campaign medium to identify a medium such as email or cost-per-click. Setting this value will override the utm_medium query parameter.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_medium": {
+                "title": "Campaign Medium",
+                "description": "Use campaign medium to identify a medium such as email or cost-per-click. Setting this value will override the utm_medium query parameter.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_name",
+          "type": "string",
+          "label": "Campaign Name",
+          "description": "Use campaign name to identify a specific product promotion or strategic campaign. Setting this value will override the utm_name query parameter.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_name": {
+                "title": "Campaign Name",
+                "description": "Use campaign name to identify a specific product promotion or strategic campaign. Setting this value will override the utm_name query parameter.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_source",
+          "type": "string",
+          "label": "Campaign Source",
+          "description": "Use campaign source to identify a search engine, newsletter name, or other source. Setting this value will override the utm_source query parameter.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_source": {
+                "title": "Campaign Source",
+                "description": "Use campaign source to identify a search engine, newsletter name, or other source. Setting this value will override the utm_source query parameter.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "campaign_term",
+          "type": "string",
+          "label": "Campaign Term",
+          "description": "Use campaign term to note the keywords for this ad. Setting this value will override the utm_term query parameter.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "campaign_term": {
+                "title": "Campaign Term",
+                "description": "Use campaign term to note the keywords for this ad. Setting this value will override the utm_term query parameter.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_group",
+          "type": "string",
+          "label": "Content Group",
+          "description": "Categorize pages and screens into custom buckets so you can see metrics for related groups of information. More information in [Google documentation](https://support.google.com/analytics/answer/11523339).",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_group": {
+                "title": "Content Group",
+                "description": "Categorize pages and screens into custom buckets so you can see metrics for related groups of information. More information in [Google documentation](https://support.google.com/analytics/answer/11523339).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "language",
+          "type": "string",
+          "label": "Language",
+          "description": "The language preference of the user. If not set, defaults to the user's navigator.language value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "language": {
+                "title": "Language",
+                "description": "The language preference of the user. If not set, defaults to the user's navigator.language value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "page_location",
+          "type": "string",
+          "label": "Page Location",
+          "description": "The full URL of the page. If not set, defaults to the user's document.location value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "page_location": {
+                "title": "Page Location",
+                "description": "The full URL of the page. If not set, defaults to the user's document.location value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "page_referrer",
+          "type": "string",
+          "label": "Page Referrer",
+          "description": "The referral source that brought traffic to a page. This value is also used to compute the traffic source. The format of this value is a URL. If not set, defaults to the user's document.referrer value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "page_referrer": {
+                "title": "Page Referrer",
+                "description": "The referral source that brought traffic to a page. This value is also used to compute the traffic source. The format of this value is a URL. If not set, defaults to the user's document.referrer value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "page_title",
+          "type": "string",
+          "label": "Page Title",
+          "description": "The title of the page or document. If not set, defaults to the user's document.title value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "page_title": {
+                "title": "Page Title",
+                "description": "The title of the page or document. If not set, defaults to the user's document.title value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "screen_resolution",
+          "type": "string",
+          "label": "Screen Resolution",
+          "description": "The resolution of the screen. Format should be two positive integers separated by an x (i.e. 800x600). If not set, calculated from the user's window.screen value.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "screen_resolution": {
+                "title": "Screen Resolution",
+                "description": "The resolution of the screen. Format should be two positive integers separated by an x (i.e. 800x600). If not set, calculated from the user's window.screen value.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_page_view",
+          "type": "boolean",
+          "label": "Send Page Views",
+          "description": "Selection overrides toggled value set within Settings",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "True",
+              "value": "true"
+            },
+            {
+              "label": "False",
+              "value": "false"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_page_view": {
+                "title": "Send Page Views",
+                "description": "Selection overrides toggled value set within Settings",
+                "type": "boolean",
+                "enum": ["true", "false"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "signUp",
+      "name": "Sign Up",
+      "description": "The method used for sign up.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Signed Up\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "method",
+          "type": "string",
+          "label": "Method",
+          "description": "The method used to login.",
+          "defaultValue": {
+            "@path": "$.properties.method"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "method": {
+                "title": "Method",
+                "description": "The method used to login.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewCart",
+      "name": "View Cart",
+      "description": "This event signifies that a user viewed their cart.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Cart Viewed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewItem",
+      "name": "View Item",
+      "description": "This event signifies that some content was shown to the user. Use this event to discover the most popular items viewed.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event =  \"Product Viewed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "defaultValue": {
+            "@path": "$.properties.value"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "The monetary value of the event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewItemList",
+      "name": "View Item List",
+      "description": "Log this event when the user has been presented with a list of items of a certain category.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Product List Viewed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "item_list_id",
+          "type": "string",
+          "label": "Item List Id",
+          "description": "The ID of the list in which the item was presented to the user.",
+          "defaultValue": {
+            "@path": "$.properties.item_list_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "item_list_id": {
+                "title": "Item List Id",
+                "description": "The ID of the list in which the item was presented to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "item_list_name",
+          "type": "string",
+          "label": "Item List Name",
+          "description": "The name of the list in which the item was presented to the user.",
+          "defaultValue": {
+            "@path": "$.properties.item_list_name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "item_list_name": {
+                "title": "Item List Name",
+                "description": "The name of the list in which the item was presented to the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "viewPromotion",
+      "name": "View Promotion",
+      "description": "This event signifies a promotion was viewed from a list.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Promotion Viewed\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "creative_name",
+          "type": "string",
+          "label": "Creative Name",
+          "description": "The name of the promotional creative.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "creative_name": {
+                "title": "Creative Name",
+                "description": "The name of the promotional creative.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "creative_slot",
+          "type": "string",
+          "label": "Creative Slot",
+          "description": "The name of the promotional creative slot associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.creative"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "creative_slot": {
+                "title": "Creative Slot",
+                "description": "The name of the promotional creative slot associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "location_id",
+          "type": "string",
+          "label": "Location ID",
+          "description": "The ID of the location.",
+          "defaultValue": {
+            "@path": "$.properties.position"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "location_id": {
+                "title": "Location ID",
+                "description": "The ID of the location.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "promotion_id",
+          "type": "string",
+          "label": "Promotion ID",
+          "description": "The ID of the promotion associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.promotion_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "promotion_id": {
+                "title": "Promotion ID",
+                "description": "The ID of the promotion associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "promotion_name",
+          "type": "string",
+          "label": "Promotion Name",
+          "description": "The name of the promotion associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "promotion_name": {
+                "title": "Promotion Name",
+                "description": "The name of the promotion associated with the event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "items",
+          "type": "object",
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "required": true,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "items": {
+                "title": "Products",
+                "description": "The list of products purchased.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "item_id": {
+                      "title": "Product ID",
+                      "description": "Identifier for the product being purchased.",
+                      "type": "string"
+                    },
+                    "item_name": {
+                      "title": "Name",
+                      "description": "Name of the product being purchased.",
+                      "type": "string"
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                      "type": "string"
+                    },
+                    "coupon": {
+                      "title": "Coupon",
+                      "description": "Coupon code used for a purchase.",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "title": "Currency",
+                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+                      "type": "string"
+                    },
+                    "discount": {
+                      "title": "Discount",
+                      "description": "Monetary value of discount associated with a purchase.",
+                      "type": "number"
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "The index/position of the item in a list.",
+                      "type": "number"
+                    },
+                    "item_brand": {
+                      "title": "Brand",
+                      "description": "Brand associated with the product.",
+                      "type": "string"
+                    },
+                    "item_category": {
+                      "title": "Category",
+                      "description": "Product category.",
+                      "type": "string"
+                    },
+                    "item_category2": {
+                      "title": "Category 2",
+                      "description": "Product category 2.",
+                      "type": "string"
+                    },
+                    "item_category3": {
+                      "title": "Category 3",
+                      "description": "Product category 3.",
+                      "type": "string"
+                    },
+                    "item_category4": {
+                      "title": "Category 4",
+                      "description": "Product category 4.",
+                      "type": "string"
+                    },
+                    "item_category5": {
+                      "title": "Category 5",
+                      "description": "Product category 5.",
+                      "type": "string"
+                    },
+                    "item_list_id": {
+                      "title": "Item List ID",
+                      "description": "The ID of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_list_name": {
+                      "title": "Item List Name",
+                      "description": "The name of the list in which the item was presented to the user.",
+                      "type": "string"
+                    },
+                    "item_variant": {
+                      "title": "Variant",
+                      "description": "Variant of the product (e.g. Black).",
+                      "type": "string"
+                    },
+                    "location_id": {
+                      "title": "Location ID",
+                      "description": "The location associated with the item.",
+                      "type": "string"
+                    },
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Item quantity.",
+                      "type": "integer"
+                    },
+                    "creative_name": {
+                      "title": "Creative Name",
+                      "description": "The name of the promotional creative.",
+                      "type": "string"
+                    },
+                    "creative_slot": {
+                      "title": "Creative Slot",
+                      "description": "The name of the promotional creative slot associated with the event.",
+                      "type": "string"
+                    },
+                    "promotion_name": {
+                      "title": "Promotion Name",
+                      "description": "The name of the promotion associated with the event.",
+                      "type": "string"
+                    },
+                    "promotion_id": {
+                      "title": "Promotion ID",
+                      "description": "The ID of the promotion associated with the event.",
+                      "type": "string"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": ["items"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_properties",
+          "type": "object",
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_properties": {
+                "title": "User Properties",
+                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "params",
+          "type": "object",
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "params": {
+                "title": "Event Parameters",
+                "description": "The event parameters to send to Google Analytics 4.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "send_to",
+          "type": "boolean",
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "defaultValue": true,
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "send_to": {
+                "title": "Send To",
+                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "setConfigurationFields",
+      "name": "Set Configuration Fields",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "send_page_view": true
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
@@ -1,529 +1,316 @@
 {
+  "slug": "actions-google-analytics-4-web",
   "name": "Google Analytics 4 Web",
-  "basicOptions": [
-    "measurementID",
-    "allowGoogleSignals",
-    "allowAdPersonalizationSignals",
-    "cookieDomain",
-    "cookieExpirationInSeconds",
-    "cookieFlags",
-    "cookiePath",
-    "cookiePrefix",
-    "cookieUpdate",
-    "enableConsentMode",
-    "defaultAdsStorageConsentState",
-    "defaultAnalyticsStorageConsentState",
-    "adUserDataConsentState",
-    "adPersonalizationConsentState",
-    "waitTimeToUpdateConsentStage",
-    "pageView",
-    "domain"
-  ],
-  "options": {
-    "measurementID": {
-      "tags": [],
-      "default": "",
-      "description": "The measurement ID associated with the web stream. Found in the Google Analytics UI under: Admin > Data Streams > Web > Measurement ID.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Measurement ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The measurementID property is required."]],
-      "uIMetadata": null
-    },
-    "allowGoogleSignals": {
-      "tags": [],
-      "default": true,
-      "description": "Set to false to disable all advertising features. Set to true by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Allow Google Signals",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "allowAdPersonalizationSignals": {
-      "tags": [],
-      "default": true,
-      "description": "Set to false to disable all advertising features. Set to true by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Allow Ad Personalization Signals",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookieDomain": {
-      "tags": [],
-      "default": "auto",
-      "description": "Specifies the domain used to store the analytics cookie. Set to “auto” by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Domain",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookieExpirationInSeconds": {
-      "tags": [],
-      "default": 63072000,
-      "description": "Every time a hit is sent to GA4, the analytics cookie expiration time is updated to be the current time plus the value of this field. The default value is two years (63072000 seconds). Please input the expiration value in seconds. More information in [Google Documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Expiration In Seconds",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookieFlags": {
-      "tags": [],
-      "default": "",
-      "description": "Appends additional flags to the analytics cookie.  See [write a new cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie) for some examples of flags to set.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Flag",
-      "private": false,
-      "scope": "event_destination",
-      "type": "array",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookiePath": {
-      "tags": [],
-      "default": "/",
-      "description": "Specifies the subpath used to store the analytics cookie. We recommend to add a forward slash, / , in the first field as it is the Default Value for GA4.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Path",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookiePrefix": {
-      "tags": [],
-      "default": "",
-      "description": "Specifies a prefix to prepend to the analytics cookie name.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Prefix",
-      "private": false,
-      "scope": "event_destination",
-      "type": "array",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookieUpdate": {
-      "tags": [],
-      "default": true,
-      "description": "Set to false to not update  cookies on each page load. This has the effect of cookie expiration being relative to the first time a user visited. Set to true by default so update cookies on each page load.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Update",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "enableConsentMode": {
-      "tags": [],
-      "default": false,
-      "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Consent Mode",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "defaultAdsStorageConsentState": {
-      "tags": [],
-      "default": "granted",
-      "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Default Ads Storage Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "measurementID": {
+        "label": "Measurement ID",
+        "description": "The measurement ID associated with the web stream. Found in the Google Analytics UI under: Admin > Data Streams > Web > Measurement ID.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "defaultAnalyticsStorageConsentState": {
-      "tags": [],
-      "default": "granted",
-      "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Default Analytics Storage Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "allowGoogleSignals": {
+        "label": "Allow Google Signals",
+        "description": "Set to false to disable all advertising features. Set to true by default.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "adUserDataConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Ad User Data Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "allowAdPersonalizationSignals": {
+        "label": "Allow Ad Personalization Signals",
+        "description": "Set to false to disable all advertising features. Set to true by default.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "adPersonalizationConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Ad Personalization Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "cookieDomain": {
+        "label": "Cookie Domain",
+        "description": "Specifies the domain used to store the analytics cookie. Set to “auto” by default.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "auto"
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "waitTimeToUpdateConsentStage": {
-      "tags": [],
-      "default": 0,
-      "description": "If your CMP loads asynchronously, it might not always run before the Google tag. To handle such situations, specify a millisecond value to control how long to wait before the consent state update is sent. Please input the wait_for_update in milliseconds.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Wait Time to Update Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "pageView": {
-      "tags": [],
-      "default": true,
-      "description": "Set to false to prevent the default snippet from sending page views. Enabled by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Page Views",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "domain": {
-      "tags": [],
-      "default": "www.googletagmanager.com",
-      "description": "A custom domain to load the Google Analytics script from. For more information see [Google's Documentation](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtag&option=cdn).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Google Custom Domain",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+      "cookieExpirationInSeconds": {
+        "label": "Cookie Expiration In Seconds",
+        "description": "Every time a hit is sent to GA4, the analytics cookie expiration time is updated to be the current time plus the value of this field. The default value is two years (63072000 seconds). Please input the expiration value in seconds. More information in [Google Documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#)",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 63072000
+      },
+      "cookieFlags": {
+        "label": "Cookie Flag",
+        "description": "Appends additional flags to the analytics cookie.  See [write a new cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie) for some examples of flags to set.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "cookiePath": {
+        "label": "Cookie Path",
+        "description": "Specifies the subpath used to store the analytics cookie. We recommend to add a forward slash, / , in the first field as it is the Default Value for GA4.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "/"
+      },
+      "cookiePrefix": {
+        "label": "Cookie Prefix",
+        "description": "Specifies a prefix to prepend to the analytics cookie name.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "cookieUpdate": {
+        "label": "Cookie Update",
+        "description": "Set to false to not update  cookies on each page load. This has the effect of cookie expiration being relative to the first time a user visited. Set to true by default so update cookies on each page load.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "enableConsentMode": {
+        "label": "Enable Consent Mode",
+        "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "defaultAdsStorageConsentState": {
+        "label": "Default Ads Storage Consent State",
+        "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": "granted"
+      },
+      "defaultAnalyticsStorageConsentState": {
+        "label": "Default Analytics Storage Consent State",
+        "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": "granted"
+      },
+      "adUserDataConsentState": {
+        "label": "Ad User Data Consent State",
+        "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      },
+      "adPersonalizationConsentState": {
+        "label": "Ad Personalization Consent State",
+        "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      },
+      "waitTimeToUpdateConsentStage": {
+        "label": "Wait Time to Update Consent State",
+        "description": "If your CMP loads asynchronously, it might not always run before the Google tag. To handle such situations, specify a millisecond value to control how long to wait before the consent state update is sent. Please input the wait_for_update in milliseconds.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "pageView": {
+        "label": "Page Views",
+        "description": "Set to false to prevent the default snippet from sending page views. Enabled by default.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "domain": {
+        "label": "Google Custom Domain",
+        "description": "A custom domain to load the Google Analytics script from. For more information see [Google's Documentation](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtag&option=cdn).",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "www.googletagmanager.com"
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "addPaymentInfo",
-      "name": "Add Payment Info",
+  "audienceConfig": null,
+  "actions": {
+    "addPaymentInfo": {
+      "title": "Add Payment Info",
       "description": "Send event when a user submits their payment information",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Payment Info Entered\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Payment Info Entered\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "currency",
-          "type": "string",
+        "currency": {
           "label": "Currency",
           "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.currency"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "value",
-          "type": "number",
+        "value": {
           "label": "Value",
           "description": "The monetary value of the event.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.value"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
+        "coupon": {
           "label": "Coupon",
           "description": "Coupon code used for a purchase.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "Coupon code used for a purchase.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "payment_type",
-          "type": "string",
+        "payment_type": {
           "label": "Payment Type",
           "description": "The chosen method of payment.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.payment_method"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "payment_type": {
-                "title": "Payment Type",
-                "description": "The chosen method of payment.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "items",
-          "type": "object",
+        "items": {
           "label": "Products",
           "description": "The list of products purchased.",
-          "defaultValue": {
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -560,3788 +347,903 @@
               }
             ]
           },
-          "required": true,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": ["items"]
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
+        "user_properties": {
           "label": "User Properties",
           "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
-          "type": "object",
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
+        "send_to": {
           "label": "Send To",
           "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "addToCart",
-      "name": "Add to Cart",
-      "description": "This event signifies that an item was added to a cart for purchase.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Product Added\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
           "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "addToWishlist",
-      "name": "Add to Wishlist",
-      "description": "The event signifies that an item was added to a wishlist. Use this event to identify popular gift items in your app.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Product Added to Wishlist\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "beginCheckout",
-      "name": "Begin Checkout",
-      "description": "This event signifies that a user has begun a checkout.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Checkout Started\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
-          "label": "Coupon",
-          "description": "Coupon code used for a purchase.",
-          "defaultValue": {
-            "@path": "$.properties.coupon"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "Coupon code used for a purchase.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "index": {
-                  "@path": "$.position"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "customEvent",
-      "name": "Custom Event",
-      "description": "Send any custom event",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event Name",
-                "description": "The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "lowercase",
-          "type": "boolean",
-          "label": "Lowercase Event Name",
-          "description": "If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
-          "defaultValue": false,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "lowercase": {
-                "title": "Lowercase Event Name",
-                "description": "If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "generateLead",
-      "name": "Generate Lead",
-      "description": "Log this event when a lead has been generated to understand the efficacy of your re-engagement campaigns.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "login",
-      "name": "Login",
+    "login": {
+      "title": "Login",
       "description": "Send event when a user logs in",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Signed In\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Signed In\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "method",
-          "type": "string",
+        "method": {
           "label": "Method",
           "description": "The method used to login.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.method"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "method": {
-                "title": "Method",
-                "description": "The method used to login.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
+        "user_properties": {
           "label": "User Properties",
           "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
-          "type": "object",
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
+        "send_to": {
           "label": "Send To",
           "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "purchase",
-      "name": "Purchase",
-      "description": "This event signifies when one or more items is purchased by a user.",
+    "signUp": {
+      "title": "Sign Up",
+      "description": "The method used for sign up.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Signed Up\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "coupon",
           "type": "string",
-          "label": "Coupon",
-          "description": "Coupon code used for a purchase.",
-          "defaultValue": {
-            "@path": "$.properties.coupon"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "Coupon code used for a purchase.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "currency",
+        "method": {
+          "label": "Method",
+          "description": "The method used to login.",
           "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": ["currency"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "index": {
-                  "@path": "$.position"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "transaction_id",
-          "type": "string",
-          "label": "Order Id",
-          "description": "The unique identifier of a transaction.",
-          "defaultValue": {
-            "@path": "$.properties.order_id"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "transaction_id": {
-                "title": "Order Id",
-                "description": "The unique identifier of a transaction.",
-                "type": "string"
-              }
-            },
-            "required": ["transaction_id"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "shipping",
-          "type": "number",
-          "label": "Shipping",
-          "description": "Shipping cost associated with the transaction.",
-          "defaultValue": {
-            "@path": "$.properties.shipping"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "shipping": {
-                "title": "Shipping",
-                "description": "Shipping cost associated with the transaction.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "tax",
-          "type": "number",
-          "label": "Tax",
-          "description": "Total tax associated with the transaction.",
-          "defaultValue": {
-            "@path": "$.properties.tax"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "tax": {
-                "title": "Tax",
-                "description": "Total tax associated with the transaction.",
-                "type": "number"
-              }
-            },
-            "required": []
+          "default": {
+            "@path": "$.properties.method"
           },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.total"
-          },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
+        "user_properties": {
           "label": "User Properties",
           "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
-          "type": "object",
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
+        "send_to": {
           "label": "Send To",
           "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "refund",
-      "name": "Refund",
-      "description": "This event signifies when one or more items is refunded to a user.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Order Refunded\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "transaction_id",
-          "type": "string",
-          "label": "Order Id",
-          "description": "The unique identifier of a transaction.",
-          "defaultValue": {
-            "@path": "$.properties.order_id"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "transaction_id": {
-                "title": "Order Id",
-                "description": "The unique identifier of a transaction.",
-                "type": "string"
-              }
-            },
-            "required": ["transaction_id"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.total"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "affiliation",
-          "type": "string",
-          "label": "Affiliation",
-          "description": "Store or affiliation from which this transaction occurred (e.g. Google Store).",
-          "defaultValue": {
-            "@path": "$.properties.affiliation"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "affiliation": {
-                "title": "Affiliation",
-                "description": "Store or affiliation from which this transaction occurred (e.g. Google Store).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "coupon",
-          "type": "string",
-          "label": "Coupon",
-          "description": "Coupon code used for a purchase.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "coupon": {
-                "title": "Coupon",
-                "description": "Coupon code used for a purchase.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "shipping",
-          "type": "number",
-          "label": "Shipping",
-          "description": "Shipping cost associated with the transaction.",
-          "defaultValue": {
-            "@path": "$.properties.shipping"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "shipping": {
-                "title": "Shipping",
-                "description": "Shipping cost associated with the transaction.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "tax",
-          "type": "number",
-          "label": "Tax",
-          "description": "Total tax associated with the transaction.",
-          "defaultValue": {
-            "@path": "$.properties.tax"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "tax": {
-                "title": "Tax",
-                "description": "Total tax associated with the transaction.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "index": {
-                  "@path": "$.position"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
           "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "removeFromCart",
-      "name": "Remove from Cart",
-      "description": "This event signifies that an item was removed from a cart.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Product Removed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "search",
-      "name": "Search",
+    "search": {
+      "title": "Search",
       "description": "The term that was searched for.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Products Searched\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Products Searched\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
+        "user_properties": {
           "label": "User Properties",
           "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
-          "type": "object",
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "search_term",
-          "type": "string",
+        "search_term": {
           "label": "Search Term",
           "description": "The term that was searched for.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.query"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "search_term": {
-                "title": "Search Term",
-                "description": "The term that was searched for.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
+        "send_to": {
           "label": "Send To",
           "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "selectItem",
-      "name": "Select Item",
-      "description": "This event signifies an item was selected from a list.",
+    "addToCart": {
+      "title": "Add to Cart",
+      "description": "This event signifies that an item was added to a cart for purchase.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Product Added\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Product Clicked\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "item_list_name",
           "type": "string",
-          "label": "Item List Name",
-          "description": "The name of the list in which the item was presented to the user.",
-          "defaultValue": {
-            "@path": "$.properties.item_list_name"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "item_list_name": {
-                "title": "Item List Name",
-                "description": "The name of the list in which the item was presented to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "item_list_id",
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
           "type": "string",
-          "label": "Item List Id",
-          "description": "The ID of the list in which the item was presented to the user.",
-          "defaultValue": {
-            "@path": "$.properties.item_list_id"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "item_list_id": {
-                "title": "Item List Id",
-                "description": "The ID of the list in which the item was presented to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "items",
-          "type": "object",
+        "items": {
           "label": "Products",
           "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
+          "type": "object",
           "required": true,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "selectPromotion",
-      "name": "Select Promotion",
-      "description": "This event signifies a promotion was selected from a list.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Promotion Clicked\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "creative_name",
-          "type": "string",
-          "label": "Creative Name",
-          "description": "The name of the promotional creative.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "creative_name": {
-                "title": "Creative Name",
-                "description": "The name of the promotional creative.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "creative_slot",
-          "type": "string",
-          "label": "Creative Slot",
-          "description": "The name of the promotional creative slot associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.creative"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "creative_slot": {
-                "title": "Creative Slot",
-                "description": "The name of the promotional creative slot associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "location_id",
-          "type": "string",
-          "label": "Location ID",
-          "description": "The ID of the location.",
-          "defaultValue": {
-            "@path": "$.properties.position"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "location_id": {
-                "title": "Location ID",
-                "description": "The ID of the location.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "promotion_id",
-          "type": "string",
-          "label": "Promotion ID",
-          "description": "The ID of the promotion associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.promotion_id"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "promotion_id": {
-                "title": "Promotion ID",
-                "description": "The ID of the promotion associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "promotion_name",
-          "type": "string",
-          "label": "Promotion Name",
-          "description": "The name of the promotion associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "promotion_name": {
-                "title": "Promotion Name",
-                "description": "The name of the promotion associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -4375,307 +1277,7950 @@
               }
             ]
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    },
-                    "creative_name": {
-                      "title": "Creative Name",
-                      "description": "The name of the promotional creative.",
-                      "type": "string"
-                    },
-                    "creative_slot": {
-                      "title": "Creative Slot",
-                      "description": "The name of the promotional creative slot associated with the event.",
-                      "type": "string"
-                    },
-                    "promotion_name": {
-                      "title": "Promotion Name",
-                      "description": "The name of the promotion associated with the event.",
-                      "type": "string"
-                    },
-                    "promotion_id": {
-                      "title": "Promotion ID",
-                      "description": "The ID of the promotion associated with the event.",
-                      "type": "string"
-                    }
-                  },
-                  "required": []
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
           "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
+        "send_to": {
           "label": "Send To",
           "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "setConfigurationFields",
-      "name": "Set Configuration Fields",
-      "description": "Set custom values for the GA4 configuration fields.",
+    "addToWishlist": {
+      "title": "Add to Wishlist",
+      "description": "The event signifies that an item was added to a wishlist. Use this event to identify popular gift items in your app.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Product Added to Wishlist\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_properties",
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
           "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
           "label": "User Properties",
           "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "ads_storage_consent_state",
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "removeFromCart": {
+      "title": "Remove from Cart",
+      "description": "This event signifies that an item was removed from a cart.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Product Removed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
           "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "selectItem": {
+      "title": "Select Item",
+      "description": "This event signifies an item was selected from a list.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Product Clicked\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "item_list_name": {
+          "label": "Item List Name",
+          "description": "The name of the list in which the item was presented to the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.item_list_name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "item_list_id": {
+          "label": "Item List Id",
+          "description": "The ID of the list in which the item was presented to the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.item_list_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "selectPromotion": {
+      "title": "Select Promotion",
+      "description": "This event signifies a promotion was selected from a list.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Promotion Clicked\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "creative_name": {
+          "label": "Creative Name",
+          "description": "The name of the promotional creative.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "creative_slot": {
+          "label": "Creative Slot",
+          "description": "The name of the promotional creative slot associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.creative"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "location_id": {
+          "label": "Location ID",
+          "description": "The ID of the location.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.position"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "promotion_id": {
+          "label": "Promotion ID",
+          "description": "The ID of the promotion associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.promotion_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "promotion_name": {
+          "label": "Promotion Name",
+          "description": "The name of the promotion associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creative_name": {
+              "label": "Creative Name",
+              "description": "The name of the promotional creative.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creative_slot": {
+              "label": "Creative Slot",
+              "description": "The name of the promotional creative slot associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotion_name": {
+              "label": "Promotion Name",
+              "description": "The name of the promotion associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotion_id": {
+              "label": "Promotion ID",
+              "description": "The ID of the promotion associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "viewItem": {
+      "title": "View Item",
+      "description": "This event signifies that some content was shown to the user. Use this event to discover the most popular items viewed.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event =  \"Product Viewed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "viewPromotion": {
+      "title": "View Promotion",
+      "description": "This event signifies a promotion was viewed from a list.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Promotion Viewed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "creative_name": {
+          "label": "Creative Name",
+          "description": "The name of the promotional creative.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "creative_slot": {
+          "label": "Creative Slot",
+          "description": "The name of the promotional creative slot associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.creative"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "location_id": {
+          "label": "Location ID",
+          "description": "The ID of the location.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.position"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "promotion_id": {
+          "label": "Promotion ID",
+          "description": "The ID of the promotion associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.promotion_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "promotion_name": {
+          "label": "Promotion Name",
+          "description": "The name of the promotion associated with the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creative_name": {
+              "label": "Creative Name",
+              "description": "The name of the promotional creative.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "creative_slot": {
+              "label": "Creative Slot",
+              "description": "The name of the promotional creative slot associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotion_name": {
+              "label": "Promotion Name",
+              "description": "The name of the promotion associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "promotion_id": {
+              "label": "Promotion ID",
+              "description": "The ID of the promotion associated with the event.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "beginCheckout": {
+      "title": "Begin Checkout",
+      "description": "This event signifies that a user has begun a checkout.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Checkout Started\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "coupon": {
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.coupon"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "purchase": {
+      "title": "Purchase",
+      "description": "This event signifies when one or more items is purchased by a user.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Order Completed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "coupon": {
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.coupon"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "transaction_id": {
+          "label": "Order Id",
+          "description": "The unique identifier of a transaction.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.order_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "shipping": {
+          "label": "Shipping",
+          "description": "Shipping cost associated with the transaction.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.shipping"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "tax": {
+          "label": "Tax",
+          "description": "Total tax associated with the transaction.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.tax"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.total"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "refund": {
+      "title": "Refund",
+      "description": "This event signifies when one or more items is refunded to a user.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Order Refunded\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "transaction_id": {
+          "label": "Order Id",
+          "description": "The unique identifier of a transaction.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.order_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.total"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "affiliation": {
+          "label": "Affiliation",
+          "description": "Store or affiliation from which this transaction occurred (e.g. Google Store).",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.affiliation"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "coupon": {
+          "label": "Coupon",
+          "description": "Coupon code used for a purchase.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "shipping": {
+          "label": "Shipping",
+          "description": "Shipping cost associated with the transaction.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.shipping"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "tax": {
+          "label": "Tax",
+          "description": "Total tax associated with the transaction.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.tax"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "viewCart": {
+      "title": "View Cart",
+      "description": "This event signifies that a user viewed their cart.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Cart Viewed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "viewItemList": {
+      "title": "View Item List",
+      "description": "Log this event when the user has been presented with a list of items of a certain category.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Product List Viewed\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "item_list_id": {
+          "label": "Item List Id",
+          "description": "The ID of the list in which the item was presented to the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.item_list_id"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "item_list_name": {
+          "label": "Item List Name",
+          "description": "The name of the list in which the item was presented to the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.item_list_name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "items": {
+          "label": "Products",
+          "description": "The list of products purchased.",
+          "type": "object",
+          "required": true,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "item_id": {
+                  "@path": "$.product_id"
+                },
+                "item_name": {
+                  "@path": "$.name"
+                },
+                "affiliation": {
+                  "@path": "$.affiliation"
+                },
+                "coupon": {
+                  "@path": "$.coupon"
+                },
+                "index": {
+                  "@path": "$.position"
+                },
+                "item_brand": {
+                  "@path": "$.brand"
+                },
+                "item_category": {
+                  "@path": "$.category"
+                },
+                "item_variant": {
+                  "@path": "$.variant"
+                },
+                "price": {
+                  "@path": "$.price"
+                },
+                "quantity": {
+                  "@path": "$.quantity"
+                }
+              }
+            ]
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "item_id": {
+              "label": "Product ID",
+              "description": "Identifier for the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_name": {
+              "label": "Name",
+              "description": "Name of the product being purchased.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "affiliation": {
+              "label": "Affiliation",
+              "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "coupon": {
+              "label": "Coupon",
+              "description": "Coupon code used for a purchase.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "currency": {
+              "label": "Currency",
+              "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "discount": {
+              "label": "Discount",
+              "description": "Monetary value of discount associated with a purchase.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "index": {
+              "label": "Index",
+              "description": "The index/position of the item in a list.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_brand": {
+              "label": "Brand",
+              "description": "Brand associated with the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category": {
+              "label": "Category",
+              "description": "Product category.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category2": {
+              "label": "Category 2",
+              "description": "Product category 2.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category3": {
+              "label": "Category 3",
+              "description": "Product category 3.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category4": {
+              "label": "Category 4",
+              "description": "Product category 4.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_category5": {
+              "label": "Category 5",
+              "description": "Product category 5.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_id": {
+              "label": "Item List ID",
+              "description": "The ID of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_list_name": {
+              "label": "Item List Name",
+              "description": "The name of the list in which the item was presented to the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "item_variant": {
+              "label": "Variant",
+              "description": "Variant of the product (e.g. Black).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "location_id": {
+              "label": "Location ID",
+              "description": "The location associated with the item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "price": {
+              "label": "Price",
+              "description": "Price of the product being purchased, in units of the specified currency parameter.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "quantity": {
+              "label": "Quantity",
+              "description": "Item quantity.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "generateLead": {
+      "title": "Generate Lead",
+      "description": "Log this event when a lead has been generated to understand the efficacy of your re-engagement campaigns.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "value": {
+          "label": "Value",
+          "description": "The monetary value of the event.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.value"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "customEvent": {
+      "title": "Custom Event",
+      "description": "Send any custom event",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Event Name",
+          "description": "The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "lowercase": {
+          "label": "Lowercase Event Name",
+          "description": "If true, the event name will be converted to lowercase before sending to Google. Event names are case sensitive in GA4 so enable this setting to avoid distinct events for casing differences. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": false,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "params": {
+          "label": "Event Parameters",
+          "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "send_to": {
+          "label": "Send To",
+          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "setConfigurationFields": {
+      "title": "Set Configuration Fields",
+      "description": "Set custom values for the GA4 configuration fields.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
+          "label": "User ID",
+          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_properties": {
+          "label": "User Properties",
+          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "ads_storage_consent_state": {
           "label": "Ads Storage Consent State",
           "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "label": "Granted",
@@ -4686,33 +9231,26 @@
               "value": "denied"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "ads_storage_consent_state": {
-                "title": "Ads Storage Consent State",
-                "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
-                "type": "string",
-                "enum": ["granted", "denied"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "analytics_storage_consent_state",
-          "type": "string",
+        "analytics_storage_consent_state": {
           "label": "Analytics Storage Consent State",
           "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "label": "Granted",
@@ -4723,33 +9261,26 @@
               "value": "denied"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "analytics_storage_consent_state": {
-                "title": "Analytics Storage Consent State",
-                "description": "Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.",
-                "type": "string",
-                "enum": ["granted", "denied"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "ad_user_data_consent_state",
-          "type": "string",
+        "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
           "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "label": "Granted",
@@ -4760,33 +9291,26 @@
               "value": "denied"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "ad_user_data_consent_state": {
-                "title": "Ad User Data Consent State",
-                "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-                "type": "string",
-                "enum": ["granted", "denied"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "ad_personalization_consent_state",
-          "type": "string",
+        "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
           "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "label": "Granted",
@@ -4797,358 +9321,278 @@
               "value": "denied"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "ad_personalization_consent_state": {
-                "title": "Ad Personalization Consent State",
-                "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-                "type": "string",
-                "enum": ["granted", "denied"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_content",
-          "type": "string",
+        "campaign_content": {
           "label": "Campaign Content",
           "description": "Use campaign content to differentiate ads or links that point to the same URL. Setting this value will override the utm_content query parameter.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_content": {
-                "title": "Campaign Content",
-                "description": "Use campaign content to differentiate ads or links that point to the same URL. Setting this value will override the utm_content query parameter.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_id",
-          "type": "string",
+        "campaign_id": {
           "label": "Campaign ID",
           "description": "Use campaign ID to identify a specific campaign. Setting this value will override the utm_id query parameter. ",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_id": {
-                "title": "Campaign ID",
-                "description": "Use campaign ID to identify a specific campaign. Setting this value will override the utm_id query parameter. ",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_medium",
-          "type": "string",
+        "campaign_medium": {
           "label": "Campaign Medium",
           "description": "Use campaign medium to identify a medium such as email or cost-per-click. Setting this value will override the utm_medium query parameter.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_medium": {
-                "title": "Campaign Medium",
-                "description": "Use campaign medium to identify a medium such as email or cost-per-click. Setting this value will override the utm_medium query parameter.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_name",
-          "type": "string",
+        "campaign_name": {
           "label": "Campaign Name",
           "description": "Use campaign name to identify a specific product promotion or strategic campaign. Setting this value will override the utm_name query parameter.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_name": {
-                "title": "Campaign Name",
-                "description": "Use campaign name to identify a specific product promotion or strategic campaign. Setting this value will override the utm_name query parameter.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_source",
-          "type": "string",
+        "campaign_source": {
           "label": "Campaign Source",
           "description": "Use campaign source to identify a search engine, newsletter name, or other source. Setting this value will override the utm_source query parameter.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_source": {
-                "title": "Campaign Source",
-                "description": "Use campaign source to identify a search engine, newsletter name, or other source. Setting this value will override the utm_source query parameter.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "campaign_term",
-          "type": "string",
+        "campaign_term": {
           "label": "Campaign Term",
           "description": "Use campaign term to note the keywords for this ad. Setting this value will override the utm_term query parameter.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "campaign_term": {
-                "title": "Campaign Term",
-                "description": "Use campaign term to note the keywords for this ad. Setting this value will override the utm_term query parameter.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_group",
-          "type": "string",
+        "content_group": {
           "label": "Content Group",
           "description": "Categorize pages and screens into custom buckets so you can see metrics for related groups of information. More information in [Google documentation](https://support.google.com/analytics/answer/11523339).",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_group": {
-                "title": "Content Group",
-                "description": "Categorize pages and screens into custom buckets so you can see metrics for related groups of information. More information in [Google documentation](https://support.google.com/analytics/answer/11523339).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "language",
-          "type": "string",
+        "language": {
           "label": "Language",
           "description": "The language preference of the user. If not set, defaults to the user's navigator.language value.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "language": {
-                "title": "Language",
-                "description": "The language preference of the user. If not set, defaults to the user's navigator.language value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "page_location",
-          "type": "string",
+        "page_location": {
           "label": "Page Location",
           "description": "The full URL of the page. If not set, defaults to the user's document.location value.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "page_location": {
-                "title": "Page Location",
-                "description": "The full URL of the page. If not set, defaults to the user's document.location value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "page_referrer",
-          "type": "string",
+        "page_referrer": {
           "label": "Page Referrer",
           "description": "The referral source that brought traffic to a page. This value is also used to compute the traffic source. The format of this value is a URL. If not set, defaults to the user's document.referrer value.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "page_referrer": {
-                "title": "Page Referrer",
-                "description": "The referral source that brought traffic to a page. This value is also used to compute the traffic source. The format of this value is a URL. If not set, defaults to the user's document.referrer value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "page_title",
-          "type": "string",
+        "page_title": {
           "label": "Page Title",
           "description": "The title of the page or document. If not set, defaults to the user's document.title value.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "page_title": {
-                "title": "Page Title",
-                "description": "The title of the page or document. If not set, defaults to the user's document.title value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "screen_resolution",
-          "type": "string",
+        "screen_resolution": {
           "label": "Screen Resolution",
           "description": "The resolution of the screen. Format should be two positive integers separated by an x (i.e. 800x600). If not set, calculated from the user's window.screen value.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "screen_resolution": {
-                "title": "Screen Resolution",
-                "description": "The resolution of the screen. Format should be two positive integers separated by an x (i.e. 800x600). If not set, calculated from the user's window.screen value.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "send_page_view",
-          "type": "boolean",
+        "send_page_view": {
           "label": "Send Page Views",
           "description": "Selection overrides toggled value set within Settings",
-          "defaultValue": true,
+          "type": "boolean",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
           "choices": [
             {
               "label": "True",
@@ -5159,1710 +9603,51 @@
               "value": "false"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_page_view": {
-                "title": "Send Page Views",
-                "description": "Selection overrides toggled value set within Settings",
-                "type": "boolean",
-                "enum": ["true", "false"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "params",
-          "type": "object",
+        "params": {
           "label": "Event Parameters",
           "description": "The event parameters to send to Google Analytics 4.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
-    },
-    {
-      "slug": "signUp",
-      "name": "Sign Up",
-      "description": "The method used for sign up.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Signed Up\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "method",
-          "type": "string",
-          "label": "Method",
-          "description": "The method used to login.",
-          "defaultValue": {
-            "@path": "$.properties.method"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "method": {
-                "title": "Method",
-                "description": "The method used to login.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "viewCart",
-      "name": "View Cart",
-      "description": "This event signifies that a user viewed their cart.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Cart Viewed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "index": {
-                  "@path": "$.position"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "viewItem",
-      "name": "View Item",
-      "description": "This event signifies that some content was shown to the user. Use this event to discover the most popular items viewed.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event =  \"Product Viewed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "value",
-          "type": "number",
-          "label": "Value",
-          "description": "The monetary value of the event.",
-          "defaultValue": {
-            "@path": "$.properties.value"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "The monetary value of the event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "viewItemList",
-      "name": "View Item List",
-      "description": "Log this event when the user has been presented with a list of items of a certain category.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Product List Viewed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "item_list_id",
-          "type": "string",
-          "label": "Item List Id",
-          "description": "The ID of the list in which the item was presented to the user.",
-          "defaultValue": {
-            "@path": "$.properties.item_list_id"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "item_list_id": {
-                "title": "Item List Id",
-                "description": "The ID of the list in which the item was presented to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "item_list_name",
-          "type": "string",
-          "label": "Item List Name",
-          "description": "The name of the list in which the item was presented to the user.",
-          "defaultValue": {
-            "@path": "$.properties.item_list_name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "item_list_name": {
-                "title": "Item List Name",
-                "description": "The name of the list in which the item was presented to the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "index": {
-                  "@path": "$.position"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "viewPromotion",
-      "name": "View Promotion",
-      "description": "This event signifies a promotion was viewed from a list.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Promotion Viewed\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "creative_name",
-          "type": "string",
-          "label": "Creative Name",
-          "description": "The name of the promotional creative.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "creative_name": {
-                "title": "Creative Name",
-                "description": "The name of the promotional creative.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "creative_slot",
-          "type": "string",
-          "label": "Creative Slot",
-          "description": "The name of the promotional creative slot associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.creative"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "creative_slot": {
-                "title": "Creative Slot",
-                "description": "The name of the promotional creative slot associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "location_id",
-          "type": "string",
-          "label": "Location ID",
-          "description": "The ID of the location.",
-          "defaultValue": {
-            "@path": "$.properties.position"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "location_id": {
-                "title": "Location ID",
-                "description": "The ID of the location.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "promotion_id",
-          "type": "string",
-          "label": "Promotion ID",
-          "description": "The ID of the promotion associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.promotion_id"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "promotion_id": {
-                "title": "Promotion ID",
-                "description": "The ID of the promotion associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "promotion_name",
-          "type": "string",
-          "label": "Promotion Name",
-          "description": "The name of the promotion associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties.name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "promotion_name": {
-                "title": "Promotion Name",
-                "description": "The name of the promotion associated with the event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "items",
-          "type": "object",
-          "label": "Products",
-          "description": "The list of products purchased.",
-          "defaultValue": {
-            "@arrayPath": [
-              "$.properties.products",
-              {
-                "item_id": {
-                  "@path": "$.product_id"
-                },
-                "item_name": {
-                  "@path": "$.name"
-                },
-                "affiliation": {
-                  "@path": "$.affiliation"
-                },
-                "coupon": {
-                  "@path": "$.coupon"
-                },
-                "item_brand": {
-                  "@path": "$.brand"
-                },
-                "item_category": {
-                  "@path": "$.category"
-                },
-                "item_variant": {
-                  "@path": "$.variant"
-                },
-                "price": {
-                  "@path": "$.price"
-                },
-                "quantity": {
-                  "@path": "$.quantity"
-                }
-              }
-            ]
-          },
-          "required": true,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "items": {
-                "title": "Products",
-                "description": "The list of products purchased.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": true,
-                  "properties": {
-                    "item_id": {
-                      "title": "Product ID",
-                      "description": "Identifier for the product being purchased.",
-                      "type": "string"
-                    },
-                    "item_name": {
-                      "title": "Name",
-                      "description": "Name of the product being purchased.",
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "title": "Affiliation",
-                      "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
-                      "type": "string"
-                    },
-                    "coupon": {
-                      "title": "Coupon",
-                      "description": "Coupon code used for a purchase.",
-                      "type": "string"
-                    },
-                    "currency": {
-                      "title": "Currency",
-                      "description": "Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.",
-                      "type": "string"
-                    },
-                    "discount": {
-                      "title": "Discount",
-                      "description": "Monetary value of discount associated with a purchase.",
-                      "type": "number"
-                    },
-                    "index": {
-                      "title": "Index",
-                      "description": "The index/position of the item in a list.",
-                      "type": "number"
-                    },
-                    "item_brand": {
-                      "title": "Brand",
-                      "description": "Brand associated with the product.",
-                      "type": "string"
-                    },
-                    "item_category": {
-                      "title": "Category",
-                      "description": "Product category.",
-                      "type": "string"
-                    },
-                    "item_category2": {
-                      "title": "Category 2",
-                      "description": "Product category 2.",
-                      "type": "string"
-                    },
-                    "item_category3": {
-                      "title": "Category 3",
-                      "description": "Product category 3.",
-                      "type": "string"
-                    },
-                    "item_category4": {
-                      "title": "Category 4",
-                      "description": "Product category 4.",
-                      "type": "string"
-                    },
-                    "item_category5": {
-                      "title": "Category 5",
-                      "description": "Product category 5.",
-                      "type": "string"
-                    },
-                    "item_list_id": {
-                      "title": "Item List ID",
-                      "description": "The ID of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_list_name": {
-                      "title": "Item List Name",
-                      "description": "The name of the list in which the item was presented to the user.",
-                      "type": "string"
-                    },
-                    "item_variant": {
-                      "title": "Variant",
-                      "description": "Variant of the product (e.g. Black).",
-                      "type": "string"
-                    },
-                    "location_id": {
-                      "title": "Location ID",
-                      "description": "The location associated with the item.",
-                      "type": "string"
-                    },
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the product being purchased, in units of the specified currency parameter.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Item quantity.",
-                      "type": "integer"
-                    },
-                    "creative_name": {
-                      "title": "Creative Name",
-                      "description": "The name of the promotional creative.",
-                      "type": "string"
-                    },
-                    "creative_slot": {
-                      "title": "Creative Slot",
-                      "description": "The name of the promotional creative slot associated with the event.",
-                      "type": "string"
-                    },
-                    "promotion_name": {
-                      "title": "Promotion Name",
-                      "description": "The name of the promotion associated with the event.",
-                      "type": "string"
-                    },
-                    "promotion_id": {
-                      "title": "Promotion ID",
-                      "description": "The ID of the promotion associated with the event.",
-                      "type": "string"
-                    }
-                  },
-                  "required": []
-                }
-              }
-            },
-            "required": ["items"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_properties",
-          "type": "object",
-          "label": "User Properties",
-          "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_properties": {
-                "title": "User Properties",
-                "description": "The user properties to send to Google Analytics 4. You must create user-scoped dimensions to ensure custom properties are picked up by Google. See Google’s [Custom user properties](https://support.google.com/analytics/answer/9269570) to learn how to set and register user properties. ",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "params",
-          "type": "object",
-          "label": "Event Parameters",
-          "description": "The event parameters to send to Google Analytics 4.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "params": {
-                "title": "Event Parameters",
-                "description": "The event parameters to send to Google Analytics 4.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "send_to",
-          "type": "boolean",
-          "label": "Send To",
-          "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-          "defaultValue": true,
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "send_to": {
-                "title": "Send To",
-                "description": "If the send_to parameter is not set, events are routed to all Tag Ids (AW-xxx, G-xxx) set via Google Tag",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "setConfigurationFields",
       "name": "Set Configuration Fields",
+      "type": "automatic",
+      "partnerAction": "setConfigurationFields",
       "subscribe": "type = \"page\"",
       "mapping": {
         "send_page_view": true
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/metadata.json
@@ -10,86 +10,107 @@
         "description": "The measurement ID associated with the web stream. Found in the Google Analytics UI under: Admin > Data Streams > Web > Measurement ID.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "allowGoogleSignals": {
         "label": "Allow Google Signals",
         "description": "Set to false to disable all advertising features. Set to true by default.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "allowAdPersonalizationSignals": {
         "label": "Allow Ad Personalization Signals",
         "description": "Set to false to disable all advertising features. Set to true by default.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "cookieDomain": {
         "label": "Cookie Domain",
         "description": "Specifies the domain used to store the analytics cookie. Set to “auto” by default.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "auto"
+        "default": "auto",
+        "depends_on": null
       },
       "cookieExpirationInSeconds": {
         "label": "Cookie Expiration In Seconds",
         "description": "Every time a hit is sent to GA4, the analytics cookie expiration time is updated to be the current time plus the value of this field. The default value is two years (63072000 seconds). Please input the expiration value in seconds. More information in [Google Documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#)",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 63072000
+        "default": 63072000,
+        "depends_on": null
       },
       "cookieFlags": {
         "label": "Cookie Flag",
         "description": "Appends additional flags to the analytics cookie.  See [write a new cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#write_a_new_cookie) for some examples of flags to set.",
         "type": "string",
         "required": false,
+        "multiple": true,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "cookiePath": {
         "label": "Cookie Path",
         "description": "Specifies the subpath used to store the analytics cookie. We recommend to add a forward slash, / , in the first field as it is the Default Value for GA4.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "/"
+        "default": "/",
+        "depends_on": null
       },
       "cookiePrefix": {
         "label": "Cookie Prefix",
         "description": "Specifies a prefix to prepend to the analytics cookie name.",
         "type": "string",
         "required": false,
+        "multiple": true,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "cookieUpdate": {
         "label": "Cookie Update",
         "description": "Set to false to not update  cookies on each page load. This has the effect of cookie expiration being relative to the first time a user visited. Set to true by default so update cookies on each page load.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "enableConsentMode": {
         "label": "Enable Consent Mode",
         "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "defaultAdsStorageConsentState": {
         "label": "Default Ads Storage Consent State",
         "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -100,13 +121,23 @@
             "value": "denied"
           }
         ],
-        "default": "granted"
+        "default": "granted",
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "defaultAnalyticsStorageConsentState": {
         "label": "Default Analytics Storage Consent State",
         "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -117,13 +148,23 @@
             "value": "denied"
           }
         ],
-        "default": "granted"
+        "default": "granted",
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "adUserDataConsentState": {
         "label": "Ad User Data Consent State",
         "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -134,13 +175,23 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "adPersonalizationConsentState": {
         "label": "Ad Personalization Consent State",
         "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -151,31 +202,46 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "waitTimeToUpdateConsentStage": {
         "label": "Wait Time to Update Consent State",
         "description": "If your CMP loads asynchronously, it might not always run before the Google tag. To handle such situations, specify a millisecond value to control how long to wait before the consent state update is sent. Please input the wait_for_update in milliseconds.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "pageView": {
         "label": "Page Views",
         "description": "Set to false to prevent the default snippet from sending page views. Enabled by default.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "domain": {
         "label": "Google Custom Domain",
         "description": "A custom domain to load the Google Analytics script from. For more information see [Google's Documentation](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtag&option=cdn).",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "www.googletagmanager.com"
+        "default": "www.googletagmanager.com",
+        "depends_on": null
       }
     }
   },
@@ -189,7 +255,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -210,7 +276,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -233,7 +301,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -256,7 +326,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -277,7 +349,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "payment_type": {
           "label": "Payment Type",
@@ -300,7 +374,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -369,7 +445,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -390,7 +468,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -411,7 +491,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -432,7 +514,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -453,7 +537,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -474,7 +560,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -495,7 +583,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -516,7 +606,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -537,7 +629,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -558,7 +652,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -579,7 +675,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -600,7 +698,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -621,7 +721,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -642,7 +744,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -663,7 +767,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -684,7 +790,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -705,7 +813,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -726,7 +836,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -747,7 +859,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -757,7 +871,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -778,7 +894,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -799,7 +917,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -820,7 +940,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -832,7 +954,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -853,7 +975,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "method": {
           "label": "Method",
@@ -876,7 +1000,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -897,7 +1023,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -918,7 +1046,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -939,7 +1069,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -951,7 +1083,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -972,7 +1104,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "method": {
           "label": "Method",
@@ -995,7 +1129,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -1016,7 +1152,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -1037,7 +1175,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -1058,7 +1198,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1070,7 +1212,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -1091,7 +1233,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -1112,7 +1256,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -1133,7 +1279,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "search_term": {
           "label": "Search Term",
@@ -1156,7 +1304,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "send_to": {
           "label": "Send To",
@@ -1177,7 +1327,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1189,7 +1341,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -1210,7 +1362,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -1233,7 +1387,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -1299,7 +1455,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -1320,7 +1478,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -1341,7 +1501,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -1362,7 +1524,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -1383,7 +1547,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -1404,7 +1570,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -1425,7 +1593,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -1446,7 +1616,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -1467,7 +1639,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -1488,7 +1662,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -1509,7 +1685,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -1530,7 +1708,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -1551,7 +1731,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -1572,7 +1754,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -1593,7 +1777,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -1614,7 +1800,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -1635,7 +1823,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -1656,7 +1846,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -1677,7 +1869,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1687,7 +1881,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "value": {
           "label": "Value",
@@ -1710,7 +1906,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -1731,7 +1929,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -1752,7 +1952,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -1773,7 +1975,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1785,7 +1989,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -1806,7 +2010,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -1829,7 +2035,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -1852,7 +2060,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -1918,7 +2128,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -1939,7 +2151,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -1960,7 +2174,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -1981,7 +2197,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -2002,7 +2220,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -2023,7 +2243,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -2044,7 +2266,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -2065,7 +2289,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -2086,7 +2312,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -2107,7 +2335,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -2128,7 +2358,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -2149,7 +2381,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -2170,7 +2404,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -2191,7 +2427,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -2212,7 +2450,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -2233,7 +2473,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -2254,7 +2496,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -2275,7 +2519,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -2296,7 +2542,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2306,7 +2554,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -2327,7 +2577,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -2348,7 +2600,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -2369,7 +2623,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -2381,7 +2637,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -2402,7 +2658,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -2425,7 +2683,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -2448,7 +2708,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -2514,7 +2776,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -2535,7 +2799,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -2556,7 +2822,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -2577,7 +2845,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -2598,7 +2868,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -2619,7 +2891,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -2640,7 +2914,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -2661,7 +2937,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -2682,7 +2960,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -2703,7 +2983,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -2724,7 +3006,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -2745,7 +3029,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -2766,7 +3052,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -2787,7 +3075,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -2808,7 +3098,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -2829,7 +3121,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -2850,7 +3144,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -2871,7 +3167,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -2892,7 +3190,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2902,7 +3202,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -2923,7 +3225,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -2944,7 +3248,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -2965,7 +3271,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -2977,7 +3285,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -2998,7 +3306,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "item_list_name": {
           "label": "Item List Name",
@@ -3021,7 +3331,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "item_list_id": {
           "label": "Item List Id",
@@ -3044,7 +3356,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -3110,7 +3424,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -3131,7 +3447,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -3152,7 +3470,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -3173,7 +3493,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -3194,7 +3516,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -3215,7 +3539,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -3236,7 +3562,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -3257,7 +3585,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -3278,7 +3608,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -3299,7 +3631,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -3320,7 +3654,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -3341,7 +3677,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -3362,7 +3700,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -3383,7 +3723,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -3404,7 +3746,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -3425,7 +3769,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -3446,7 +3792,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -3467,7 +3815,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -3488,7 +3838,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -3498,7 +3850,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -3519,7 +3873,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -3540,7 +3896,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -3561,7 +3919,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -3573,7 +3933,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -3594,7 +3954,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "creative_name": {
           "label": "Creative Name",
@@ -3615,7 +3977,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "creative_slot": {
           "label": "Creative Slot",
@@ -3638,7 +4002,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "location_id": {
           "label": "Location ID",
@@ -3661,7 +4027,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "promotion_id": {
           "label": "Promotion ID",
@@ -3684,7 +4052,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "promotion_name": {
           "label": "Promotion Name",
@@ -3707,7 +4077,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -3773,7 +4145,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -3794,7 +4168,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -3815,7 +4191,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -3836,7 +4214,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -3857,7 +4237,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -3878,7 +4260,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -3899,7 +4283,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -3920,7 +4306,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -3941,7 +4329,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -3962,7 +4352,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -3983,7 +4375,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -4004,7 +4398,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -4025,7 +4421,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -4046,7 +4444,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -4067,7 +4467,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -4088,7 +4490,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -4109,7 +4513,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -4130,7 +4536,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -4151,7 +4559,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creative_name": {
               "label": "Creative Name",
@@ -4172,7 +4582,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creative_slot": {
               "label": "Creative Slot",
@@ -4193,7 +4605,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotion_name": {
               "label": "Promotion Name",
@@ -4214,7 +4628,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotion_id": {
               "label": "Promotion ID",
@@ -4235,7 +4651,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -4245,7 +4663,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -4266,7 +4686,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -4287,7 +4709,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -4308,7 +4732,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -4320,7 +4746,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -4341,7 +4767,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -4364,7 +4792,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -4387,7 +4817,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -4453,7 +4885,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -4474,7 +4908,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -4495,7 +4931,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -4516,7 +4954,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -4537,7 +4977,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -4558,7 +5000,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -4579,7 +5023,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -4600,7 +5046,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -4621,7 +5069,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -4642,7 +5092,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -4663,7 +5115,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -4684,7 +5138,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -4705,7 +5161,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -4726,7 +5184,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -4747,7 +5207,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -4768,7 +5230,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -4789,7 +5253,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -4810,7 +5276,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -4831,7 +5299,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -4841,7 +5311,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -4862,7 +5334,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -4883,7 +5357,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -4904,7 +5380,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -4916,7 +5394,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -4937,7 +5415,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "creative_name": {
           "label": "Creative Name",
@@ -4958,7 +5438,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "creative_slot": {
           "label": "Creative Slot",
@@ -4981,7 +5463,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "location_id": {
           "label": "Location ID",
@@ -5004,7 +5488,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "promotion_id": {
           "label": "Promotion ID",
@@ -5027,7 +5513,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "promotion_name": {
           "label": "Promotion Name",
@@ -5050,7 +5538,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -5116,7 +5606,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -5137,7 +5629,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -5158,7 +5652,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -5179,7 +5675,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -5200,7 +5698,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -5221,7 +5721,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -5242,7 +5744,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -5263,7 +5767,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -5284,7 +5790,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -5305,7 +5813,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -5326,7 +5836,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -5347,7 +5859,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -5368,7 +5882,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -5389,7 +5905,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -5410,7 +5928,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -5431,7 +5951,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -5452,7 +5974,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -5473,7 +5997,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -5494,7 +6020,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creative_name": {
               "label": "Creative Name",
@@ -5515,7 +6043,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "creative_slot": {
               "label": "Creative Slot",
@@ -5536,7 +6066,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotion_name": {
               "label": "Promotion Name",
@@ -5557,7 +6089,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "promotion_id": {
               "label": "Promotion ID",
@@ -5578,7 +6112,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -5588,7 +6124,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -5609,7 +6147,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -5630,7 +6170,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -5651,7 +6193,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -5663,7 +6207,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -5684,7 +6228,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -5707,7 +6253,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -5730,7 +6278,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -5799,7 +6349,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -5820,7 +6372,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -5841,7 +6395,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -5862,7 +6418,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -5883,7 +6441,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -5904,7 +6464,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -5925,7 +6487,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -5946,7 +6510,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -5967,7 +6533,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -5988,7 +6556,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -6009,7 +6579,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -6030,7 +6602,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -6051,7 +6625,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -6072,7 +6648,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -6093,7 +6671,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -6114,7 +6694,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -6135,7 +6717,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -6156,7 +6740,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -6177,7 +6763,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -6187,7 +6775,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "value": {
           "label": "Value",
@@ -6210,7 +6800,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "params": {
           "label": "Event Parameters",
@@ -6231,7 +6823,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -6252,7 +6846,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -6273,7 +6869,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -6285,7 +6883,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -6306,7 +6904,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -6329,7 +6929,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -6352,7 +6954,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -6421,7 +7025,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -6442,7 +7048,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -6463,7 +7071,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -6484,7 +7094,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -6505,7 +7117,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -6526,7 +7140,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -6547,7 +7163,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -6568,7 +7186,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -6589,7 +7209,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -6610,7 +7232,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -6631,7 +7255,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -6652,7 +7278,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -6673,7 +7301,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -6694,7 +7324,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -6715,7 +7347,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -6736,7 +7370,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -6757,7 +7393,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -6778,7 +7416,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -6799,7 +7439,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -6809,7 +7451,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "transaction_id": {
           "label": "Order Id",
@@ -6832,7 +7476,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "shipping": {
           "label": "Shipping",
@@ -6855,7 +7501,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "tax": {
           "label": "Tax",
@@ -6878,7 +7526,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -6901,7 +7551,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -6922,7 +7574,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -6943,7 +7597,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -6964,7 +7620,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -6976,7 +7634,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -6997,7 +7655,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -7020,7 +7680,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "transaction_id": {
           "label": "Order Id",
@@ -7043,7 +7705,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -7066,7 +7730,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "affiliation": {
           "label": "Affiliation",
@@ -7089,7 +7755,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "coupon": {
           "label": "Coupon",
@@ -7110,7 +7778,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "shipping": {
           "label": "Shipping",
@@ -7133,7 +7803,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "tax": {
           "label": "Tax",
@@ -7156,7 +7828,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -7225,7 +7899,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -7246,7 +7922,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -7267,7 +7945,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -7288,7 +7968,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -7309,7 +7991,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -7330,7 +8014,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -7351,7 +8037,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -7372,7 +8060,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -7393,7 +8083,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -7414,7 +8106,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -7435,7 +8129,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -7456,7 +8152,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -7477,7 +8175,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -7498,7 +8198,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -7519,7 +8221,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -7540,7 +8244,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -7561,7 +8267,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -7582,7 +8290,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -7603,7 +8313,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -7613,7 +8325,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -7634,7 +8348,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -7655,7 +8371,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -7676,7 +8394,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -7688,7 +8408,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -7709,7 +8429,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -7732,7 +8454,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -7755,7 +8479,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -7824,7 +8550,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -7845,7 +8573,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -7866,7 +8596,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -7887,7 +8619,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -7908,7 +8642,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -7929,7 +8665,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -7950,7 +8688,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -7971,7 +8711,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -7992,7 +8734,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -8013,7 +8757,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -8034,7 +8780,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -8055,7 +8803,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -8076,7 +8826,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -8097,7 +8849,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -8118,7 +8872,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -8139,7 +8895,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -8160,7 +8918,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -8181,7 +8941,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -8202,7 +8964,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -8212,7 +8976,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -8233,7 +8999,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -8254,7 +9022,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -8275,7 +9045,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -8287,7 +9059,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -8308,7 +9080,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "item_list_id": {
           "label": "Item List Id",
@@ -8331,7 +9105,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "item_list_name": {
           "label": "Item List Name",
@@ -8354,7 +9130,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "items": {
           "label": "Products",
@@ -8423,7 +9201,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_name": {
               "label": "Name",
@@ -8444,7 +9224,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "affiliation": {
               "label": "Affiliation",
@@ -8465,7 +9247,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "coupon": {
               "label": "Coupon",
@@ -8486,7 +9270,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "currency": {
               "label": "Currency",
@@ -8507,7 +9293,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "discount": {
               "label": "Discount",
@@ -8528,7 +9316,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "index": {
               "label": "Index",
@@ -8549,7 +9339,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_brand": {
               "label": "Brand",
@@ -8570,7 +9362,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category": {
               "label": "Category",
@@ -8591,7 +9385,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category2": {
               "label": "Category 2",
@@ -8612,7 +9408,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category3": {
               "label": "Category 3",
@@ -8633,7 +9431,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category4": {
               "label": "Category 4",
@@ -8654,7 +9454,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_category5": {
               "label": "Category 5",
@@ -8675,7 +9477,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_id": {
               "label": "Item List ID",
@@ -8696,7 +9500,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_list_name": {
               "label": "Item List Name",
@@ -8717,7 +9523,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "item_variant": {
               "label": "Variant",
@@ -8738,7 +9546,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "location_id": {
               "label": "Location ID",
@@ -8759,7 +9569,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "price": {
               "label": "Price",
@@ -8780,7 +9592,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -8801,7 +9615,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -8811,7 +9627,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_properties": {
           "label": "User Properties",
@@ -8832,7 +9650,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -8853,7 +9673,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -8874,7 +9696,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -8886,7 +9710,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -8907,7 +9731,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -8930,7 +9756,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -8953,7 +9781,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -8974,7 +9804,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -8995,7 +9827,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -9016,7 +9850,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -9028,7 +9864,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event Name",
@@ -9051,7 +9887,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "lowercase": {
           "label": "Lowercase Event Name",
@@ -9072,7 +9910,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_id": {
           "label": "User ID",
@@ -9093,7 +9933,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -9114,7 +9956,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "params": {
           "label": "Event Parameters",
@@ -9135,7 +9979,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "send_to": {
           "label": "Send To",
@@ -9156,7 +10002,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -9168,7 +10016,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -9189,7 +10037,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_properties": {
           "label": "User Properties",
@@ -9210,7 +10060,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "ads_storage_consent_state": {
           "label": "Ads Storage Consent State",
@@ -9240,7 +10092,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "analytics_storage_consent_state": {
           "label": "Analytics Storage Consent State",
@@ -9270,7 +10124,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
@@ -9300,7 +10156,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
@@ -9330,7 +10188,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_content": {
           "label": "Campaign Content",
@@ -9351,7 +10211,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_id": {
           "label": "Campaign ID",
@@ -9372,7 +10234,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_medium": {
           "label": "Campaign Medium",
@@ -9393,7 +10257,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_name": {
           "label": "Campaign Name",
@@ -9414,7 +10280,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_source": {
           "label": "Campaign Source",
@@ -9435,7 +10303,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "campaign_term": {
           "label": "Campaign Term",
@@ -9456,7 +10326,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_group": {
           "label": "Content Group",
@@ -9477,7 +10349,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "language": {
           "label": "Language",
@@ -9498,7 +10372,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "page_location": {
           "label": "Page Location",
@@ -9519,7 +10395,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "page_referrer": {
           "label": "Page Referrer",
@@ -9540,7 +10418,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "page_title": {
           "label": "Page Title",
@@ -9561,7 +10441,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "screen_resolution": {
           "label": "Screen Resolution",
@@ -9582,7 +10464,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "send_page_view": {
           "label": "Send Page Views",
@@ -9612,7 +10496,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "params": {
           "label": "Event Parameters",
@@ -9633,7 +10519,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         }
       }
     }

--- a/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
@@ -10,38 +10,47 @@
         "description": "In Campaign Manager, go to Floodlight -> Configuration, and Advertiser ID is located under the Configuration heading.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": "DC-"
+        "default": "DC-",
+        "depends_on": null
       },
       "allowAdPersonalizationSignals": {
         "label": "Allow Ad Personalization Signals",
         "description": "This feature can be disabled if you do not want the global site tag to allow personalized remarketing data for site users.",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "conversionLinker": {
         "label": "Conversion Linker",
         "description": "This feature can be disabled if you do not want the global site tag to set first party cookies on your site domain.",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "enableConsentMode": {
         "label": "Enable Consent Mode",
         "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "adUserDataConsentState": {
         "label": "Ad User Data Consent State",
         "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -52,13 +61,23 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "adPersonalizationConsentState": {
         "label": "Ad Personalization Consent State",
         "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -69,13 +88,23 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "defaultAdsStorageConsentState": {
         "label": "Default Ads Storage Consent State",
         "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -86,13 +115,23 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "defaultAnalyticsStorageConsentState": {
         "label": "Default Analytics Storage Consent State",
         "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Granted",
@@ -103,7 +142,16 @@
             "value": "denied"
           }
         ],
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "enableConsentMode",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       }
     }
   },
@@ -117,7 +165,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "activityGroupTagString": {
           "label": "Activity Group Tag String",
@@ -138,7 +186,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "activityTagString": {
           "label": "Activity Tag String",
@@ -159,7 +209,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "enableDynamicTags": {
           "label": "Enable Dynamic Tags",
@@ -180,7 +232,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "countingMethod": {
           "label": "Counting Method",
@@ -214,7 +268,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "sessionId": {
           "label": "Session ID",
@@ -235,7 +291,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "uVariables": {
           "label": "U Variables",
@@ -256,7 +314,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "dcCustomParams": {
           "label": "Custom Parameters",
@@ -277,7 +337,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -289,7 +351,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "activityGroupTagString": {
           "label": "Activity Group Tag String",
@@ -310,7 +372,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "activityTagString": {
           "label": "Activity Tag String",
@@ -331,7 +395,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "enableDynamicTags": {
           "label": "Enable Dynamic Tags",
@@ -352,7 +418,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "countingMethod": {
           "label": "Counting Method",
@@ -382,7 +450,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "transactionId": {
           "label": "Transaction ID",
@@ -405,7 +475,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -428,7 +500,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "quantity": {
           "label": "Quantity",
@@ -449,7 +523,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "uVariables": {
           "label": "U Variables",
@@ -470,7 +546,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "dcCustomParams": {
           "label": "Custom Parameters",
@@ -491,7 +569,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
@@ -1,0 +1,713 @@
+{
+  "name": "Google Tag for Campaign Manager",
+  "basicOptions": [
+    "advertiserId",
+    "allowAdPersonalizationSignals",
+    "conversionLinker",
+    "enableConsentMode",
+    "adUserDataConsentState",
+    "adPersonalizationConsentState",
+    "defaultAdsStorageConsentState",
+    "defaultAnalyticsStorageConsentState"
+  ],
+  "options": {
+    "advertiserId": {
+      "tags": [],
+      "default": "DC-",
+      "description": "In Campaign Manager, go to Floodlight -> Configuration, and Advertiser ID is located under the Configuration heading.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Advertiser ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The advertiserId property is required."]],
+      "uIMetadata": null
+    },
+    "allowAdPersonalizationSignals": {
+      "tags": [],
+      "default": true,
+      "description": "This feature can be disabled if you do not want the global site tag to allow personalized remarketing data for site users.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Allow Ad Personalization Signals",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The allowAdPersonalizationSignals property is required."]],
+      "uIMetadata": null
+    },
+    "conversionLinker": {
+      "tags": [],
+      "default": true,
+      "description": "This feature can be disabled if you do not want the global site tag to set first party cookies on your site domain.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Conversion Linker",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The conversionLinker property is required."]],
+      "uIMetadata": null
+    },
+    "enableConsentMode": {
+      "tags": [],
+      "default": false,
+      "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Consent Mode",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "adUserDataConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Ad User Data Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "adPersonalizationConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Ad Personalization Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "defaultAdsStorageConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Default Ads Storage Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "defaultAnalyticsStorageConsentState": {
+      "tags": [],
+      "default": "",
+      "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Default Analytics Storage Consent State",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "granted",
+          "label": "Granted",
+          "text": "Granted"
+        },
+        {
+          "value": "denied",
+          "label": "Denied",
+          "text": "Denied"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "enableConsentMode",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "counterActivity",
+      "name": "Counter Activity",
+      "description": "Record non-monetary conversion data such as unique users, conversions, and session length.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "activityGroupTagString",
+          "type": "string",
+          "label": "Activity Group Tag String",
+          "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "activityGroupTagString": {
+                "title": "Activity Group Tag String",
+                "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+                "type": "string"
+              }
+            },
+            "required": ["activityGroupTagString"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "activityTagString",
+          "type": "string",
+          "label": "Activity Tag String",
+          "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "activityTagString": {
+                "title": "Activity Tag String",
+                "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+                "type": "string"
+              }
+            },
+            "required": ["activityTagString"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "enableDynamicTags",
+          "type": "boolean",
+          "label": "Enable Dynamic Tags",
+          "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enableDynamicTags": {
+                "title": "Enable Dynamic Tags",
+                "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "countingMethod",
+          "type": "string",
+          "label": "Counting Method",
+          "description": "Specifies how conversions will be counted for this Floodlight activity.",
+          "required": true,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "standard",
+              "label": "Standard"
+            },
+            {
+              "value": "unique",
+              "label": "Unique"
+            },
+            {
+              "value": "per_session",
+              "label": "Per Session"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "countingMethod": {
+                "title": "Counting Method",
+                "description": "Specifies how conversions will be counted for this Floodlight activity.",
+                "type": "string",
+                "enum": ["standard", "unique", "per_session"]
+              }
+            },
+            "required": ["countingMethod"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "sessionId",
+          "type": "string",
+          "label": "Session ID",
+          "description": "Use this field to insert a unique session ID if you’re using counter tags with a per session counting methodology. The session ID tells Campaign Manager 360 to count only one event per session on your site.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sessionId": {
+                "title": "Session ID",
+                "description": "Use this field to insert a unique session ID if you’re using counter tags with a per session counting methodology. The session ID tells Campaign Manager 360 to count only one event per session on your site.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "uVariables",
+          "type": "object",
+          "label": "U Variables",
+          "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "uVariables": {
+                "title": "U Variables",
+                "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "dcCustomParams",
+          "type": "object",
+          "label": "Custom Parameters",
+          "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dcCustomParams": {
+                "title": "Custom Parameters",
+                "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "salesActivity",
+      "name": "Sales Activity",
+      "description": "Record monetary data for conversions, such as cost and the number of items sold.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "activityGroupTagString",
+          "type": "string",
+          "label": "Activity Group Tag String",
+          "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "activityGroupTagString": {
+                "title": "Activity Group Tag String",
+                "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+                "type": "string"
+              }
+            },
+            "required": ["activityGroupTagString"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "activityTagString",
+          "type": "string",
+          "label": "Activity Tag String",
+          "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "activityTagString": {
+                "title": "Activity Tag String",
+                "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+                "type": "string"
+              }
+            },
+            "required": ["activityTagString"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "enableDynamicTags",
+          "type": "boolean",
+          "label": "Enable Dynamic Tags",
+          "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enableDynamicTags": {
+                "title": "Enable Dynamic Tags",
+                "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "countingMethod",
+          "type": "string",
+          "label": "Counting Method",
+          "description": "Specifies how conversions will be counted for this Floodlight activity.",
+          "required": true,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "transactions",
+              "label": "Transactions"
+            },
+            {
+              "value": "items_sold",
+              "label": "Items Sold"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "countingMethod": {
+                "title": "Counting Method",
+                "description": "Specifies how conversions will be counted for this Floodlight activity.",
+                "type": "string",
+                "enum": ["transactions", "items_sold"]
+              }
+            },
+            "required": ["countingMethod"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "transactionId",
+          "type": "string",
+          "label": "Transaction ID",
+          "description": "Use this field to insert a unique numerical identifier for each transaction.  Can be alphanumeric.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "transactionId": {
+                "title": "Transaction ID",
+                "description": "Use this field to insert a unique numerical identifier for each transaction.  Can be alphanumeric.",
+                "type": "string"
+              }
+            },
+            "required": ["transactionId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "string",
+          "label": "Value",
+          "description": "Use this field to pass the revenue generated by a transaction. Typically the purchase price and value does not include taxes or shipping.",
+          "defaultValue": {
+            "@path": "$.properties.total"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "Use this field to pass the revenue generated by a transaction. Typically the purchase price and value does not include taxes or shipping.",
+                "type": "string"
+              }
+            },
+            "required": ["value"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "quantity",
+          "type": "integer",
+          "label": "Quantity",
+          "description": "\n      Use this field to pass the number of items sold during a transaction:\n      - If you're counting each transaction as a single conversion, the value is 1.\n      - If you're counting each item sold during a single transaction as a separate conversion, insert the number of items sold as part of each transaction as the value.\n      - The value must be an integer greater than zero.\n      ",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "quantity": {
+                "title": "Quantity",
+                "description": "\n      Use this field to pass the number of items sold during a transaction:\n      - If you're counting each transaction as a single conversion, the value is 1.\n      - If you're counting each item sold during a single transaction as a separate conversion, insert the number of items sold as part of each transaction as the value.\n      - The value must be an integer greater than zero.\n      ",
+                "type": "integer"
+              }
+            },
+            "required": ["quantity"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "uVariables",
+          "type": "object",
+          "label": "U Variables",
+          "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "uVariables": {
+                "title": "U Variables",
+                "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "dcCustomParams",
+          "type": "object",
+          "label": "Custom Parameters",
+          "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dcCustomParams": {
+                "title": "Custom Parameters",
+                "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/metadata.json
@@ -1,323 +1,196 @@
 {
+  "slug": "actions-google-campaign-manager",
   "name": "Google Tag for Campaign Manager",
-  "basicOptions": [
-    "advertiserId",
-    "allowAdPersonalizationSignals",
-    "conversionLinker",
-    "enableConsentMode",
-    "adUserDataConsentState",
-    "adPersonalizationConsentState",
-    "defaultAdsStorageConsentState",
-    "defaultAnalyticsStorageConsentState"
-  ],
-  "options": {
-    "advertiserId": {
-      "tags": [],
-      "default": "DC-",
-      "description": "In Campaign Manager, go to Floodlight -> Configuration, and Advertiser ID is located under the Configuration heading.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Advertiser ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The advertiserId property is required."]],
-      "uIMetadata": null
-    },
-    "allowAdPersonalizationSignals": {
-      "tags": [],
-      "default": true,
-      "description": "This feature can be disabled if you do not want the global site tag to allow personalized remarketing data for site users.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Allow Ad Personalization Signals",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The allowAdPersonalizationSignals property is required."]],
-      "uIMetadata": null
-    },
-    "conversionLinker": {
-      "tags": [],
-      "default": true,
-      "description": "This feature can be disabled if you do not want the global site tag to set first party cookies on your site domain.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Conversion Linker",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The conversionLinker property is required."]],
-      "uIMetadata": null
-    },
-    "enableConsentMode": {
-      "tags": [],
-      "default": false,
-      "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Consent Mode",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "adUserDataConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Ad User Data Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "advertiserId": {
+        "label": "Advertiser ID",
+        "description": "In Campaign Manager, go to Floodlight -> Configuration, and Advertiser ID is located under the Configuration heading.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": "DC-"
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "adPersonalizationConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Ad Personalization Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "allowAdPersonalizationSignals": {
+        "label": "Allow Ad Personalization Signals",
+        "description": "This feature can be disabled if you do not want the global site tag to allow personalized remarketing data for site users.",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "defaultAdsStorageConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Default Ads Storage Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "conversionLinker": {
+        "label": "Conversion Linker",
+        "description": "This feature can be disabled if you do not want the global site tag to set first party cookies on your site domain.",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "defaultAnalyticsStorageConsentState": {
-      "tags": [],
-      "default": "",
-      "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Default Analytics Storage Consent State",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "granted",
-          "label": "Granted",
-          "text": "Granted"
-        },
-        {
-          "value": "denied",
-          "label": "Denied",
-          "text": "Denied"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "enableConsentMode",
-            "operator": "is",
-            "value": true
-          }
-        ]
+      "enableConsentMode": {
+        "label": "Enable Consent Mode",
+        "description": "Set to true to enable Google’s [Consent Mode](https://support.google.com/analytics/answer/9976101?hl=en). Set to false by default.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
       },
-      "validators": [],
-      "uIMetadata": null
+      "adUserDataConsentState": {
+        "label": "Ad User Data Consent State",
+        "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      },
+      "adPersonalizationConsentState": {
+        "label": "Ad Personalization Consent State",
+        "description": "Consent state indicated by the user for ad cookies. Value must be \"granted\" or \"denied.\" This is only used if the Enable Consent Mode setting is on.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      },
+      "defaultAdsStorageConsentState": {
+        "label": "Default Ads Storage Consent State",
+        "description": "The default value for ad cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      },
+      "defaultAnalyticsStorageConsentState": {
+        "label": "Default Analytics Storage Consent State",
+        "description": "The default value for analytics cookies consent state. This is only used if Enable Consent Mode is on. Set to  “granted” if it is not explicitly set. Consent state can be updated for each user in the Set Configuration Fields action.",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "Granted",
+            "value": "granted"
+          },
+          {
+            "label": "Denied",
+            "value": "denied"
+          }
+        ],
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "counterActivity",
-      "name": "Counter Activity",
+  "audienceConfig": null,
+  "actions": {
+    "counterActivity": {
+      "title": "Counter Activity",
       "description": "Record non-monetary conversion data such as unique users, conversions, and session length.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "activityGroupTagString",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "activityGroupTagString": {
           "label": "Activity Group Tag String",
           "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "activityGroupTagString": {
-                "title": "Activity Group Tag String",
-                "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
-                "type": "string"
-              }
-            },
-            "required": ["activityGroupTagString"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "activityTagString",
-          "type": "string",
+        "activityTagString": {
           "label": "Activity Tag String",
           "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "activityTagString": {
-                "title": "Activity Tag String",
-                "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
-                "type": "string"
-              }
-            },
-            "required": ["activityTagString"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "enableDynamicTags",
-          "type": "boolean",
+        "enableDynamicTags": {
           "label": "Enable Dynamic Tags",
           "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enableDynamicTags": {
-                "title": "Enable Dynamic Tags",
-                "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "countingMethod",
-          "type": "string",
+        "countingMethod": {
           "label": "Counting Method",
           "description": "Specifies how conversions will be counted for this Floodlight activity.",
+          "type": "string",
           "required": true,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "value": "standard",
@@ -332,207 +205,164 @@
               "label": "Per Session"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "countingMethod": {
-                "title": "Counting Method",
-                "description": "Specifies how conversions will be counted for this Floodlight activity.",
-                "type": "string",
-                "enum": ["standard", "unique", "per_session"]
-              }
-            },
-            "required": ["countingMethod"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "sessionId",
-          "type": "string",
+        "sessionId": {
           "label": "Session ID",
           "description": "Use this field to insert a unique session ID if you’re using counter tags with a per session counting methodology. The session ID tells Campaign Manager 360 to count only one event per session on your site.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "sessionId": {
-                "title": "Session ID",
-                "description": "Use this field to insert a unique session ID if you’re using counter tags with a per session counting methodology. The session ID tells Campaign Manager 360 to count only one event per session on your site.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "uVariables",
-          "type": "object",
+        "uVariables": {
           "label": "U Variables",
           "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "uVariables": {
-                "title": "U Variables",
-                "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "dcCustomParams",
-          "type": "object",
+        "dcCustomParams": {
           "label": "Custom Parameters",
           "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "dcCustomParams": {
-                "title": "Custom Parameters",
-                "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "salesActivity",
-      "name": "Sales Activity",
+    "salesActivity": {
+      "title": "Sales Activity",
       "description": "Record monetary data for conversions, such as cost and the number of items sold.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "activityGroupTagString",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "activityGroupTagString": {
           "label": "Activity Group Tag String",
           "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "activityGroupTagString": {
-                "title": "Activity Group Tag String",
-                "description": "An identifier for the Floodlight activity group associated with this activity, which appears as a parameter in your tags. This value is case sensitive.",
-                "type": "string"
-              }
-            },
-            "required": ["activityGroupTagString"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "activityTagString",
-          "type": "string",
+        "activityTagString": {
           "label": "Activity Tag String",
           "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "activityTagString": {
-                "title": "Activity Tag String",
-                "description": "An identifier for your Floodlight activity, which appears as a parameter in your tags. This value is case sensitive.",
-                "type": "string"
-              }
-            },
-            "required": ["activityTagString"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "enableDynamicTags",
-          "type": "boolean",
+        "enableDynamicTags": {
           "label": "Enable Dynamic Tags",
           "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "enableDynamicTags": {
-                "title": "Enable Dynamic Tags",
-                "description": "In Campaign Manager, go to Floodlight -> Configuration, under Tags, if **Dynamic** is selected, select **True**.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "countingMethod",
-          "type": "string",
+        "countingMethod": {
           "label": "Counting Method",
           "description": "Specifies how conversions will be counted for this Floodlight activity.",
+          "type": "string",
           "required": true,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "value": "transactions",
@@ -543,171 +373,128 @@
               "label": "Items Sold"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "countingMethod": {
-                "title": "Counting Method",
-                "description": "Specifies how conversions will be counted for this Floodlight activity.",
-                "type": "string",
-                "enum": ["transactions", "items_sold"]
-              }
-            },
-            "required": ["countingMethod"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "transactionId",
-          "type": "string",
+        "transactionId": {
           "label": "Transaction ID",
           "description": "Use this field to insert a unique numerical identifier for each transaction.  Can be alphanumeric.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.order_id"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "transactionId": {
-                "title": "Transaction ID",
-                "description": "Use this field to insert a unique numerical identifier for each transaction.  Can be alphanumeric.",
-                "type": "string"
-              }
-            },
-            "required": ["transactionId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "value",
-          "type": "string",
+        "value": {
           "label": "Value",
           "description": "Use this field to pass the revenue generated by a transaction. Typically the purchase price and value does not include taxes or shipping.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.total"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "Use this field to pass the revenue generated by a transaction. Typically the purchase price and value does not include taxes or shipping.",
-                "type": "string"
-              }
-            },
-            "required": ["value"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "quantity",
-          "type": "integer",
+        "quantity": {
           "label": "Quantity",
           "description": "\n      Use this field to pass the number of items sold during a transaction:\n      - If you're counting each transaction as a single conversion, the value is 1.\n      - If you're counting each item sold during a single transaction as a separate conversion, insert the number of items sold as part of each transaction as the value.\n      - The value must be an integer greater than zero.\n      ",
+          "type": "integer",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "quantity": {
-                "title": "Quantity",
-                "description": "\n      Use this field to pass the number of items sold during a transaction:\n      - If you're counting each transaction as a single conversion, the value is 1.\n      - If you're counting each item sold during a single transaction as a separate conversion, insert the number of items sold as part of each transaction as the value.\n      - The value must be an integer greater than zero.\n      ",
-                "type": "integer"
-              }
-            },
-            "required": ["quantity"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "uVariables",
-          "type": "object",
+        "uVariables": {
           "label": "U Variables",
           "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "uVariables": {
-                "title": "U Variables",
-                "description": "Custom Floodlight variables enable you to capture information beyond the basics (visits and revenue) that you can collect with standard parameters in your tags.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "dcCustomParams",
-          "type": "object",
+        "dcCustomParams": {
           "label": "Custom Parameters",
           "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "dcCustomParams": {
-                "title": "Custom Parameters",
-                "description": "You can insert custom data into event snippets with the dc_custom_params field. This field accepts any values you want to pass to Google Marketing Platform.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/heap/metadata.json
+++ b/packages/browser-destinations/destinations/heap/metadata.json
@@ -10,56 +10,70 @@
         "description": "The app ID of the environment to which you want to send data. You can find this ID on the [Projects](https://heapanalytics.com/app/manage/projects) page.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "disableTextCapture": {
         "label": "Global data redaction via Disabling Text Capture",
         "description": "Setting to true will redact all target text on your website. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#global-data-redaction-via-disabling-text-capture).",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "secureCookie": {
         "label": "Secure Cookie",
         "description": "This option is turned off by default to accommodate websites not served over HTTPS. If your application uses HTTPS, we recommend enabling secure cookies to prevent Heap cookies from being observed by unauthorized parties. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#securecookie).",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "trackingServer": {
         "label": "Tracking Server (deprecated)",
         "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap). This field is deprecated in favor of `ingestServer`. If `trackingServer` is set and `ingestServer` is not set, then the Classic SDK will be loaded. If both are set, `ingestServer` will take precedence, and the latest stable version of the Heap SDK will be loaded.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "ingestServer": {
         "label": "Ingest Server",
         "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#ingestserver).",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "hostname": {
         "label": "Hostname",
         "description": "This is an optional setting used to set the host that loads the Heap SDK. This setting is used when the Heap SDK is self-hosted. In most cased this should be left unset. The hostname should not contain https or app id. When _both_ `hostname` and `trackingServer` are set, the Classic SDK will be loaded via: `https://${hostname}/js/heap-${appId}.js`. If `hostname` is set and `trackingServer` is not set, then the latest version of the Heap SDK will be loaded via: `https://${settings.hostname}/config/${settings.appId}/heap_config.js`. For more information visit the Heap [docs page](https://developers.heap.io/docs/self-hosting-heapjs).",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "browserArrayLimit": {
         "label": "Browser Array Limit",
         "description": "This is an optional setting. When set, nested array items will be sent in as new Heap events. Defaults to 0.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -73,7 +87,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -96,7 +110,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -119,7 +135,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "identity": {
           "label": "Identity",
@@ -140,7 +158,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -163,7 +183,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Properties",
@@ -186,7 +208,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -198,7 +222,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "Identity",
@@ -221,7 +245,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -244,7 +270,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/heap/metadata.json
+++ b/packages/browser-destinations/destinations/heap/metadata.json
@@ -1,377 +1,259 @@
 {
+  "slug": "actions-heap-web",
   "name": "Heap Web (Actions)",
-  "basicOptions": [
-    "appId",
-    "disableTextCapture",
-    "secureCookie",
-    "trackingServer",
-    "ingestServer",
-    "hostname",
-    "browserArrayLimit"
-  ],
-  "options": {
-    "appId": {
-      "tags": [],
-      "default": "",
-      "description": "The app ID of the environment to which you want to send data. You can find this ID on the [Projects](https://heapanalytics.com/app/manage/projects) page.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Heap app ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The appId property is required."]],
-      "uIMetadata": null
-    },
-    "disableTextCapture": {
-      "tags": [],
-      "default": false,
-      "description": "Setting to true will redact all target text on your website. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#global-data-redaction-via-disabling-text-capture).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Global data redaction via Disabling Text Capture",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "secureCookie": {
-      "tags": [],
-      "default": false,
-      "description": "This option is turned off by default to accommodate websites not served over HTTPS. If your application uses HTTPS, we recommend enabling secure cookies to prevent Heap cookies from being observed by unauthorized parties. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#securecookie).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Secure Cookie",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "trackingServer": {
-      "tags": [],
-      "default": "",
-      "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap). This field is deprecated in favor of `ingestServer`. If `trackingServer` is set and `ingestServer` is not set, then the Classic SDK will be loaded. If both are set, `ingestServer` will take precedence, and the latest stable version of the Heap SDK will be loaded.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Tracking Server (deprecated)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "ingestServer": {
-      "tags": [],
-      "default": "",
-      "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#ingestserver).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Ingest Server",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "hostname": {
-      "tags": [],
-      "default": "",
-      "description": "This is an optional setting used to set the host that loads the Heap SDK. This setting is used when the Heap SDK is self-hosted. In most cased this should be left unset. The hostname should not contain https or app id. When _both_ `hostname` and `trackingServer` are set, the Classic SDK will be loaded via: `https://${hostname}/js/heap-${appId}.js`. If `hostname` is set and `trackingServer` is not set, then the latest version of the Heap SDK will be loaded via: `https://${settings.hostname}/config/${settings.appId}/heap_config.js`. For more information visit the Heap [docs page](https://developers.heap.io/docs/self-hosting-heapjs).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Hostname",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "browserArrayLimit": {
-      "tags": [],
-      "default": 0,
-      "description": "This is an optional setting. When set, nested array items will be sent in as new Heap events. Defaults to 0.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Browser Array Limit",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "appId": {
+        "label": "Heap app ID",
+        "description": "The app ID of the environment to which you want to send data. You can find this ID on the [Projects](https://heapanalytics.com/app/manage/projects) page.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "disableTextCapture": {
+        "label": "Global data redaction via Disabling Text Capture",
+        "description": "Setting to true will redact all target text on your website. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#global-data-redaction-via-disabling-text-capture).",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "secureCookie": {
+        "label": "Secure Cookie",
+        "description": "This option is turned off by default to accommodate websites not served over HTTPS. If your application uses HTTPS, we recommend enabling secure cookies to prevent Heap cookies from being observed by unauthorized parties. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#securecookie).",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "trackingServer": {
+        "label": "Tracking Server (deprecated)",
+        "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap). This field is deprecated in favor of `ingestServer`. If `trackingServer` is set and `ingestServer` is not set, then the Classic SDK will be loaded. If both are set, `ingestServer` will take precedence, and the latest stable version of the Heap SDK will be loaded.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "ingestServer": {
+        "label": "Ingest Server",
+        "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#ingestserver).",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "hostname": {
+        "label": "Hostname",
+        "description": "This is an optional setting used to set the host that loads the Heap SDK. This setting is used when the Heap SDK is self-hosted. In most cased this should be left unset. The hostname should not contain https or app id. When _both_ `hostname` and `trackingServer` are set, the Classic SDK will be loaded via: `https://${hostname}/js/heap-${appId}.js`. If `hostname` is set and `trackingServer` is not set, then the latest version of the Heap SDK will be loaded via: `https://${settings.hostname}/config/${settings.appId}/heap_config.js`. For more information visit the Heap [docs page](https://developers.heap.io/docs/self-hosting-heapjs).",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "browserArrayLimit": {
+        "label": "Browser Array Limit",
+        "description": "This is an optional setting. When set, nested array items will be sent in as new Heap events. Defaults to 0.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Sets user identity",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "Identity",
-          "description": "The user's identity",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "Identity",
-                "description": "The user's identity",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "The Segment traits to be forwarded to Heap",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to Heap",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Track events",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "A JSON object containing additional information about the event that will be indexed by Heap.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing additional information about the event that will be indexed by Heap.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "identity",
-          "type": "string",
+        "identity": {
           "label": "Identity",
           "description": "a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "identity": {
-                "title": "Identity",
-                "description": "a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "The segment anonymous identifier for the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.anonymousId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The segment anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "User Properties",
-          "description": "An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.",
-          "defaultValue": {
-            "@path": "$.context.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Properties",
-                "description": "An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "userId": {
-          "@path": "$.userId"
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "User Properties",
+          "description": "An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
+      }
     },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Sets user identity",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "Identity",
+          "description": "The user's identity",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Heap",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -387,7 +269,22 @@
           "@path": "$.context.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/heap/metadata.json
+++ b/packages/browser-destinations/destinations/heap/metadata.json
@@ -1,0 +1,393 @@
+{
+  "name": "Heap Web (Actions)",
+  "basicOptions": [
+    "appId",
+    "disableTextCapture",
+    "secureCookie",
+    "trackingServer",
+    "ingestServer",
+    "hostname",
+    "browserArrayLimit"
+  ],
+  "options": {
+    "appId": {
+      "tags": [],
+      "default": "",
+      "description": "The app ID of the environment to which you want to send data. You can find this ID on the [Projects](https://heapanalytics.com/app/manage/projects) page.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Heap app ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The appId property is required."]],
+      "uIMetadata": null
+    },
+    "disableTextCapture": {
+      "tags": [],
+      "default": false,
+      "description": "Setting to true will redact all target text on your website. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#global-data-redaction-via-disabling-text-capture).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Global data redaction via Disabling Text Capture",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "secureCookie": {
+      "tags": [],
+      "default": false,
+      "description": "This option is turned off by default to accommodate websites not served over HTTPS. If your application uses HTTPS, we recommend enabling secure cookies to prevent Heap cookies from being observed by unauthorized parties. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#securecookie).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Secure Cookie",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "trackingServer": {
+      "tags": [],
+      "default": "",
+      "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/set-up-first-party-data-collection-in-heap). This field is deprecated in favor of `ingestServer`. If `trackingServer` is set and `ingestServer` is not set, then the Classic SDK will be loaded. If both are set, `ingestServer` will take precedence, and the latest stable version of the Heap SDK will be loaded.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Tracking Server (deprecated)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "ingestServer": {
+      "tags": [],
+      "default": "",
+      "description": "This is an optional setting. This is used to set up first-party data collection. For most cased this should not be set. For more information visit the Heap [docs page](https://developers.heap.io/docs/web#ingestserver).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Ingest Server",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "hostname": {
+      "tags": [],
+      "default": "",
+      "description": "This is an optional setting used to set the host that loads the Heap SDK. This setting is used when the Heap SDK is self-hosted. In most cased this should be left unset. The hostname should not contain https or app id. When _both_ `hostname` and `trackingServer` are set, the Classic SDK will be loaded via: `https://${hostname}/js/heap-${appId}.js`. If `hostname` is set and `trackingServer` is not set, then the latest version of the Heap SDK will be loaded via: `https://${settings.hostname}/config/${settings.appId}/heap_config.js`. For more information visit the Heap [docs page](https://developers.heap.io/docs/self-hosting-heapjs).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Hostname",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "browserArrayLimit": {
+      "tags": [],
+      "default": 0,
+      "description": "This is an optional setting. When set, nested array items will be sent in as new Heap events. Defaults to 0.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Browser Array Limit",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sets user identity",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "Identity",
+          "description": "The user's identity",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "Identity",
+                "description": "The user's identity",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Heap",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to Heap",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by Heap.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing additional information about the event that will be indexed by Heap.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "identity",
+          "type": "string",
+          "label": "Identity",
+          "description": "a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "identity": {
+                "title": "Identity",
+                "description": "a string that uniquely identifies a user, such as an email, handle, or username. This means no two users in one environment may share the same identity. More on identify: https://developers.heap.io/docs/using-identify",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The segment anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The segment anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Properties",
+          "description": "An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.",
+          "defaultValue": {
+            "@path": "$.context.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Properties",
+                "description": "An object with key-value properties you want associated with the user. Each property must either be a number or string with fewer than 1024 characters.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "traits": {
+          "@path": "$.context.traits"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/hubble-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubble-web/metadata.json
@@ -1,0 +1,302 @@
+{
+  "name": "Hubble (actions)",
+  "description": "From design to production, monitor, measure and enhance your user experience with seamless integration with Segment",
+  "basicOptions": ["id"],
+  "options": {
+    "id": {
+      "tags": [],
+      "default": "",
+      "description": "Unique identifier for your team (given in Hubble app)",
+      "encrypt": false,
+      "hidden": false,
+      "label": "id",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The id property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Set identifiers and attributes for a user",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifer of the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifer of the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier of the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier of the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "User Attributes (Traits)",
+          "description": "User traits used to enrich user identification",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributes": {
+                "title": "User Attributes (Traits)",
+                "description": "User traits used to enrich user identification",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "track",
+      "name": "Track",
+      "description": "Track events to trigger Hubble surveys",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "Event",
+          "description": "Event to be tracked",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "Event",
+                "description": "Event to be tracked",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "Event Attributes",
+          "description": "Object containing the attributes (properties) of the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributes": {
+                "title": "Event Attributes",
+                "description": "Object containing the attributes (properties) of the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifer of the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifer of the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier of the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier of the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identify",
+      "name": "Identify user",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "attributes": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "track",
+      "name": "Track event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event": {
+          "@path": "$.event"
+        },
+        "attributes": {
+          "@path": "$.properties"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/hubble-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubble-web/metadata.json
@@ -11,8 +11,10 @@
         "description": "Unique identifier for your team (given in Hubble app)",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -26,7 +28,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event": {
           "label": "Event",
@@ -49,7 +51,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "attributes": {
           "label": "Event Attributes",
@@ -72,7 +76,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -95,7 +101,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -118,7 +126,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -130,7 +140,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -153,7 +163,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -176,7 +188,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "attributes": {
           "label": "User Attributes (Traits)",
@@ -199,7 +213,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/hubble-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubble-web/metadata.json
@@ -1,269 +1,214 @@
 {
+  "slug": "hubble-web",
   "name": "Hubble (actions)",
+  "mode": "device",
   "description": "From design to production, monitor, measure and enhance your user experience with seamless integration with Segment",
-  "basicOptions": ["id"],
-  "options": {
-    "id": {
-      "tags": [],
-      "default": "",
-      "description": "Unique identifier for your team (given in Hubble app)",
-      "encrypt": false,
-      "hidden": false,
-      "label": "id",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The id property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "id": {
+        "label": "id",
+        "description": "Unique identifier for your team (given in Hubble app)",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identify",
-      "name": "Identify",
-      "description": "Set identifiers and attributes for a user",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "Unique identifer of the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifer of the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "Anonymous identifier of the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier of the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "attributes",
-          "type": "object",
-          "label": "User Attributes (Traits)",
-          "description": "User traits used to enrich user identification",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributes": {
-                "title": "User Attributes (Traits)",
-                "description": "User traits used to enrich user identification",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "track",
-      "name": "Track",
+  "audienceConfig": null,
+  "actions": {
+    "track": {
+      "title": "Track",
       "description": "Track events to trigger Hubble surveys",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event": {
           "label": "Event",
           "description": "Event to be tracked",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "Event",
-                "description": "Event to be tracked",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "attributes",
-          "type": "object",
+        "attributes": {
           "label": "Event Attributes",
           "description": "Object containing the attributes (properties) of the event",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributes": {
-                "title": "Event Attributes",
-                "description": "Object containing the attributes (properties) of the event",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "Unique identifer of the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifer of the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "Anonymous identifier of the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier of the user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identify": {
+      "title": "Identify",
+      "description": "Set identifiers and attributes for a user",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "User ID",
+          "description": "Unique identifer of the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier of the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "attributes": {
+          "label": "User Attributes (Traits)",
+          "description": "User traits used to enrich user identification",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identify",
       "name": "Identify user",
+      "type": "automatic",
+      "partnerAction": "identify",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -276,11 +221,12 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "track",
       "name": "Track event",
+      "type": "automatic",
+      "partnerAction": "track",
       "subscribe": "type = \"track\"",
       "mapping": {
         "event": {
@@ -296,7 +242,7 @@
           "@path": "$.anonymousId"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/hubspot-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubspot-web/metadata.json
@@ -1,0 +1,563 @@
+{
+  "name": "Hubspot Web (Actions)",
+  "basicOptions": [
+    "portalId",
+    "enableEuropeanDataCenter",
+    "flushIdentifyImmediately",
+    "formatCustomBehavioralEventNames",
+    "loadFormsSDK"
+  ],
+  "options": {
+    "portalId": {
+      "tags": [],
+      "default": "",
+      "description": "The Hub ID of your HubSpot account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Hub ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The portalId property is required."]],
+      "uIMetadata": null
+    },
+    "enableEuropeanDataCenter": {
+      "tags": [],
+      "default": false,
+      "description": "Enable this option if you would like Segment to load the HubSpot SDK for EU data residency.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable the European Data Center SDK.",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "flushIdentifyImmediately": {
+      "tags": [],
+      "default": false,
+      "description": "Enable this option to fire a `trackPageView` HubSpot event immediately after each Segment `identify` call to flush the data to HubSpot immediately.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Flush Identify Calls Immediately",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "formatCustomBehavioralEventNames": {
+      "tags": [],
+      "default": true,
+      "description": "Format the event names for custom behavioral event automatically to standard HubSpot format (`pe<HubID>_event_name`).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Format Custom Behavioral Event Names",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "loadFormsSDK": {
+      "tags": [],
+      "default": false,
+      "description": "Enable this option if you would like Segment to automatically load the HubSpot Forms SDK onto your site.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Load Forms SDK",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "trackCustomBehavioralEvent",
+      "name": "Track Custom Behavioral Event",
+      "description": "Send a custom behavioral event to HubSpot.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The internal event name assigned by HubSpot. This can be found in your HubSpot account. If the \"Format Custom Behavioral Event Names\" setting is enabled, Segment will automatically convert your Segment event name into the expected HubSpot internal event name format.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event Name",
+                "description": "The internal event name assigned by HubSpot. This can be found in your HubSpot account. If the \"Format Custom Behavioral Event Names\" setting is enabled, Segment will automatically convert your Segment event name into the expected HubSpot internal event name format.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "A list of key-value pairs that describe the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "A list of key-value pairs that describe the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPageView",
+      "name": "Track Page View",
+      "description": "Track the page view for the current page in HubSpot.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "path",
+          "type": "string",
+          "label": "Path String",
+          "description": "The path of the current page. The set path will be treated as relative to the current domain being viewed.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "title": "Path String",
+                "description": "The path of the current page. The set path will be treated as relative to the current domain being viewed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "upsertContact",
+      "name": "Upsert Contact",
+      "description": "Create or update a contact in HubSpot.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email Address",
+          "description": "The contact’s email. Email is used to uniquely identify contact records in HubSpot and create or update the contact accordingly.",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email Address",
+                "description": "The contact’s email. Email is used to uniquely identify contact records in HubSpot and create or update the contact accordingly.",
+                "type": "string"
+              }
+            },
+            "required": ["email"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "id",
+          "type": "string",
+          "label": "External ID",
+          "description": "A custom external ID that identifies the visitor.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "title": "External ID",
+                "description": "A custom external ID that identifies the visitor.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "custom_properties",
+          "type": "object",
+          "label": "Custom Properties",
+          "description": "A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "custom_properties": {
+                "title": "Custom Properties",
+                "description": "A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "company",
+          "type": "string",
+          "label": "Company Name",
+          "description": "The name of the company the contact is associated with.",
+          "defaultValue": {
+            "@path": "$.traits.company.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "company": {
+                "title": "Company Name",
+                "description": "The name of the company the contact is associated with.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "country",
+          "type": "string",
+          "label": "Country",
+          "description": "The name of the country the contact is associated with.",
+          "defaultValue": {
+            "@path": "$.traits.address.country"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "country": {
+                "title": "Country",
+                "description": "The name of the country the contact is associated with.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "state",
+          "type": "string",
+          "label": "State",
+          "description": "The name of the state the contact is associated with.",
+          "defaultValue": {
+            "@path": "$.traits.address.state"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "state": {
+                "title": "State",
+                "description": "The name of the state the contact is associated with.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "city",
+          "type": "string",
+          "label": "City",
+          "description": "The name of the city the contact is associated with.",
+          "defaultValue": {
+            "@path": "$.traits.address.city"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "city": {
+                "title": "City",
+                "description": "The name of the city the contact is associated with.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "address",
+          "type": "string",
+          "label": "Street Address",
+          "description": "The street address of the contact.",
+          "defaultValue": {
+            "@path": "$.traits.address.street"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "title": "Street Address",
+                "description": "The street address of the contact.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "zip",
+          "type": "string",
+          "label": "Postal Code",
+          "description": "The postal code of the contact.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits.address.postalCode"
+              },
+              "then": {
+                "@path": "$.traits.address.postalCode"
+              },
+              "else": {
+                "@path": "$.traits.address.postal_code"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "zip": {
+                "title": "Postal Code",
+                "description": "The postal code of the contact.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "trackCustomBehavioralEvent",
+      "name": "Track Custom Behavioral Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPageView",
+      "name": "Track Page View",
+      "subscribe": "type = \"page\"",
+      "mapping": {},
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "upsertContact",
+      "name": "Upsert Contact",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "id": {
+          "@path": "$.userId"
+        },
+        "custom_properties": {
+          "@path": "$.traits"
+        },
+        "company": {
+          "@path": "$.traits.company.name"
+        },
+        "country": {
+          "@path": "$.traits.address.country"
+        },
+        "state": {
+          "@path": "$.traits.address.state"
+        },
+        "city": {
+          "@path": "$.traits.address.city"
+        },
+        "address": {
+          "@path": "$.traits.address.street"
+        },
+        "zip": {
+          "@if": {
+            "exists": {
+              "@path": "$.traits.address.postalCode"
+            },
+            "then": {
+              "@path": "$.traits.address.postalCode"
+            },
+            "else": {
+              "@path": "$.traits.address.postal_code"
+            }
+          }
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/hubspot-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubspot-web/metadata.json
@@ -1,460 +1,348 @@
 {
+  "slug": "actions-hubspot-web",
   "name": "Hubspot Web (Actions)",
-  "basicOptions": [
-    "portalId",
-    "enableEuropeanDataCenter",
-    "flushIdentifyImmediately",
-    "formatCustomBehavioralEventNames",
-    "loadFormsSDK"
-  ],
-  "options": {
-    "portalId": {
-      "tags": [],
-      "default": "",
-      "description": "The Hub ID of your HubSpot account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Hub ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The portalId property is required."]],
-      "uIMetadata": null
-    },
-    "enableEuropeanDataCenter": {
-      "tags": [],
-      "default": false,
-      "description": "Enable this option if you would like Segment to load the HubSpot SDK for EU data residency.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable the European Data Center SDK.",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "flushIdentifyImmediately": {
-      "tags": [],
-      "default": false,
-      "description": "Enable this option to fire a `trackPageView` HubSpot event immediately after each Segment `identify` call to flush the data to HubSpot immediately.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Flush Identify Calls Immediately",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "formatCustomBehavioralEventNames": {
-      "tags": [],
-      "default": true,
-      "description": "Format the event names for custom behavioral event automatically to standard HubSpot format (`pe<HubID>_event_name`).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Format Custom Behavioral Event Names",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "loadFormsSDK": {
-      "tags": [],
-      "default": false,
-      "description": "Enable this option if you would like Segment to automatically load the HubSpot Forms SDK onto your site.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Load Forms SDK",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "portalId": {
+        "label": "Hub ID",
+        "description": "The Hub ID of your HubSpot account.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "enableEuropeanDataCenter": {
+        "label": "Enable the European Data Center SDK.",
+        "description": "Enable this option if you would like Segment to load the HubSpot SDK for EU data residency.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "flushIdentifyImmediately": {
+        "label": "Flush Identify Calls Immediately",
+        "description": "Enable this option to fire a `trackPageView` HubSpot event immediately after each Segment `identify` call to flush the data to HubSpot immediately.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "formatCustomBehavioralEventNames": {
+        "label": "Format Custom Behavioral Event Names",
+        "description": "Format the event names for custom behavioral event automatically to standard HubSpot format (`pe<HubID>_event_name`).",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "loadFormsSDK": {
+        "label": "Load Forms SDK",
+        "description": "Enable this option if you would like Segment to automatically load the HubSpot Forms SDK onto your site.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "trackCustomBehavioralEvent",
-      "name": "Track Custom Behavioral Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackCustomBehavioralEvent": {
+      "title": "Track Custom Behavioral Event",
       "description": "Send a custom behavioral event to HubSpot.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event Name",
           "description": "The internal event name assigned by HubSpot. This can be found in your HubSpot account. If the \"Format Custom Behavioral Event Names\" setting is enabled, Segment will automatically convert your Segment event name into the expected HubSpot internal event name format.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.event"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event Name",
-                "description": "The internal event name assigned by HubSpot. This can be found in your HubSpot account. If the \"Format Custom Behavioral Event Names\" setting is enabled, Segment will automatically convert your Segment event name into the expected HubSpot internal event name format.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "A list of key-value pairs that describe the event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "A list of key-value pairs that describe the event.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackPageView",
-      "name": "Track Page View",
+    "trackPageView": {
+      "title": "Track Page View",
       "description": "Track the page view for the current page in HubSpot.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "path",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "path": {
           "label": "Path String",
           "description": "The path of the current page. The set path will be treated as relative to the current domain being viewed.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "path": {
-                "title": "Path String",
-                "description": "The path of the current page. The set path will be treated as relative to the current domain being viewed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "upsertContact",
-      "name": "Upsert Contact",
+    "upsertContact": {
+      "title": "Upsert Contact",
       "description": "Create or update a contact in HubSpot.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "email",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "email": {
           "label": "Email Address",
           "description": "The contact’s email. Email is used to uniquely identify contact records in HubSpot and create or update the contact accordingly.",
-          "defaultValue": {
-            "@path": "$.traits.email"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email Address",
-                "description": "The contact’s email. Email is used to uniquely identify contact records in HubSpot and create or update the contact accordingly.",
-                "type": "string"
-              }
-            },
-            "required": ["email"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.email"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "id",
-          "type": "string",
+        "id": {
           "label": "External ID",
           "description": "A custom external ID that identifies the visitor.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "id": {
-                "title": "External ID",
-                "description": "A custom external ID that identifies the visitor.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "custom_properties",
-          "type": "object",
+        "custom_properties": {
           "label": "Custom Properties",
           "description": "A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_properties": {
-                "title": "Custom Properties",
-                "description": "A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "company",
-          "type": "string",
+        "company": {
           "label": "Company Name",
           "description": "The name of the company the contact is associated with.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.company.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "company": {
-                "title": "Company Name",
-                "description": "The name of the company the contact is associated with.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "country",
-          "type": "string",
+        "country": {
           "label": "Country",
           "description": "The name of the country the contact is associated with.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.country"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "title": "Country",
-                "description": "The name of the country the contact is associated with.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "state",
-          "type": "string",
+        "state": {
           "label": "State",
           "description": "The name of the state the contact is associated with.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.state"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "state": {
-                "title": "State",
-                "description": "The name of the state the contact is associated with.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "city",
-          "type": "string",
+        "city": {
           "label": "City",
           "description": "The name of the city the contact is associated with.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.address.city"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "city": {
-                "title": "City",
-                "description": "The name of the city the contact is associated with.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "address",
-          "type": "string",
+        "address": {
           "label": "Street Address",
           "description": "The street address of the contact.",
-          "defaultValue": {
-            "@path": "$.traits.address.street"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "address": {
-                "title": "Street Address",
-                "description": "The street address of the contact.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.address.street"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "zip",
-          "type": "string",
+        "zip": {
           "label": "Postal Code",
           "description": "The postal code of the contact.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.traits.address.postalCode"
@@ -467,35 +355,26 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "zip": {
-                "title": "Postal Code",
-                "description": "The postal code of the contact.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "trackCustomBehavioralEvent",
       "name": "Track Custom Behavioral Event",
+      "type": "automatic",
+      "partnerAction": "trackCustomBehavioralEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -505,18 +384,12 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackPageView",
-      "name": "Track Page View",
-      "subscribe": "type = \"page\"",
-      "mapping": {},
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "upsertContact",
       "name": "Upsert Contact",
+      "type": "automatic",
+      "partnerAction": "upsertContact",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "email": {
@@ -557,7 +430,15 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Track Page View",
+      "type": "automatic",
+      "partnerAction": "trackPageView",
+      "subscribe": "type = \"page\"",
+      "mapping": {},
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/hubspot-web/metadata.json
+++ b/packages/browser-destinations/destinations/hubspot-web/metadata.json
@@ -10,40 +10,50 @@
         "description": "The Hub ID of your HubSpot account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "enableEuropeanDataCenter": {
         "label": "Enable the European Data Center SDK.",
         "description": "Enable this option if you would like Segment to load the HubSpot SDK for EU data residency.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "flushIdentifyImmediately": {
         "label": "Flush Identify Calls Immediately",
         "description": "Enable this option to fire a `trackPageView` HubSpot event immediately after each Segment `identify` call to flush the data to HubSpot immediately.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "formatCustomBehavioralEventNames": {
         "label": "Format Custom Behavioral Event Names",
         "description": "Format the event names for custom behavioral event automatically to standard HubSpot format (`pe<HubID>_event_name`).",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "loadFormsSDK": {
         "label": "Load Forms SDK",
         "description": "Enable this option if you would like Segment to automatically load the HubSpot Forms SDK onto your site.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -57,7 +67,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event Name",
@@ -80,7 +90,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -103,7 +115,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -115,7 +129,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "path": {
           "label": "Path String",
@@ -136,7 +150,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -148,7 +164,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "email": {
           "label": "Email Address",
@@ -171,7 +187,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "id": {
           "label": "External ID",
@@ -194,7 +212,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "custom_properties": {
           "label": "Custom Properties",
@@ -217,7 +237,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "company": {
           "label": "Company Name",
@@ -240,7 +262,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "country": {
           "label": "Country",
@@ -263,7 +287,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "state": {
           "label": "State",
@@ -286,7 +312,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "city": {
           "label": "City",
@@ -309,7 +337,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "address": {
           "label": "Street Address",
@@ -332,7 +362,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "zip": {
           "label": "Postal Code",
@@ -365,7 +397,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/intercom/metadata.json
+++ b/packages/browser-destinations/destinations/intercom/metadata.json
@@ -1,475 +1,337 @@
 {
+  "slug": "actions-intercom-web",
   "name": "Intercom Web (Actions)",
-  "basicOptions": ["appId", "activator", "richLinkProperties", "apiBase"],
-  "options": {
-    "appId": {
-      "tags": [],
-      "default": "",
-      "description": "The app_id of your Intercom app which will indicate where to store any data.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "App ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The appId property is required."]],
-      "uIMetadata": null
-    },
-    "activator": {
-      "tags": [],
-      "default": "#IntercomDefaultWidget",
-      "description": "By default, Intercom will inject their own inbox button onto the page, but you can choose to use your own custom button instead by providing a CSS selector, e.g. #my-button. You must have the \"Show the Intercom Inbox\" setting enabled for this to work. The default value is #IntercomDefaultWidget.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Custom Inbox Button Selector",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "richLinkProperties": {
-      "tags": [],
-      "default": "",
-      "description": "A list of rich link property keys.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Rich Link Properties",
-      "private": false,
-      "scope": "event_destination",
-      "type": "array",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "apiBase": {
-      "tags": [],
-      "default": "https://api-iam.intercom.io",
-      "description": "The regional API to use for processing the data",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Regional Data Hosting",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "https://api-iam.intercom.io",
-          "label": "US",
-          "text": "US"
-        },
-        {
-          "value": "https://api-iam.eu.intercom.io",
-          "label": "EU",
-          "text": "EU"
-        },
-        {
-          "value": "https://api-iam.au.intercom.io",
-          "label": "Australia",
-          "text": "Australia"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "appId": {
+        "label": "App ID",
+        "description": "The app_id of your Intercom app which will indicate where to store any data.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "activator": {
+        "label": "Custom Inbox Button Selector",
+        "description": "By default, Intercom will inject their own inbox button onto the page, but you can choose to use your own custom button instead by providing a CSS selector, e.g. #my-button. You must have the \"Show the Intercom Inbox\" setting enabled for this to work. The default value is #IntercomDefaultWidget.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "#IntercomDefaultWidget"
+      },
+      "richLinkProperties": {
+        "label": "Rich Link Properties",
+        "description": "A list of rich link property keys.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "apiBase": {
+        "label": "Regional Data Hosting",
+        "description": "The regional API to use for processing the data",
+        "type": "string",
+        "required": false,
+        "choices": [
+          {
+            "label": "US",
+            "value": "https://api-iam.intercom.io"
+          },
+          {
+            "label": "EU",
+            "value": "https://api-iam.eu.intercom.io"
+          },
+          {
+            "label": "Australia",
+            "value": "https://api-iam.au.intercom.io"
+          }
+        ],
+        "default": "https://api-iam.intercom.io"
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyCompany",
-      "name": "Identify Company",
-      "description": "Create or update a company in Intercom.",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Submit an event to Intercom.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "company",
-          "type": "object",
-          "label": "Company",
-          "description": "The user's company.",
-          "defaultValue": {
-            "company_id": {
-              "@path": "$.groupId"
-            },
-            "name": {
-              "@path": "$.traits.name"
-            },
-            "created_at": {
-              "@if": {
-                "exists": {
-                  "@path": "$.traits.createdAt"
-                },
-                "then": {
-                  "@path": "$.traits.createdAt"
-                },
-                "else": {
-                  "@path": "$.traits.created_at"
-                }
-              }
-            },
-            "plan": {
-              "@path": "$.traits.plan"
-            },
-            "size": {
-              "@path": "$.traits.size"
-            },
-            "website": {
-              "@path": "$.traits.website"
-            },
-            "industry": {
-              "@path": "$.traits.industry"
-            },
-            "monthly_spend": {
-              "@path": "$.traits.monthly_spend"
-            }
-          },
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "company": {
-                "title": "Company",
-                "description": "The user's company.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "company_id": {
-                    "title": "Company ID",
-                    "description": "The unique identifier of the company.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "title": "Company Name",
-                    "description": "The name of the company.",
-                    "type": "string"
-                  },
-                  "created_at": {
-                    "title": "Company Creation Time",
-                    "description": "The time the company was created in your system.",
-                    "type": ["string", "number"],
-                    "format": "date-like"
-                  },
-                  "plan": {
-                    "title": "Company Plan",
-                    "description": "The name of the plan you have associated with the company.",
-                    "type": "string"
-                  },
-                  "monthly_spend": {
-                    "title": "Monthly Spend",
-                    "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
-                    "type": "integer"
-                  },
-                  "size": {
-                    "title": "Company Size",
-                    "description": "The number of employees in the company.",
-                    "type": "integer"
-                  },
-                  "website": {
-                    "title": "Company Website",
-                    "description": "The URL for the company website.",
-                    "type": "string"
-                  },
-                  "industry": {
-                    "title": "Industry",
-                    "description": "The industry that the company operates in.",
-                    "type": "string"
-                  },
-                  "company_custom_traits": {
-                    "title": "Company Custom Attributes",
-                    "description": "The custom attributes for the company object.",
-                    "type": "object"
-                  }
-                },
-                "required": ["company_id", "name"]
-              }
-            },
-            "required": ["company"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "hide_default_launcher",
-          "type": "boolean",
-          "label": "Hide Default Launcher",
-          "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.Intercom.hideDefaultLauncher"
-              },
-              "then": {
-                "@path": "$.context.Intercom.hideDefaultLauncher"
-              },
-              "else": {
-                "@path": "$.context.Intercom.hide_default_launcher"
-              }
-            }
-          },
+        "revenue": {
+          "label": "Revenue",
+          "description": "The amount associated with a purchase. Segment will multiply by 100 as Intercom requires the amount in cents.",
+          "type": "number",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "hide_default_launcher": {
-                "title": "Hide Default Launcher",
-                "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
-                "type": "boolean"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.revenue"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "currency": {
+          "label": "Currency",
+          "description": "The currency of the purchase amount. Segment will default to USD if revenue is provided without a currency.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "event_metadata": {
+          "label": "Event Metadata",
+          "description": "Optional metadata describing the event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Create or update a user in Intercom.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\" or type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\" or type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "user_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "user_id": {
           "label": "User ID",
           "description": "A unique identifier for the user.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_id": {
-                "title": "User ID",
-                "description": "A unique identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "custom_traits",
-          "type": "object",
+        "custom_traits": {
           "label": "Custom Attributes",
           "description": "The user's custom attributes.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_traits": {
-                "title": "Custom Attributes",
-                "description": "The user's custom attributes.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "name",
-          "type": "string",
+        "name": {
           "label": "Name",
           "description": "The user's name.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.name"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The user's name.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "phone",
-          "type": "string",
+        "phone": {
           "label": "Phone Number",
           "description": "The user's phone number.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.phone"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "phone": {
-                "title": "Phone Number",
-                "description": "The user's phone number.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "unsubscribed_from_emails",
-          "type": "boolean",
+        "unsubscribed_from_emails": {
           "label": "Unsubscribed From Emails",
           "description": "The user's email unsubscribe status.",
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "unsubscribed_from_emails": {
-                "title": "Unsubscribed From Emails",
-                "description": "The user's email unsubscribe status.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "language_override",
-          "type": "string",
+        "language_override": {
           "label": "Language Override",
           "description": "The user's messenger language (instead of relying on browser language settings).",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "language_override": {
-                "title": "Language Override",
-                "description": "The user's messenger language (instead of relying on browser language settings).",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email Address",
           "description": "The user's email address.",
-          "defaultValue": {
-            "@path": "$.traits.email"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email Address",
-                "description": "The user's email address.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.email"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "created_at",
-          "type": "datetime",
+        "created_at": {
           "label": "User Creation Time",
           "description": "The time the user was created in your system.",
-          "defaultValue": {
+          "type": "datetime",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.traits.createdAt"
@@ -482,65 +344,50 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "created_at": {
-                "title": "User Creation Time",
-                "description": "The time the user was created in your system.",
-                "type": ["string", "number"],
-                "format": "date-like"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "avatar_image_url",
-          "type": "string",
+        "avatar_image_url": {
           "label": "Avatar",
           "description": "The URL for the user's avatar/profile image.",
-          "defaultValue": {
-            "@path": "$.traits.avatar"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "avatar_image_url": {
-                "title": "Avatar",
-                "description": "The URL for the user's avatar/profile image.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.avatar"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_hash",
-          "type": "string",
+        "user_hash": {
           "label": "User Hash",
           "description": "The user hash used for identity verification. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.integrations.Intercom.user_hash"
@@ -553,34 +400,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_hash": {
-                "title": "User Hash",
-                "description": "The user hash used for identity verification. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "intercom_user_jwt",
-          "type": "string",
+        "intercom_user_jwt": {
           "label": "Intercom User JWT",
           "description": "The intercom user JWT is used to secure your messenger for your users. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.integrations.Intercom.intercom_user_jwt"
@@ -593,34 +433,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "intercom_user_jwt": {
-                "title": "Intercom User JWT",
-                "description": "The intercom user JWT is used to secure your messenger for your users. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "company",
-          "type": "object",
+        "company": {
           "label": "Company",
           "description": "The user's company.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "company_id": {
               "@path": "$.traits.company.id"
             },
@@ -656,85 +489,217 @@
               "@path": "$.traits.company.monthly_spend"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "company": {
-                "title": "Company",
-                "description": "The user's company.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "company_id": {
-                    "title": "Company ID",
-                    "description": "The unique identifier of the company.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "title": "Company Name",
-                    "description": "The name of the company.",
-                    "type": "string"
-                  },
-                  "created_at": {
-                    "title": "Company Creation Time",
-                    "description": "The time the company was created in your system.",
-                    "type": ["string", "number"],
-                    "format": "date-like"
-                  },
-                  "plan": {
-                    "title": "Company Plan",
-                    "description": "The name of the plan you have associated with the company.",
-                    "type": "string"
-                  },
-                  "monthly_spend": {
-                    "title": "Monthly Spend",
-                    "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
-                    "type": "integer"
-                  },
-                  "size": {
-                    "title": "Company Size",
-                    "description": "The number of employees in the company.",
-                    "type": "integer"
-                  },
-                  "website": {
-                    "title": "Company Website",
-                    "description": "The URL for the company website.",
-                    "type": "string"
-                  },
-                  "industry": {
-                    "title": "Industry",
-                    "description": "The industry that the company operates in.",
-                    "type": "string"
-                  },
-                  "company_custom_traits": {
-                    "title": "Company Custom Attributes",
-                    "description": "The custom attributes for the company object.",
-                    "type": "object"
-                  }
-                },
-                "required": ["company_id", "name"]
-              }
+          "placeholder": null,
+          "properties": {
+            "company_id": {
+              "label": "Company ID",
+              "description": "The unique identifier of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "name": {
+              "label": "Company Name",
+              "description": "The name of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created_at": {
+              "label": "Company Creation Time",
+              "description": "The time the company was created in your system.",
+              "type": "datetime",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "plan": {
+              "label": "Company Plan",
+              "description": "The name of the plan you have associated with the company.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "monthly_spend": {
+              "label": "Monthly Spend",
+              "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "size": {
+              "label": "Company Size",
+              "description": "The number of employees in the company.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "website": {
+              "label": "Company Website",
+              "description": "The URL for the company website.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "industry": {
+              "label": "Industry",
+              "description": "The industry that the company operates in.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "company_custom_traits": {
+              "label": "Company Custom Attributes",
+              "description": "The custom attributes for the company object.",
+              "type": "object",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": "keyvalue",
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "companies",
-          "type": "object",
+        "companies": {
           "label": "Companies",
           "description": "The array of companies the user is associated to.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.traits.companies",
               {
@@ -775,88 +740,217 @@
               }
             ]
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "companies": {
-                "title": "Companies",
-                "description": "The array of companies the user is associated to.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "company_id": {
-                      "title": "Company ID",
-                      "description": "The unique identifier of the company.",
-                      "type": "string"
-                    },
-                    "name": {
-                      "title": "Company Name",
-                      "description": "The name of the company.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "title": "Company Creation Time",
-                      "description": "The time the company was created in your system.",
-                      "type": ["string", "number"],
-                      "format": "date-like"
-                    },
-                    "plan": {
-                      "title": "Company Plan",
-                      "description": "The name of the plan you have associated with the company.",
-                      "type": "string"
-                    },
-                    "monthly_spend": {
-                      "title": "Monthly Spend",
-                      "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
-                      "type": "integer"
-                    },
-                    "size": {
-                      "title": "Company Size",
-                      "description": "The number of employees in the company.",
-                      "type": "integer"
-                    },
-                    "website": {
-                      "title": "Company Website",
-                      "description": "The URL for the company website.",
-                      "type": "string"
-                    },
-                    "industry": {
-                      "title": "Industry",
-                      "description": "The industry that the company operates in.",
-                      "type": "string"
-                    },
-                    "company_custom_traits": {
-                      "title": "Company Custom Attributes",
-                      "description": "The custom attributes for the company object.",
-                      "type": "object"
-                    }
-                  },
-                  "required": ["company_id", "name"]
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "company_id": {
+              "label": "Company ID",
+              "description": "The unique identifier of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "name": {
+              "label": "Company Name",
+              "description": "The name of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created_at": {
+              "label": "Company Creation Time",
+              "description": "The time the company was created in your system.",
+              "type": "datetime",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "plan": {
+              "label": "Company Plan",
+              "description": "The name of the plan you have associated with the company.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "monthly_spend": {
+              "label": "Monthly Spend",
+              "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "size": {
+              "label": "Company Size",
+              "description": "The number of employees in the company.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "website": {
+              "label": "Company Website",
+              "description": "The URL for the company website.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "industry": {
+              "label": "Industry",
+              "description": "The industry that the company operates in.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "company_custom_traits": {
+              "label": "Company Custom Attributes",
+              "description": "The custom attributes for the company object.",
+              "type": "object",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": "keyvalue",
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "hide_default_launcher",
-          "type": "boolean",
+        "hide_default_launcher": {
           "label": "Hide Default Launcher",
           "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
-          "defaultValue": {
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.context.Intercom.hideDefaultLauncher"
@@ -869,222 +963,338 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "hide_default_launcher": {
-                "title": "Hide Default Launcher",
-                "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Submit an event to Intercom.",
+    "identifyCompany": {
+      "title": "Identify Company",
+      "description": "Create or update a company in Intercom.",
       "platform": "web",
+      "defaultSubscription": "type = \"group\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "company": {
+          "label": "Company",
+          "description": "The user's company.",
+          "type": "object",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event.",
-                "type": "string"
+          "dynamic": false,
+          "default": {
+            "company_id": {
+              "@path": "$.groupId"
+            },
+            "name": {
+              "@path": "$.traits.name"
+            },
+            "created_at": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.createdAt"
+                },
+                "then": {
+                  "@path": "$.traits.createdAt"
+                },
+                "else": {
+                  "@path": "$.traits.created_at"
+                }
               }
             },
-            "required": ["event_name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "revenue",
-          "type": "number",
-          "label": "Revenue",
-          "description": "The amount associated with a purchase. Segment will multiply by 100 as Intercom requires the amount in cents.",
-          "defaultValue": {
-            "@path": "$.properties.revenue"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "revenue": {
-                "title": "Revenue",
-                "description": "The amount associated with a purchase. Segment will multiply by 100 as Intercom requires the amount in cents.",
-                "type": "number"
-              }
+            "plan": {
+              "@path": "$.traits.plan"
             },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "currency",
-          "type": "string",
-          "label": "Currency",
-          "description": "The currency of the purchase amount. Segment will default to USD if revenue is provided without a currency.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "The currency of the purchase amount. Segment will default to USD if revenue is provided without a currency.",
-                "type": "string"
-              }
+            "size": {
+              "@path": "$.traits.size"
             },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "event_metadata",
-          "type": "object",
-          "label": "Event Metadata",
-          "description": "Optional metadata describing the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_metadata": {
-                "title": "Event Metadata",
-                "description": "Optional metadata describing the event.",
-                "type": "object"
-              }
+            "website": {
+              "@path": "$.traits.website"
             },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyCompany",
-      "name": "Identify Company",
-      "subscribe": "type = \"group\"",
-      "mapping": {
-        "company": {
-          "company_id": {
-            "@path": "$.groupId"
-          },
-          "name": {
-            "@path": "$.traits.name"
-          },
-          "created_at": {
-            "@if": {
-              "exists": {
-                "@path": "$.traits.createdAt"
-              },
-              "then": {
-                "@path": "$.traits.createdAt"
-              },
-              "else": {
-                "@path": "$.traits.created_at"
-              }
+            "industry": {
+              "@path": "$.traits.industry"
+            },
+            "monthly_spend": {
+              "@path": "$.traits.monthly_spend"
             }
           },
-          "plan": {
-            "@path": "$.traits.plan"
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "company_id": {
+              "label": "Company ID",
+              "description": "The unique identifier of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "name": {
+              "label": "Company Name",
+              "description": "The name of the company.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created_at": {
+              "label": "Company Creation Time",
+              "description": "The time the company was created in your system.",
+              "type": "datetime",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "plan": {
+              "label": "Company Plan",
+              "description": "The name of the plan you have associated with the company.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "monthly_spend": {
+              "label": "Monthly Spend",
+              "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "size": {
+              "label": "Company Size",
+              "description": "The number of employees in the company.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "website": {
+              "label": "Company Website",
+              "description": "The URL for the company website.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "industry": {
+              "label": "Industry",
+              "description": "The industry that the company operates in.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "company_custom_traits": {
+              "label": "Company Custom Attributes",
+              "description": "The custom attributes for the company object.",
+              "type": "object",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": "keyvalue",
+              "disabledInputMethods": null
+            }
           },
-          "size": {
-            "@path": "$.traits.size"
-          },
-          "website": {
-            "@path": "$.traits.website"
-          },
-          "industry": {
-            "@path": "$.traits.industry"
-          },
-          "monthly_spend": {
-            "@path": "$.traits.monthly_spend"
-          }
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "hide_default_launcher": {
-          "@if": {
-            "exists": {
-              "@path": "$.context.Intercom.hideDefaultLauncher"
-            },
-            "then": {
-              "@path": "$.context.Intercom.hideDefaultLauncher"
-            },
-            "else": {
-              "@path": "$.context.Intercom.hide_default_launcher"
+          "label": "Hide Default Launcher",
+          "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "then": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "else": {
+                "@path": "$.context.Intercom.hide_default_launcher"
+              }
             }
-          }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    }
+  },
+  "presets": [
+    {
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "revenue": {
+          "@path": "$.properties.revenue"
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "event_metadata": {
+          "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "identifyUser",
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\" or type = \"page\"",
       "mapping": {
         "user_id": {
@@ -1232,27 +1442,65 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackEvent",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
+      "name": "Identify Company",
+      "type": "automatic",
+      "partnerAction": "identifyCompany",
+      "subscribe": "type = \"group\"",
       "mapping": {
-        "event_name": {
-          "@path": "$.event"
+        "company": {
+          "company_id": {
+            "@path": "$.groupId"
+          },
+          "name": {
+            "@path": "$.traits.name"
+          },
+          "created_at": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits.createdAt"
+              },
+              "then": {
+                "@path": "$.traits.createdAt"
+              },
+              "else": {
+                "@path": "$.traits.created_at"
+              }
+            }
+          },
+          "plan": {
+            "@path": "$.traits.plan"
+          },
+          "size": {
+            "@path": "$.traits.size"
+          },
+          "website": {
+            "@path": "$.traits.website"
+          },
+          "industry": {
+            "@path": "$.traits.industry"
+          },
+          "monthly_spend": {
+            "@path": "$.traits.monthly_spend"
+          }
         },
-        "revenue": {
-          "@path": "$.properties.revenue"
-        },
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "event_metadata": {
-          "@path": "$.properties"
+        "hide_default_launcher": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "then": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "else": {
+              "@path": "$.context.Intercom.hide_default_launcher"
+            }
+          }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/intercom/metadata.json
+++ b/packages/browser-destinations/destinations/intercom/metadata.json
@@ -1,0 +1,1258 @@
+{
+  "name": "Intercom Web (Actions)",
+  "basicOptions": ["appId", "activator", "richLinkProperties", "apiBase"],
+  "options": {
+    "appId": {
+      "tags": [],
+      "default": "",
+      "description": "The app_id of your Intercom app which will indicate where to store any data.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "App ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The appId property is required."]],
+      "uIMetadata": null
+    },
+    "activator": {
+      "tags": [],
+      "default": "#IntercomDefaultWidget",
+      "description": "By default, Intercom will inject their own inbox button onto the page, but you can choose to use your own custom button instead by providing a CSS selector, e.g. #my-button. You must have the \"Show the Intercom Inbox\" setting enabled for this to work. The default value is #IntercomDefaultWidget.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Custom Inbox Button Selector",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "richLinkProperties": {
+      "tags": [],
+      "default": "",
+      "description": "A list of rich link property keys.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Rich Link Properties",
+      "private": false,
+      "scope": "event_destination",
+      "type": "array",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "apiBase": {
+      "tags": [],
+      "default": "https://api-iam.intercom.io",
+      "description": "The regional API to use for processing the data",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Regional Data Hosting",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "https://api-iam.intercom.io",
+          "label": "US",
+          "text": "US"
+        },
+        {
+          "value": "https://api-iam.eu.intercom.io",
+          "label": "EU",
+          "text": "EU"
+        },
+        {
+          "value": "https://api-iam.au.intercom.io",
+          "label": "Australia",
+          "text": "Australia"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyCompany",
+      "name": "Identify Company",
+      "description": "Create or update a company in Intercom.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "company",
+          "type": "object",
+          "label": "Company",
+          "description": "The user's company.",
+          "defaultValue": {
+            "company_id": {
+              "@path": "$.groupId"
+            },
+            "name": {
+              "@path": "$.traits.name"
+            },
+            "created_at": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.createdAt"
+                },
+                "then": {
+                  "@path": "$.traits.createdAt"
+                },
+                "else": {
+                  "@path": "$.traits.created_at"
+                }
+              }
+            },
+            "plan": {
+              "@path": "$.traits.plan"
+            },
+            "size": {
+              "@path": "$.traits.size"
+            },
+            "website": {
+              "@path": "$.traits.website"
+            },
+            "industry": {
+              "@path": "$.traits.industry"
+            },
+            "monthly_spend": {
+              "@path": "$.traits.monthly_spend"
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "company": {
+                "title": "Company",
+                "description": "The user's company.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "company_id": {
+                    "title": "Company ID",
+                    "description": "The unique identifier of the company.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "title": "Company Name",
+                    "description": "The name of the company.",
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "title": "Company Creation Time",
+                    "description": "The time the company was created in your system.",
+                    "type": ["string", "number"],
+                    "format": "date-like"
+                  },
+                  "plan": {
+                    "title": "Company Plan",
+                    "description": "The name of the plan you have associated with the company.",
+                    "type": "string"
+                  },
+                  "monthly_spend": {
+                    "title": "Monthly Spend",
+                    "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "title": "Company Size",
+                    "description": "The number of employees in the company.",
+                    "type": "integer"
+                  },
+                  "website": {
+                    "title": "Company Website",
+                    "description": "The URL for the company website.",
+                    "type": "string"
+                  },
+                  "industry": {
+                    "title": "Industry",
+                    "description": "The industry that the company operates in.",
+                    "type": "string"
+                  },
+                  "company_custom_traits": {
+                    "title": "Company Custom Attributes",
+                    "description": "The custom attributes for the company object.",
+                    "type": "object"
+                  }
+                },
+                "required": ["company_id", "name"]
+              }
+            },
+            "required": ["company"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "hide_default_launcher",
+          "type": "boolean",
+          "label": "Hide Default Launcher",
+          "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "then": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "else": {
+                "@path": "$.context.Intercom.hide_default_launcher"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hide_default_launcher": {
+                "title": "Hide Default Launcher",
+                "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Create or update a user in Intercom.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\" or type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "user_id",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_id": {
+                "title": "User ID",
+                "description": "A unique identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "custom_traits",
+          "type": "object",
+          "label": "Custom Attributes",
+          "description": "The user's custom attributes.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "custom_traits": {
+                "title": "Custom Attributes",
+                "description": "The user's custom attributes.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The user's name.",
+          "defaultValue": {
+            "@path": "$.traits.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The user's name.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "phone",
+          "type": "string",
+          "label": "Phone Number",
+          "description": "The user's phone number.",
+          "defaultValue": {
+            "@path": "$.traits.phone"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "phone": {
+                "title": "Phone Number",
+                "description": "The user's phone number.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "unsubscribed_from_emails",
+          "type": "boolean",
+          "label": "Unsubscribed From Emails",
+          "description": "The user's email unsubscribe status.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "unsubscribed_from_emails": {
+                "title": "Unsubscribed From Emails",
+                "description": "The user's email unsubscribe status.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "language_override",
+          "type": "string",
+          "label": "Language Override",
+          "description": "The user's messenger language (instead of relying on browser language settings).",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "language_override": {
+                "title": "Language Override",
+                "description": "The user's messenger language (instead of relying on browser language settings).",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email Address",
+          "description": "The user's email address.",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email Address",
+                "description": "The user's email address.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "created_at",
+          "type": "datetime",
+          "label": "User Creation Time",
+          "description": "The time the user was created in your system.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits.createdAt"
+              },
+              "then": {
+                "@path": "$.traits.createdAt"
+              },
+              "else": {
+                "@path": "$.traits.created_at"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "created_at": {
+                "title": "User Creation Time",
+                "description": "The time the user was created in your system.",
+                "type": ["string", "number"],
+                "format": "date-like"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "avatar_image_url",
+          "type": "string",
+          "label": "Avatar",
+          "description": "The URL for the user's avatar/profile image.",
+          "defaultValue": {
+            "@path": "$.traits.avatar"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "avatar_image_url": {
+                "title": "Avatar",
+                "description": "The URL for the user's avatar/profile image.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_hash",
+          "type": "string",
+          "label": "User Hash",
+          "description": "The user hash used for identity verification. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.integrations.Intercom.user_hash"
+              },
+              "then": {
+                "@path": "$.integrations.Intercom.user_hash"
+              },
+              "else": {
+                "@path": "$.integrations.Intercom.userHash"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_hash": {
+                "title": "User Hash",
+                "description": "The user hash used for identity verification. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "intercom_user_jwt",
+          "type": "string",
+          "label": "Intercom User JWT",
+          "description": "The intercom user JWT is used to secure your messenger for your users. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.integrations.Intercom.intercom_user_jwt"
+              },
+              "then": {
+                "@path": "$.integrations.Intercom.intercom_user_jwt"
+              },
+              "else": {
+                "@path": "$.integrations.Intercom.intercomUserJwt"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "intercom_user_jwt": {
+                "title": "Intercom User JWT",
+                "description": "The intercom user JWT is used to secure your messenger for your users. See [Intercom docs](https://www.intercom.com/help/en/collections/12295815-messenger-security) for more information on how to set this field.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "company",
+          "type": "object",
+          "label": "Company",
+          "description": "The user's company.",
+          "defaultValue": {
+            "company_id": {
+              "@path": "$.traits.company.id"
+            },
+            "name": {
+              "@path": "$.traits.company.name"
+            },
+            "created_at": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.company.createdAt"
+                },
+                "then": {
+                  "@path": "$.traits.company.createdAt"
+                },
+                "else": {
+                  "@path": "$.traits.company.created_at"
+                }
+              }
+            },
+            "plan": {
+              "@path": "$.traits.company.plan"
+            },
+            "size": {
+              "@path": "$.traits.company.size"
+            },
+            "website": {
+              "@path": "$.traits.company.website"
+            },
+            "industry": {
+              "@path": "$.traits.company.industry"
+            },
+            "monthly_spend": {
+              "@path": "$.traits.company.monthly_spend"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "company": {
+                "title": "Company",
+                "description": "The user's company.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "company_id": {
+                    "title": "Company ID",
+                    "description": "The unique identifier of the company.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "title": "Company Name",
+                    "description": "The name of the company.",
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "title": "Company Creation Time",
+                    "description": "The time the company was created in your system.",
+                    "type": ["string", "number"],
+                    "format": "date-like"
+                  },
+                  "plan": {
+                    "title": "Company Plan",
+                    "description": "The name of the plan you have associated with the company.",
+                    "type": "string"
+                  },
+                  "monthly_spend": {
+                    "title": "Monthly Spend",
+                    "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+                    "type": "integer"
+                  },
+                  "size": {
+                    "title": "Company Size",
+                    "description": "The number of employees in the company.",
+                    "type": "integer"
+                  },
+                  "website": {
+                    "title": "Company Website",
+                    "description": "The URL for the company website.",
+                    "type": "string"
+                  },
+                  "industry": {
+                    "title": "Industry",
+                    "description": "The industry that the company operates in.",
+                    "type": "string"
+                  },
+                  "company_custom_traits": {
+                    "title": "Company Custom Attributes",
+                    "description": "The custom attributes for the company object.",
+                    "type": "object"
+                  }
+                },
+                "required": ["company_id", "name"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "companies",
+          "type": "object",
+          "label": "Companies",
+          "description": "The array of companies the user is associated to.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.traits.companies",
+              {
+                "company_id": {
+                  "@path": "$.id"
+                },
+                "name": {
+                  "@path": "$.name"
+                },
+                "created_at": {
+                  "@if": {
+                    "exists": {
+                      "@path": "$.createdAt"
+                    },
+                    "then": {
+                      "@path": "$.createdAt"
+                    },
+                    "else": {
+                      "@path": "$.created_at"
+                    }
+                  }
+                },
+                "plan": {
+                  "@path": "$.plan"
+                },
+                "size": {
+                  "@path": "$.size"
+                },
+                "website": {
+                  "@path": "$.website"
+                },
+                "industry": {
+                  "@path": "$.industry"
+                },
+                "monthly_spend": {
+                  "@path": "$.monthly_spend"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "companies": {
+                "title": "Companies",
+                "description": "The array of companies the user is associated to.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "company_id": {
+                      "title": "Company ID",
+                      "description": "The unique identifier of the company.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "title": "Company Name",
+                      "description": "The name of the company.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "title": "Company Creation Time",
+                      "description": "The time the company was created in your system.",
+                      "type": ["string", "number"],
+                      "format": "date-like"
+                    },
+                    "plan": {
+                      "title": "Company Plan",
+                      "description": "The name of the plan you have associated with the company.",
+                      "type": "string"
+                    },
+                    "monthly_spend": {
+                      "title": "Monthly Spend",
+                      "description": "The monthly spend of the company, e.g. how much revenue the company generates for your business.",
+                      "type": "integer"
+                    },
+                    "size": {
+                      "title": "Company Size",
+                      "description": "The number of employees in the company.",
+                      "type": "integer"
+                    },
+                    "website": {
+                      "title": "Company Website",
+                      "description": "The URL for the company website.",
+                      "type": "string"
+                    },
+                    "industry": {
+                      "title": "Industry",
+                      "description": "The industry that the company operates in.",
+                      "type": "string"
+                    },
+                    "company_custom_traits": {
+                      "title": "Company Custom Attributes",
+                      "description": "The custom attributes for the company object.",
+                      "type": "object"
+                    }
+                  },
+                  "required": ["company_id", "name"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "hide_default_launcher",
+          "type": "boolean",
+          "label": "Hide Default Launcher",
+          "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "then": {
+                "@path": "$.context.Intercom.hideDefaultLauncher"
+              },
+              "else": {
+                "@path": "$.context.Intercom.hide_default_launcher"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hide_default_launcher": {
+                "title": "Hide Default Launcher",
+                "description": "Selectively show the chat widget. As per [Intercom docs](https://www.intercom.com/help/en/articles/189-turn-off-show-or-hide-the-intercom-messenger), you want to first hide the Messenger for all users inside the Intercom UI using Messenger settings. Then think about how you want to programmatically decide which users you would like to show the widget to.",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Submit an event to Intercom.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "revenue",
+          "type": "number",
+          "label": "Revenue",
+          "description": "The amount associated with a purchase. Segment will multiply by 100 as Intercom requires the amount in cents.",
+          "defaultValue": {
+            "@path": "$.properties.revenue"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "revenue": {
+                "title": "Revenue",
+                "description": "The amount associated with a purchase. Segment will multiply by 100 as Intercom requires the amount in cents.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "The currency of the purchase amount. Segment will default to USD if revenue is provided without a currency.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "The currency of the purchase amount. Segment will default to USD if revenue is provided without a currency.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_metadata",
+          "type": "object",
+          "label": "Event Metadata",
+          "description": "Optional metadata describing the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_metadata": {
+                "title": "Event Metadata",
+                "description": "Optional metadata describing the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyCompany",
+      "name": "Identify Company",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "company": {
+          "company_id": {
+            "@path": "$.groupId"
+          },
+          "name": {
+            "@path": "$.traits.name"
+          },
+          "created_at": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits.createdAt"
+              },
+              "then": {
+                "@path": "$.traits.createdAt"
+              },
+              "else": {
+                "@path": "$.traits.created_at"
+              }
+            }
+          },
+          "plan": {
+            "@path": "$.traits.plan"
+          },
+          "size": {
+            "@path": "$.traits.size"
+          },
+          "website": {
+            "@path": "$.traits.website"
+          },
+          "industry": {
+            "@path": "$.traits.industry"
+          },
+          "monthly_spend": {
+            "@path": "$.traits.monthly_spend"
+          }
+        },
+        "hide_default_launcher": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "then": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "else": {
+              "@path": "$.context.Intercom.hide_default_launcher"
+            }
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\" or type = \"page\"",
+      "mapping": {
+        "user_id": {
+          "@path": "$.userId"
+        },
+        "name": {
+          "@path": "$.traits.name"
+        },
+        "phone": {
+          "@path": "$.traits.phone"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "created_at": {
+          "@if": {
+            "exists": {
+              "@path": "$.traits.createdAt"
+            },
+            "then": {
+              "@path": "$.traits.createdAt"
+            },
+            "else": {
+              "@path": "$.traits.created_at"
+            }
+          }
+        },
+        "avatar_image_url": {
+          "@path": "$.traits.avatar"
+        },
+        "user_hash": {
+          "@if": {
+            "exists": {
+              "@path": "$.integrations.Intercom.user_hash"
+            },
+            "then": {
+              "@path": "$.integrations.Intercom.user_hash"
+            },
+            "else": {
+              "@path": "$.integrations.Intercom.userHash"
+            }
+          }
+        },
+        "intercom_user_jwt": {
+          "@if": {
+            "exists": {
+              "@path": "$.integrations.Intercom.intercom_user_jwt"
+            },
+            "then": {
+              "@path": "$.integrations.Intercom.intercom_user_jwt"
+            },
+            "else": {
+              "@path": "$.integrations.Intercom.intercomUserJwt"
+            }
+          }
+        },
+        "company": {
+          "company_id": {
+            "@path": "$.traits.company.id"
+          },
+          "name": {
+            "@path": "$.traits.company.name"
+          },
+          "created_at": {
+            "@if": {
+              "exists": {
+                "@path": "$.traits.company.createdAt"
+              },
+              "then": {
+                "@path": "$.traits.company.createdAt"
+              },
+              "else": {
+                "@path": "$.traits.company.created_at"
+              }
+            }
+          },
+          "plan": {
+            "@path": "$.traits.company.plan"
+          },
+          "size": {
+            "@path": "$.traits.company.size"
+          },
+          "website": {
+            "@path": "$.traits.company.website"
+          },
+          "industry": {
+            "@path": "$.traits.company.industry"
+          },
+          "monthly_spend": {
+            "@path": "$.traits.company.monthly_spend"
+          }
+        },
+        "companies": {
+          "@arrayPath": [
+            "$.traits.companies",
+            {
+              "company_id": {
+                "@path": "$.id"
+              },
+              "name": {
+                "@path": "$.name"
+              },
+              "created_at": {
+                "@if": {
+                  "exists": {
+                    "@path": "$.createdAt"
+                  },
+                  "then": {
+                    "@path": "$.createdAt"
+                  },
+                  "else": {
+                    "@path": "$.created_at"
+                  }
+                }
+              },
+              "plan": {
+                "@path": "$.plan"
+              },
+              "size": {
+                "@path": "$.size"
+              },
+              "website": {
+                "@path": "$.website"
+              },
+              "industry": {
+                "@path": "$.industry"
+              },
+              "monthly_spend": {
+                "@path": "$.monthly_spend"
+              }
+            }
+          ]
+        },
+        "hide_default_launcher": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "then": {
+              "@path": "$.context.Intercom.hideDefaultLauncher"
+            },
+            "else": {
+              "@path": "$.context.Intercom.hide_default_launcher"
+            }
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "revenue": {
+          "@path": "$.properties.revenue"
+        },
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "event_metadata": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/intercom/metadata.json
+++ b/packages/browser-destinations/destinations/intercom/metadata.json
@@ -10,30 +10,37 @@
         "description": "The app_id of your Intercom app which will indicate where to store any data.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "activator": {
         "label": "Custom Inbox Button Selector",
         "description": "By default, Intercom will inject their own inbox button onto the page, but you can choose to use your own custom button instead by providing a CSS selector, e.g. #my-button. You must have the \"Show the Intercom Inbox\" setting enabled for this to work. The default value is #IntercomDefaultWidget.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "#IntercomDefaultWidget"
+        "default": "#IntercomDefaultWidget",
+        "depends_on": null
       },
       "richLinkProperties": {
         "label": "Rich Link Properties",
         "description": "A list of rich link property keys.",
         "type": "string",
         "required": false,
+        "multiple": true,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "apiBase": {
         "label": "Regional Data Hosting",
         "description": "The regional API to use for processing the data",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "US",
@@ -48,7 +55,8 @@
             "value": "https://api-iam.au.intercom.io"
           }
         ],
-        "default": "https://api-iam.intercom.io"
+        "default": "https://api-iam.intercom.io",
+        "depends_on": null
       }
     }
   },
@@ -62,7 +70,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -85,7 +93,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "revenue": {
           "label": "Revenue",
@@ -108,7 +118,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -131,7 +143,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_metadata": {
           "label": "Event Metadata",
@@ -154,7 +168,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -166,7 +182,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "user_id": {
           "label": "User ID",
@@ -189,7 +205,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "custom_traits": {
           "label": "Custom Attributes",
@@ -210,7 +228,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "name": {
           "label": "Name",
@@ -233,7 +253,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "phone": {
           "label": "Phone Number",
@@ -256,7 +278,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "unsubscribed_from_emails": {
           "label": "Unsubscribed From Emails",
@@ -277,7 +301,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "language_override": {
           "label": "Language Override",
@@ -298,7 +324,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email Address",
@@ -321,7 +349,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "created_at": {
           "label": "User Creation Time",
@@ -354,7 +384,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "avatar_image_url": {
           "label": "Avatar",
@@ -377,7 +409,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_hash": {
           "label": "User Hash",
@@ -410,7 +444,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "intercom_user_jwt": {
           "label": "Intercom User JWT",
@@ -443,7 +479,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "company": {
           "label": "Company",
@@ -511,7 +549,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Company Name",
@@ -532,7 +572,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created_at": {
               "label": "Company Creation Time",
@@ -553,7 +595,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "plan": {
               "label": "Company Plan",
@@ -574,7 +618,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "monthly_spend": {
               "label": "Monthly Spend",
@@ -595,7 +641,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "size": {
               "label": "Company Size",
@@ -616,7 +664,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "website": {
               "label": "Company Website",
@@ -637,7 +687,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "industry": {
               "label": "Industry",
@@ -658,7 +710,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "company_custom_traits": {
               "label": "Company Custom Attributes",
@@ -679,7 +733,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": "keyvalue",
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -689,7 +745,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "companies": {
           "label": "Companies",
@@ -762,7 +820,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Company Name",
@@ -783,7 +843,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created_at": {
               "label": "Company Creation Time",
@@ -804,7 +866,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "plan": {
               "label": "Company Plan",
@@ -825,7 +889,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "monthly_spend": {
               "label": "Monthly Spend",
@@ -846,7 +912,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "size": {
               "label": "Company Size",
@@ -867,7 +935,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "website": {
               "label": "Company Website",
@@ -888,7 +958,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "industry": {
               "label": "Industry",
@@ -909,7 +981,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "company_custom_traits": {
               "label": "Company Custom Attributes",
@@ -930,7 +1004,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": "keyvalue",
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -940,7 +1016,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "hide_default_launcher": {
           "label": "Hide Default Launcher",
@@ -973,7 +1051,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -985,7 +1065,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "company": {
           "label": "Company",
@@ -1053,7 +1133,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Company Name",
@@ -1074,7 +1156,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created_at": {
               "label": "Company Creation Time",
@@ -1095,7 +1179,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "plan": {
               "label": "Company Plan",
@@ -1116,7 +1202,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "monthly_spend": {
               "label": "Monthly Spend",
@@ -1137,7 +1225,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "size": {
               "label": "Company Size",
@@ -1158,7 +1248,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "website": {
               "label": "Company Website",
@@ -1179,7 +1271,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "industry": {
               "label": "Industry",
@@ -1200,7 +1294,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "company_custom_traits": {
               "label": "Company Custom Attributes",
@@ -1221,7 +1317,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": "keyvalue",
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1231,7 +1329,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "hide_default_launcher": {
           "label": "Hide Default Launcher",
@@ -1264,7 +1364,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/iterate/metadata.json
+++ b/packages/browser-destinations/destinations/iterate/metadata.json
@@ -1,0 +1,169 @@
+{
+  "name": "Iterate Web (Actions)",
+  "basicOptions": ["apiKey"],
+  "options": {
+    "apiKey": {
+      "tags": [],
+      "default": "",
+      "description": "The Embed API Key for your account. You can find this on your settings pages.",
+      "encrypt": true,
+      "hidden": false,
+      "label": "Embed API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The apiKey property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sets user identity",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "Identity",
+          "description": "The user's identity.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "Identity",
+                "description": "The user's identity.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Iterate.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to Iterate.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/iterate/metadata.json
+++ b/packages/browser-destinations/destinations/iterate/metadata.json
@@ -10,8 +10,10 @@
         "description": "The Embed API Key for your account. You can find this on your settings pages.",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -60,7 +64,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "Identity",
@@ -83,7 +87,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -106,7 +112,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/iterate/metadata.json
+++ b/packages/browser-destinations/destinations/iterate/metadata.json
@@ -1,148 +1,133 @@
 {
+  "slug": "actions-iterate",
   "name": "Iterate Web (Actions)",
-  "basicOptions": ["apiKey"],
-  "options": {
-    "apiKey": {
-      "tags": [],
-      "default": "",
-      "description": "The Embed API Key for your account. You can find this on your settings pages.",
-      "encrypt": true,
-      "hidden": false,
-      "label": "Embed API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The apiKey property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "apiKey": {
+        "label": "Embed API Key",
+        "description": "The Embed API Key for your account. You can find this on your settings pages.",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Sets user identity",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "Identity",
-          "description": "The user's identity.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "Identity",
-                "description": "The user's identity.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "The Segment traits to be forwarded to Iterate.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to Iterate.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Track events",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Sets user identity",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "Identity",
+          "description": "The user's identity.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Iterate.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -152,18 +137,7 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "name": {
-          "@path": "$.event"
-        }
-      },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/jimo/metadata.json
+++ b/packages/browser-destinations/destinations/jimo/metadata.json
@@ -1,0 +1,482 @@
+{
+  "name": "Jimo (Actions)",
+  "description": "Load Jimo SDK and send user profile data to Jimo",
+  "basicOptions": ["projectId", "refetchExperiencesOnTraitsUpdate", "manualInit"],
+  "options": {
+    "projectId": {
+      "tags": [],
+      "default": "",
+      "description": "Id of the Jimo project. You can find the Project Id here: https://i.usejimo.com/settings/install/portal",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Id",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The projectId property is required."]],
+      "uIMetadata": null
+    },
+    "refetchExperiencesOnTraitsUpdate": {
+      "tags": [],
+      "default": false,
+      "description": "Enable this option if you'd like Jimo to refetch experiences supposed to be shown to the user after user traits get updated. This is useful when if you have experiences that use segment based on Segment traits.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Refetch experiences after traits changes",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "manualInit": {
+      "tags": [],
+      "default": false,
+      "description": "If true, Jimo SDK will be initialized only after a Segment event containing a userID has been triggered. This prevents from having anonymous profile created in Jimo.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Initialize only for identified users",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "sendGroupData",
+      "name": "Send Group Data",
+      "description": "Send group ID and traits to Jimo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Group ID",
+          "description": "The unique identifier for the group",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Group ID",
+                "description": "The unique identifier for the group",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Group Traits",
+          "description": "A list of attributes coming from segment group traits",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Group Traits",
+                "description": "A list of attributes coming from segment group traits",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "sendTrackEvent",
+      "name": "Send Track Event",
+      "description": "Submit an event to Jimo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "messageId",
+          "type": "string",
+          "label": "Message Id",
+          "description": "The internal id of the message.",
+          "defaultValue": {
+            "@path": "$.messageId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "messageId": {
+                "title": "Message Id",
+                "description": "The internal id of the message.",
+                "type": "string"
+              }
+            },
+            "required": ["messageId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "timestamp",
+          "type": "string",
+          "label": "Timestamp",
+          "description": "The timestamp of the event.",
+          "defaultValue": {
+            "@path": "$.timestamp"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "timestamp": {
+                "title": "Timestamp",
+                "description": "The timestamp of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["timestamp"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "An anonymous identifier for the user.",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "An anonymous identifier for the user.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Information associated with the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Information associated with the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "sendUserData",
+      "name": "Send User Data",
+      "description": "Send user ID and email to Jimo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The unique user identifier",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The unique user identifier",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "User email",
+          "description": "The email of the user",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "User email",
+                "description": "The email of the user",
+                "type": ["string", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Traits",
+          "description": "A list of attributes coming from segment traits",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Traits",
+                "description": "A list of attributes coming from segment traits",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "sendGroupData",
+      "name": "Send Group Data",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "sendTrackEvent",
+      "name": "Send Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "messageId": {
+          "@path": "$.messageId"
+        },
+        "timestamp": {
+          "@path": "$.timestamp"
+        },
+        "event_name": {
+          "@path": "$.event"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "sendUserData",
+      "name": "Send User Data",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/jimo/metadata.json
+++ b/packages/browser-destinations/destinations/jimo/metadata.json
@@ -1,443 +1,352 @@
 {
+  "slug": "actions-jimo",
   "name": "Jimo (Actions)",
+  "mode": "device",
   "description": "Load Jimo SDK and send user profile data to Jimo",
-  "basicOptions": ["projectId", "refetchExperiencesOnTraitsUpdate", "manualInit"],
-  "options": {
-    "projectId": {
-      "tags": [],
-      "default": "",
-      "description": "Id of the Jimo project. You can find the Project Id here: https://i.usejimo.com/settings/install/portal",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Id",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The projectId property is required."]],
-      "uIMetadata": null
-    },
-    "refetchExperiencesOnTraitsUpdate": {
-      "tags": [],
-      "default": false,
-      "description": "Enable this option if you'd like Jimo to refetch experiences supposed to be shown to the user after user traits get updated. This is useful when if you have experiences that use segment based on Segment traits.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Refetch experiences after traits changes",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "manualInit": {
-      "tags": [],
-      "default": false,
-      "description": "If true, Jimo SDK will be initialized only after a Segment event containing a userID has been triggered. This prevents from having anonymous profile created in Jimo.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Initialize only for identified users",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "projectId": {
+        "label": "Id",
+        "description": "Id of the Jimo project. You can find the Project Id here: https://i.usejimo.com/settings/install/portal",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "refetchExperiencesOnTraitsUpdate": {
+        "label": "Refetch experiences after traits changes",
+        "description": "Enable this option if you'd like Jimo to refetch experiences supposed to be shown to the user after user traits get updated. This is useful when if you have experiences that use segment based on Segment traits.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "manualInit": {
+        "label": "Initialize only for identified users",
+        "description": "If true, Jimo SDK will be initialized only after a Segment event containing a userID has been triggered. This prevents from having anonymous profile created in Jimo.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "sendGroupData",
-      "name": "Send Group Data",
+  "audienceConfig": null,
+  "actions": {
+    "sendGroupData": {
+      "title": "Send Group Data",
       "description": "Send group ID and traits to Jimo",
       "platform": "web",
+      "defaultSubscription": "type = \"group\"",
       "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "groupId": {
           "label": "Group ID",
           "description": "The unique identifier for the group",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.groupId"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Group ID",
-                "description": "The unique identifier for the group",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "Group Traits",
           "description": "A list of attributes coming from segment group traits",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Group Traits",
-                "description": "A list of attributes coming from segment group traits",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "sendTrackEvent",
-      "name": "Send Track Event",
-      "description": "Submit an event to Jimo",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "messageId",
-          "type": "string",
-          "label": "Message Id",
-          "description": "The internal id of the message.",
-          "defaultValue": {
-            "@path": "$.messageId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "messageId": {
-                "title": "Message Id",
-                "description": "The internal id of the message.",
-                "type": "string"
-              }
-            },
-            "required": ["messageId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "timestamp",
-          "type": "string",
-          "label": "Timestamp",
-          "description": "The timestamp of the event.",
-          "defaultValue": {
-            "@path": "$.timestamp"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "timestamp": {
-                "title": "Timestamp",
-                "description": "The timestamp of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["timestamp"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "event_name",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["event_name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "A unique identifier for the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "An anonymous identifier for the user.",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "An anonymous identifier for the user.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Information associated with the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Information associated with the event",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "sendUserData",
-      "name": "Send User Data",
+    "sendUserData": {
+      "title": "Send User Data",
       "description": "Send user ID and email to Jimo",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The unique user identifier",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The unique user identifier",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "User email",
           "description": "The email of the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": true,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.email"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "User email",
-                "description": "The email of the user",
-                "type": ["string", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "User Traits",
           "description": "A list of attributes coming from segment traits",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Traits",
-                "description": "A list of attributes coming from segment traits",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "sendTrackEvent": {
+      "title": "Send Track Event",
+      "description": "Submit an event to Jimo",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "messageId": {
+          "label": "Message Id",
+          "description": "The internal id of the message.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "timestamp": {
+          "label": "Timestamp",
+          "description": "The timestamp of the event.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.timestamp"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "event_name": {
+          "label": "Event Name",
+          "description": "The name of the event.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "A unique identifier for the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "An anonymous identifier for the user.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Information associated with the event",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "sendGroupData",
-      "name": "Send Group Data",
-      "subscribe": "type = \"group\"",
+      "name": "Send User Data",
+      "type": "automatic",
+      "partnerAction": "sendUserData",
+      "subscribe": "type = \"identify\"",
       "mapping": {
-        "groupId": {
-          "@path": "$.groupId"
+        "userId": {
+          "@path": "$.userId"
+        },
+        "email": {
+          "@path": "$.traits.email"
         },
         "traits": {
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "sendTrackEvent",
       "name": "Send Track Event",
+      "type": "automatic",
+      "partnerAction": "sendTrackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "messageId": {
@@ -459,24 +368,22 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "sendUserData",
-      "name": "Send User Data",
-      "subscribe": "type = \"identify\"",
+      "name": "Send Group Data",
+      "type": "automatic",
+      "partnerAction": "sendGroupData",
+      "subscribe": "type = \"group\"",
       "mapping": {
-        "userId": {
-          "@path": "$.userId"
-        },
-        "email": {
-          "@path": "$.traits.email"
+        "groupId": {
+          "@path": "$.groupId"
         },
         "traits": {
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/jimo/metadata.json
+++ b/packages/browser-destinations/destinations/jimo/metadata.json
@@ -11,24 +11,30 @@
         "description": "Id of the Jimo project. You can find the Project Id here: https://i.usejimo.com/settings/install/portal",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "refetchExperiencesOnTraitsUpdate": {
         "label": "Refetch experiences after traits changes",
         "description": "Enable this option if you'd like Jimo to refetch experiences supposed to be shown to the user after user traits get updated. This is useful when if you have experiences that use segment based on Segment traits.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "manualInit": {
         "label": "Initialize only for identified users",
         "description": "If true, Jimo SDK will be initialized only after a Segment event containing a userID has been triggered. This prevents from having anonymous profile created in Jimo.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -42,7 +48,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Group ID",
@@ -65,7 +71,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Group Traits",
@@ -88,7 +96,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -100,7 +110,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -123,7 +133,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "User email",
@@ -146,7 +158,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Traits",
@@ -169,7 +183,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -181,7 +197,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "messageId": {
           "label": "Message Id",
@@ -204,7 +220,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "timestamp": {
           "label": "Timestamp",
@@ -227,7 +245,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_name": {
           "label": "Event Name",
@@ -250,7 +270,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -273,7 +295,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -296,7 +320,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -319,7 +345,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/koala/metadata.json
+++ b/packages/browser-destinations/destinations/koala/metadata.json
@@ -1,162 +1,122 @@
 {
+  "slug": "actions-koala",
   "name": "Koala",
+  "mode": "device",
   "description": "Connect Koala in Segment to send visitor events or traits to Koala.",
-  "basicOptions": ["project_slug"],
-  "options": {
-    "project_slug": {
-      "tags": [],
-      "default": "",
-      "description": "Please enter your Public API Key found in your Koala workspace settings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Public API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The project_slug property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "project_slug": {
+        "label": "Public API Key",
+        "description": "Please enter your Public API Key found in your Koala workspace settings.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyVisitor",
-      "name": "Identify Visitor",
-      "description": "Update visitor traits in Koala.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "Traits to associate with the visitor in Koala.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "object",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "Traits to associate with the visitor in Koala.",
-                "type": "object"
-              }
-            },
-            "required": ["traits"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Send visitor events to Koala.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event": {
           "label": "Event Name",
           "description": "The event name.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "Event Name",
-                "description": "The event name.",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Properties to send with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "object",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Properties to send with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "object",
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identifyVisitor": {
+      "title": "Identify Visitor",
+      "description": "Update visitor traits in Koala.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "traits": {
+          "label": "Traits",
+          "description": "Traits to associate with the visitor in Koala.",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "object",
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyVisitor",
-      "name": "Identify Visitor",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "traits": {
-          "@path": "$.traits"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "event": {
@@ -166,7 +126,19 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify Visitor",
+      "type": "automatic",
+      "partnerAction": "identifyVisitor",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/koala/metadata.json
+++ b/packages/browser-destinations/destinations/koala/metadata.json
@@ -11,8 +11,10 @@
         "description": "Please enter your Public API Key found in your Koala workspace settings.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -26,7 +28,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event": {
           "label": "Event Name",
@@ -49,7 +51,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -72,7 +76,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "object",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -84,7 +90,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "traits": {
           "label": "Traits",
@@ -107,7 +113,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "object",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/koala/metadata.json
+++ b/packages/browser-destinations/destinations/koala/metadata.json
@@ -1,0 +1,172 @@
+{
+  "name": "Koala",
+  "description": "Connect Koala in Segment to send visitor events or traits to Koala.",
+  "basicOptions": ["project_slug"],
+  "options": {
+    "project_slug": {
+      "tags": [],
+      "default": "",
+      "description": "Please enter your Public API Key found in your Koala workspace settings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Public API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The project_slug property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyVisitor",
+      "name": "Identify Visitor",
+      "description": "Update visitor traits in Koala.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "Traits to associate with the visitor in Koala.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "object",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "Traits to associate with the visitor in Koala.",
+                "type": "object"
+              }
+            },
+            "required": ["traits"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send visitor events to Koala.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The event name.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "Event Name",
+                "description": "The event name.",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Properties to send with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "object",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Properties to send with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyVisitor",
+      "name": "Identify Visitor",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/logrocket/metadata.json
+++ b/packages/browser-destinations/destinations/logrocket/metadata.json
@@ -10,24 +10,30 @@
         "description": "The LogRocket app ID.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "networkSanitization": {
         "label": "Network Sanitization",
         "description": "Sanitize all network request and response bodies from session recordings.",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "inputSanitization": {
         "label": "Input Sanitization",
         "description": "Obfuscate all user-input elements (like <input> and <select>) from session recordings.",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       }
     }
   },
@@ -41,7 +47,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -64,7 +70,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -87,7 +95,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -99,7 +109,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -122,7 +132,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -145,7 +157,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/logrocket/metadata.json
+++ b/packages/browser-destinations/destinations/logrocket/metadata.json
@@ -1,0 +1,232 @@
+{
+  "name": "Logrocket",
+  "basicOptions": ["appID", "networkSanitization", "inputSanitization"],
+  "options": {
+    "appID": {
+      "tags": [],
+      "default": "",
+      "description": "The LogRocket app ID.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "LogRocket App",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The appID property is required."]],
+      "uIMetadata": null
+    },
+    "networkSanitization": {
+      "tags": [],
+      "default": true,
+      "description": "Sanitize all network request and response bodies from session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Network Sanitization",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The networkSanitization property is required."]],
+      "uIMetadata": null
+    },
+    "inputSanitization": {
+      "tags": [],
+      "default": true,
+      "description": "Obfuscate all user-input elements (like <input> and <select>) from session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Input Sanitization",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The inputSanitization property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Send identification information to logrocket.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "user id",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "user id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "A JSON object containing additional traits that will be associated with the user.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "A JSON object containing additional traits that will be associated with the user.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "track",
+      "name": "Track",
+      "description": "Send track events to logrocket for filtering and tagging.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing additional properties that will be associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing additional properties that will be associated with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identify",
+      "name": "Identify",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "track",
+      "name": "Track",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/logrocket/metadata.json
+++ b/packages/browser-destinations/destinations/logrocket/metadata.json
@@ -1,222 +1,160 @@
 {
+  "slug": "actions-logrocket",
   "name": "Logrocket",
-  "basicOptions": ["appID", "networkSanitization", "inputSanitization"],
-  "options": {
-    "appID": {
-      "tags": [],
-      "default": "",
-      "description": "The LogRocket app ID.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "LogRocket App",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The appID property is required."]],
-      "uIMetadata": null
-    },
-    "networkSanitization": {
-      "tags": [],
-      "default": true,
-      "description": "Sanitize all network request and response bodies from session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Network Sanitization",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The networkSanitization property is required."]],
-      "uIMetadata": null
-    },
-    "inputSanitization": {
-      "tags": [],
-      "default": true,
-      "description": "Obfuscate all user-input elements (like <input> and <select>) from session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Input Sanitization",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The inputSanitization property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "appID": {
+        "label": "LogRocket App",
+        "description": "The LogRocket app ID.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "networkSanitization": {
+        "label": "Network Sanitization",
+        "description": "Sanitize all network request and response bodies from session recordings.",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "inputSanitization": {
+        "label": "Input Sanitization",
+        "description": "Obfuscate all user-input elements (like <input> and <select>) from session recordings.",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identify",
-      "name": "Identify",
-      "description": "Send identification information to logrocket.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "user id",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "user id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "A JSON object containing additional traits that will be associated with the user.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "A JSON object containing additional traits that will be associated with the user.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "track",
-      "name": "Track",
+  "audienceConfig": null,
+  "actions": {
+    "track": {
+      "title": "Track",
       "description": "Send track events to logrocket for filtering and tagging.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "A JSON object containing additional properties that will be associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing additional properties that will be associated with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identify",
-      "name": "Identify",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
+      }
+    },
+    "identify": {
+      "title": "Identify",
+      "description": "Send identification information to logrocket.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
         "userId": {
-          "@path": "$.userId"
+          "label": "User ID",
+          "description": "user id",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "Traits",
+          "description": "A JSON object containing additional traits that will be associated with the user.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
-    },
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "track",
       "name": "Track",
+      "type": "automatic",
+      "partnerAction": "track",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -226,7 +164,22 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify",
+      "type": "automatic",
+      "partnerAction": "identify",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/mixpanel-web/metadata.json
+++ b/packages/browser-destinations/destinations/mixpanel-web/metadata.json
@@ -10,30 +10,37 @@
         "description": "Your Mixpanel project token.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "name": {
         "label": "Mixpanel Instance Name",
         "description": "The name for the new mixpanel instance that you want created.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "api_host": {
         "label": "API Host",
         "description": "The Mixpanel API host to send data to.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": "https://api-js.mixpanel.com"
+        "default": "https://api-js.mixpanel.com",
+        "depends_on": null
       },
       "autocapture": {
         "label": "Autocapture",
         "description": "Enable or disable Mixpanel autocapture functionality. Select \"Custom\" to specify fine grained control over which events are autocaptured.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Enabled",
@@ -48,13 +55,15 @@
             "value": "custom"
           }
         ],
-        "default": "enabled"
+        "default": "enabled",
+        "depends_on": null
       },
       "pageview": {
         "label": "Autocapture Pageview",
         "description": "Capture pageview events automatically",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "Full URL",
@@ -69,77 +78,159 @@
             "value": "url-with-path"
           }
         ],
-        "default": "full-url"
+        "default": "full-url",
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "click": {
         "label": "Autocapture Click",
         "description": "Capture click events automatically",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "dead_click": {
         "label": "Autocapture Dead Click",
         "description": "Capture dead click events automatically",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "input": {
         "label": "Autocapture Input",
         "description": "Capture input events automatically",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "rage_click": {
         "label": "Autocapture Rage Click",
         "description": "Capture rage click events automatically",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "scroll": {
         "label": "Autocapture Scroll",
         "description": "Capture scroll events automatically",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "submit": {
         "label": "Autocapture Submit",
         "description": "Capture form submit events automatically",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "capture_text_content": {
         "label": "Autocapture Capture Text Content",
         "description": "Capture text content of elements in autocaptured events",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "autocapture",
+              "operator": "is",
+              "value": "custom"
+            }
+          ]
+        }
       },
       "cross_subdomain_cookie": {
         "label": "Cross Subdomain Cookie",
         "description": "Enable or disable cross subdomain cookies for Mixpanel.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "persistence": {
         "label": "Persistence Method",
         "description": "Set the persistence method for Mixpanel (cookie or localStorage).",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": [
           {
             "label": "Cookie",
@@ -150,119 +241,148 @@
             "value": "localStorage"
           }
         ],
-        "default": "cookie"
+        "default": "cookie",
+        "depends_on": null
       },
       "track_marketing": {
         "label": "Track Marketing Campaigns",
         "description": "Enable or disable tracking of marketing campaigns in Mixpanel. Includes UTM parameters and click identifiers for various ad platforms.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "cookie_expiration": {
         "label": "Cookie Expiration (days)",
         "description": "Set the cookie expiration time in days for Mixpanel cookies.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 365
+        "default": 365,
+        "depends_on": null
       },
       "disable_persistence": {
         "label": "Disable Persistence",
         "description": "Disable all persistence mechanisms for Mixpanel.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "ip": {
         "label": "Send IP Address",
         "description": "Enable or disable sending IP address information to Mixpanel.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "record_block_class": {
         "label": "Record Block Class",
         "description": "CSS class to block elements from being recorded in session recordings.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "mp-block"
+        "default": "mp-block",
+        "depends_on": null
       },
       "record_block_selector": {
         "label": "Record Block Selector",
         "description": "CSS selector to block elements from being recorded in session recordings.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "img, video, audio"
+        "default": "img, video, audio",
+        "depends_on": null
       },
       "record_canvas": {
         "label": "Record Canvas",
         "description": "Enable or disable recording of canvas elements in session recordings.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "record_heatmap_data": {
         "label": "Record Heatmap Data",
         "description": "Enable or disable tracking of heatmap events in session recordings.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "record_idle_timeout_ms": {
         "label": "Record Idle Timeout (ms)",
         "description": "Idle timeout in milliseconds for session recordings.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 180000
+        "default": 180000,
+        "depends_on": null
       },
       "record_mask_text_class": {
         "label": "Record Mask Text Class",
         "description": "CSS class to mask text elements in session recordings.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "mp-mask"
+        "default": "mp-mask",
+        "depends_on": null
       },
       "record_mask_text_selector": {
         "label": "Record Mask Text Selector",
         "description": "CSS selector to mask text elements in session recordings.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": "*"
+        "default": "*",
+        "depends_on": null
       },
       "record_max_ms": {
         "label": "Record Max (ms)",
         "description": "Maximum recording time in milliseconds for session recordings.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 86400000
+        "default": 86400000,
+        "depends_on": null
       },
       "record_min_ms": {
         "label": "Record Min (ms)",
         "description": "Minimum recording time in milliseconds for session recordings.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 0
+        "default": 0,
+        "depends_on": null
       },
       "record_sessions_percent": {
         "label": "Record Sessions Percent",
         "description": "Percentage of sessions to record for session recordings.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 0
+        "default": 0,
+        "depends_on": null
       }
     }
   },
@@ -276,7 +396,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -299,7 +419,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -322,7 +444,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "unique_id": {
           "label": "Unique ID",
@@ -343,7 +467,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_set": {
           "label": "User Profile Properties to Set",
@@ -376,7 +502,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "first_name": {
               "label": "First Name",
@@ -397,7 +525,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "last_name": {
               "label": "Last Name",
@@ -418,7 +548,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -439,7 +571,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "phone": {
               "label": "Phone",
@@ -460,7 +594,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "avatar": {
               "label": "Avatar",
@@ -481,7 +617,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created": {
               "label": "Created",
@@ -502,7 +640,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -512,7 +652,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_profile_properties_to_set_once": {
           "label": "User Profile Properties to Set Once",
@@ -533,7 +675,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_increment": {
           "label": "User Profile Properties to Increment",
@@ -554,7 +698,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_details": {
           "label": "Group Details",
@@ -587,7 +733,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "group_id": {
               "label": "Group ID",
@@ -608,7 +756,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -618,7 +768,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set": {
           "label": "Group properties to Set",
@@ -639,7 +791,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set_once": {
           "label": "Group properties to set once",
@@ -660,7 +814,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_union": {
           "label": "Group list properties to union",
@@ -693,7 +849,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "string_values": {
               "label": "Values",
@@ -714,7 +872,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -724,7 +884,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "arrayeditor",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -736,7 +898,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -759,7 +921,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -782,7 +946,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "unique_id": {
           "label": "Unique ID",
@@ -803,7 +969,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_set": {
           "label": "User Profile Properties to Set",
@@ -836,7 +1004,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "first_name": {
               "label": "First Name",
@@ -857,7 +1027,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "last_name": {
               "label": "Last Name",
@@ -878,7 +1050,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -899,7 +1073,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "phone": {
               "label": "Phone",
@@ -920,7 +1096,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "avatar": {
               "label": "Avatar",
@@ -941,7 +1119,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created": {
               "label": "Created",
@@ -962,7 +1142,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -972,7 +1154,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_profile_properties_to_set_once": {
           "label": "User Profile Properties to Set Once",
@@ -993,7 +1177,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_increment": {
           "label": "User Profile Properties to Increment",
@@ -1014,7 +1200,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_details": {
           "label": "Group Details",
@@ -1047,7 +1235,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "group_id": {
               "label": "Group ID",
@@ -1068,7 +1258,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1078,7 +1270,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set": {
           "label": "Group properties to Set",
@@ -1099,7 +1293,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set_once": {
           "label": "Group properties to set once",
@@ -1120,7 +1316,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_union": {
           "label": "Group list properties to union",
@@ -1153,7 +1351,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "string_values": {
               "label": "Values",
@@ -1174,7 +1374,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1184,7 +1386,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "arrayeditor",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1196,7 +1400,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "unique_id": {
           "label": "Unique ID",
@@ -1219,7 +1423,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_set": {
           "label": "User Profile Properties to Set",
@@ -1274,7 +1480,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "first_name": {
               "label": "First Name",
@@ -1295,7 +1503,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "last_name": {
               "label": "Last Name",
@@ -1316,7 +1526,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -1337,7 +1549,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "phone": {
               "label": "Phone",
@@ -1358,7 +1572,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "avatar": {
               "label": "Avatar",
@@ -1379,7 +1595,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "created": {
               "label": "Created",
@@ -1400,7 +1618,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1410,7 +1630,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "user_profile_properties_to_set_once": {
           "label": "User Profile Properties to Set Once",
@@ -1431,7 +1653,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user_profile_properties_to_increment": {
           "label": "User Profile Properties to Increment",
@@ -1452,7 +1676,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1464,7 +1690,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "group_details": {
           "label": "Group Details",
@@ -1504,7 +1730,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "group_id": {
               "label": "Group ID",
@@ -1525,7 +1753,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1535,7 +1765,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set": {
           "label": "Group properties to Set",
@@ -1556,7 +1788,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_set_once": {
           "label": "Group properties to set once",
@@ -1577,7 +1811,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "group_profile_properties_to_union": {
           "label": "Group list properties to union",
@@ -1610,7 +1846,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "string_values": {
               "label": "Values",
@@ -1631,7 +1869,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1641,7 +1881,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "arrayeditor",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1653,7 +1895,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "alias": {
           "label": "Alias ID",
@@ -1676,7 +1918,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "original": {
           "label": "Original ID",
@@ -1699,7 +1943,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/mixpanel-web/metadata.json
+++ b/packages/browser-destinations/destinations/mixpanel-web/metadata.json
@@ -1,0 +1,1796 @@
+{
+  "name": "Mixpanel Web (actions)",
+  "basicOptions": [
+    "projectToken",
+    "name",
+    "api_host",
+    "autocapture",
+    "pageview",
+    "click",
+    "dead_click",
+    "input",
+    "rage_click",
+    "scroll",
+    "submit",
+    "capture_text_content",
+    "cross_subdomain_cookie",
+    "persistence",
+    "track_marketing",
+    "cookie_expiration",
+    "disable_persistence",
+    "ip",
+    "record_block_class",
+    "record_block_selector",
+    "record_canvas",
+    "record_heatmap_data",
+    "record_idle_timeout_ms",
+    "record_mask_text_class",
+    "record_mask_text_selector",
+    "record_max_ms",
+    "record_min_ms",
+    "record_sessions_percent"
+  ],
+  "options": {
+    "projectToken": {
+      "tags": [],
+      "default": "",
+      "description": "Your Mixpanel project token.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Project Token",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The projectToken property is required."]],
+      "uIMetadata": null
+    },
+    "name": {
+      "tags": [],
+      "default": "",
+      "description": "The name for the new mixpanel instance that you want created.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Mixpanel Instance Name",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "api_host": {
+      "tags": [],
+      "default": "https://api-js.mixpanel.com",
+      "description": "The Mixpanel API host to send data to.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "API Host",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The api_host property is required."]],
+      "uIMetadata": null
+    },
+    "autocapture": {
+      "tags": [],
+      "default": "enabled",
+      "description": "Enable or disable Mixpanel autocapture functionality. Select \"Custom\" to specify fine grained control over which events are autocaptured.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "enabled",
+          "label": "Enabled",
+          "text": "Enabled"
+        },
+        {
+          "value": "disabled",
+          "label": "Disabled",
+          "text": "Disabled"
+        },
+        {
+          "value": "custom",
+          "label": "Custom",
+          "text": "Custom"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "pageview": {
+      "tags": [],
+      "default": "full-url",
+      "description": "Capture pageview events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Pageview",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "full-url",
+          "label": "Full URL",
+          "text": "Full URL"
+        },
+        {
+          "value": "url-with-path-and-query-string",
+          "label": "URL with Path and Query String",
+          "text": "URL with Path and Query String"
+        },
+        {
+          "value": "url-with-path",
+          "label": "URL with Path",
+          "text": "URL with Path"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The pageview property is required."]],
+      "uIMetadata": null
+    },
+    "click": {
+      "tags": [],
+      "default": true,
+      "description": "Capture click events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Click",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The click property is required."]],
+      "uIMetadata": null
+    },
+    "dead_click": {
+      "tags": [],
+      "default": true,
+      "description": "Capture dead click events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Dead Click",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The dead_click property is required."]],
+      "uIMetadata": null
+    },
+    "input": {
+      "tags": [],
+      "default": true,
+      "description": "Capture input events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Input",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The input property is required."]],
+      "uIMetadata": null
+    },
+    "rage_click": {
+      "tags": [],
+      "default": true,
+      "description": "Capture rage click events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Rage Click",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The rage_click property is required."]],
+      "uIMetadata": null
+    },
+    "scroll": {
+      "tags": [],
+      "default": true,
+      "description": "Capture scroll events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Scroll",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The scroll property is required."]],
+      "uIMetadata": null
+    },
+    "submit": {
+      "tags": [],
+      "default": true,
+      "description": "Capture form submit events automatically",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Submit",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "capture_text_content": {
+      "tags": [],
+      "default": false,
+      "description": "Capture text content of elements in autocaptured events",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Autocapture Capture Text Content",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "autocapture",
+            "operator": "is",
+            "value": "custom"
+          }
+        ]
+      },
+      "validators": [["required", "The capture_text_content property is required."]],
+      "uIMetadata": null
+    },
+    "cross_subdomain_cookie": {
+      "tags": [],
+      "default": true,
+      "description": "Enable or disable cross subdomain cookies for Mixpanel.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cross Subdomain Cookie",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "persistence": {
+      "tags": [],
+      "default": "cookie",
+      "description": "Set the persistence method for Mixpanel (cookie or localStorage).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Persistence Method",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "cookie",
+          "label": "Cookie",
+          "text": "Cookie"
+        },
+        {
+          "value": "localStorage",
+          "label": "Local Storage",
+          "text": "Local Storage"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "track_marketing": {
+      "tags": [],
+      "default": true,
+      "description": "Enable or disable tracking of marketing campaigns in Mixpanel. Includes UTM parameters and click identifiers for various ad platforms.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Track Marketing Campaigns",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cookie_expiration": {
+      "tags": [],
+      "default": 365,
+      "description": "Set the cookie expiration time in days for Mixpanel cookies.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Cookie Expiration (days)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disable_persistence": {
+      "tags": [],
+      "default": false,
+      "description": "Disable all persistence mechanisms for Mixpanel.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Persistence",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "ip": {
+      "tags": [],
+      "default": true,
+      "description": "Enable or disable sending IP address information to Mixpanel.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Send IP Address",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_block_class": {
+      "tags": [],
+      "default": "mp-block",
+      "description": "CSS class to block elements from being recorded in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Block Class",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_block_selector": {
+      "tags": [],
+      "default": "img, video, audio",
+      "description": "CSS selector to block elements from being recorded in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Block Selector",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_canvas": {
+      "tags": [],
+      "default": false,
+      "description": "Enable or disable recording of canvas elements in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Canvas",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_heatmap_data": {
+      "tags": [],
+      "default": false,
+      "description": "Enable or disable tracking of heatmap events in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Heatmap Data",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_idle_timeout_ms": {
+      "tags": [],
+      "default": 180000,
+      "description": "Idle timeout in milliseconds for session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Idle Timeout (ms)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_mask_text_class": {
+      "tags": [],
+      "default": "mp-mask",
+      "description": "CSS class to mask text elements in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Mask Text Class",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_mask_text_selector": {
+      "tags": [],
+      "default": "*",
+      "description": "CSS selector to mask text elements in session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Mask Text Selector",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_max_ms": {
+      "tags": [],
+      "default": 86400000,
+      "description": "Maximum recording time in milliseconds for session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Max (ms)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_min_ms": {
+      "tags": [],
+      "default": 0,
+      "description": "Minimum recording time in milliseconds for session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Min (ms)",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "record_sessions_percent": {
+      "tags": [],
+      "default": 0,
+      "description": "Percentage of sessions to record for session recordings.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Record Sessions Percent",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "alias",
+      "name": "Alias",
+      "description": "Sync alias data to Mixpanel. Use this to replace a Unique ID with a new one.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"alias\"",
+      "fields": [
+        {
+          "fieldKey": "alias",
+          "type": "string",
+          "label": "Alias ID",
+          "description": "The new ID to associate with the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "alias": {
+                "title": "Alias ID",
+                "description": "The new ID to associate with the user.",
+                "type": "string"
+              }
+            },
+            "required": ["alias"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "original",
+          "type": "string",
+          "label": "Original ID",
+          "description": "The original ID to associate with the user.",
+          "defaultValue": {
+            "@path": "$.previousId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "original": {
+                "title": "Original ID",
+                "description": "The original ID to associate with the user.",
+                "type": "string"
+              }
+            },
+            "required": ["original"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "group",
+      "name": "Group",
+      "description": "Sync Group data to Mixpanel.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "group_details",
+          "type": "object",
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel.",
+          "defaultValue": {
+            "group_key": {
+              "@path": "$.traits.group_key"
+            },
+            "group_id": {
+              "@path": "$.groupId"
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_details": {
+                "title": "Group Details",
+                "description": "Details for the group to be created or updated in Mixpanel.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "group_key": {
+                    "title": "Group Key",
+                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+                    "type": "string"
+                  },
+                  "group_id": {
+                    "title": "Group ID",
+                    "description": "The unique ID to associate with the group.",
+                    "type": "string"
+                  }
+                },
+                "required": ["group_key", "group_id"]
+              }
+            },
+            "required": ["group_details"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set",
+          "type": "object",
+          "label": "Group properties to Set",
+          "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set": {
+                "title": "Group properties to Set",
+                "description": "Group Profile Properties to set on the group in Mixpanel.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set_once",
+          "type": "object",
+          "label": "Group properties to set once",
+          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set_once": {
+                "title": "Group properties to set once",
+                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_union",
+          "type": "object",
+          "label": "Group list properties to union",
+          "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "arrayeditor",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_union": {
+                "title": "Group list properties to union",
+                "description": "Merge a list into a list group property. Duplicates will be removed.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "list_name": {
+                      "title": "List Name",
+                      "description": "The name of the list property to union values into.",
+                      "type": "string"
+                    },
+                    "string_values": {
+                      "title": "Values",
+                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["list_name", "string_values"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Sync user profile data to Mixpanel.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "unique_id",
+          "type": "string",
+          "label": "Unique ID",
+          "description": "The unique ID to associate with the user.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "unique_id": {
+                "title": "Unique ID",
+                "description": "The unique ID to associate with the user.",
+                "type": "string"
+              }
+            },
+            "required": ["unique_id"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set",
+          "type": "object",
+          "label": "User Profile Properties to Set",
+          "description": "User Profile Properties to set on the user profile in Mixpanel.",
+          "defaultValue": {
+            "name": {
+              "@path": "$.traits.name"
+            },
+            "first_name": {
+              "@path": "$.traits.first_name"
+            },
+            "last_name": {
+              "@path": "$.traits.last_name"
+            },
+            "email": {
+              "@path": "$.traits.email"
+            },
+            "phone": {
+              "@path": "$.traits.phone"
+            },
+            "avatar": {
+              "@path": "$.traits.avatar"
+            },
+            "created": {
+              "@path": "$.traits.created"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_profile_properties_to_set": {
+                "title": "User Profile Properties to Set",
+                "description": "User Profile Properties to set on the user profile in Mixpanel.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "name": {
+                    "title": "Name",
+                    "description": "The name of the user.",
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "title": "First Name",
+                    "description": "The first name of the user.",
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "title": "Last Name",
+                    "description": "The last name of the user.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email of the user.",
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone": {
+                    "title": "Phone",
+                    "description": "The phone number of the user.",
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "title": "Avatar",
+                    "description": "The avatar URL of the user.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "created": {
+                    "title": "Created",
+                    "description": "The creation date of the user profile.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set_once",
+          "type": "object",
+          "label": "User Profile Properties to Set Once",
+          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_set_once": {
+                "title": "User Profile Properties to Set Once",
+                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_increment",
+          "type": "object",
+          "label": "User Profile Properties to Increment",
+          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_increment": {
+                "title": "User Profile Properties to Increment",
+                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "track",
+      "name": "Track",
+      "description": "Sync Segment track events to Mixpanel.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event to track in Mixpanel.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event to track in Mixpanel.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Properties to associate with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Properties to associate with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "unique_id",
+          "type": "string",
+          "label": "Unique ID",
+          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the track event is sent.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "unique_id": {
+                "title": "Unique ID",
+                "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the track event is sent.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set",
+          "type": "object",
+          "label": "User Profile Properties to Set",
+          "description": "User Profile Properties to set on the user profile in Mixpanel.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_profile_properties_to_set": {
+                "title": "User Profile Properties to Set",
+                "description": "User Profile Properties to set on the user profile in Mixpanel.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "name": {
+                    "title": "Name",
+                    "description": "The name of the user.",
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "title": "First Name",
+                    "description": "The first name of the user.",
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "title": "Last Name",
+                    "description": "The last name of the user.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email of the user.",
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone": {
+                    "title": "Phone",
+                    "description": "The phone number of the user.",
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "title": "Avatar",
+                    "description": "The avatar URL of the user.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "created": {
+                    "title": "Created",
+                    "description": "The creation date of the user profile.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set_once",
+          "type": "object",
+          "label": "User Profile Properties to Set Once",
+          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_set_once": {
+                "title": "User Profile Properties to Set Once",
+                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_increment",
+          "type": "object",
+          "label": "User Profile Properties to Increment",
+          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_increment": {
+                "title": "User Profile Properties to Increment",
+                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_details",
+          "type": "object",
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the track event is sent.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_details": {
+                "title": "Group Details",
+                "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the track event is sent.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "group_key": {
+                    "title": "Group Key",
+                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+                    "type": "string"
+                  },
+                  "group_id": {
+                    "title": "Group ID",
+                    "description": "The unique ID to associate with the group.",
+                    "type": "string"
+                  }
+                },
+                "required": ["group_key", "group_id"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set",
+          "type": "object",
+          "label": "Group properties to Set",
+          "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set": {
+                "title": "Group properties to Set",
+                "description": "Group Profile Properties to set on the group in Mixpanel.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set_once",
+          "type": "object",
+          "label": "Group properties to set once",
+          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set_once": {
+                "title": "Group properties to set once",
+                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_union",
+          "type": "object",
+          "label": "Group list properties to union",
+          "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "arrayeditor",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_union": {
+                "title": "Group list properties to union",
+                "description": "Merge a list into a list group property. Duplicates will be removed.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "list_name": {
+                      "title": "List Name",
+                      "description": "The name of the list property to union values into.",
+                      "type": "string"
+                    },
+                    "string_values": {
+                      "title": "Values",
+                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["list_name", "string_values"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPageView",
+      "name": "Track Page View",
+      "description": "Sync Segment page events to Mixpanel.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event to track in Mixpanel.",
+          "defaultValue": {
+            "@path": "$.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event to track in Mixpanel.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Properties to associate with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Properties to associate with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "unique_id",
+          "type": "string",
+          "label": "Unique ID",
+          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the page event is sent.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "unique_id": {
+                "title": "Unique ID",
+                "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the page event is sent.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set",
+          "type": "object",
+          "label": "User Profile Properties to Set",
+          "description": "User Profile Properties to set on the user profile in Mixpanel.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "user_profile_properties_to_set": {
+                "title": "User Profile Properties to Set",
+                "description": "User Profile Properties to set on the user profile in Mixpanel.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "name": {
+                    "title": "Name",
+                    "description": "The name of the user.",
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "title": "First Name",
+                    "description": "The first name of the user.",
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "title": "Last Name",
+                    "description": "The last name of the user.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email of the user.",
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone": {
+                    "title": "Phone",
+                    "description": "The phone number of the user.",
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "title": "Avatar",
+                    "description": "The avatar URL of the user.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "created": {
+                    "title": "Created",
+                    "description": "The creation date of the user profile.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_set_once",
+          "type": "object",
+          "label": "User Profile Properties to Set Once",
+          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_set_once": {
+                "title": "User Profile Properties to Set Once",
+                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user_profile_properties_to_increment",
+          "type": "object",
+          "label": "User Profile Properties to Increment",
+          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user_profile_properties_to_increment": {
+                "title": "User Profile Properties to Increment",
+                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_details",
+          "type": "object",
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the page event is sent.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue:only",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_details": {
+                "title": "Group Details",
+                "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the page event is sent.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "group_key": {
+                    "title": "Group Key",
+                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+                    "type": "string"
+                  },
+                  "group_id": {
+                    "title": "Group ID",
+                    "description": "The unique ID to associate with the group.",
+                    "type": "string"
+                  }
+                },
+                "required": ["group_key", "group_id"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set",
+          "type": "object",
+          "label": "Group properties to Set",
+          "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set": {
+                "title": "Group properties to Set",
+                "description": "Group Profile Properties to set on the group in Mixpanel.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_set_once",
+          "type": "object",
+          "label": "Group properties to set once",
+          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_set_once": {
+                "title": "Group properties to set once",
+                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "group_profile_properties_to_union",
+          "type": "object",
+          "label": "Group list properties to union",
+          "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "arrayeditor",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "group_profile_properties_to_union": {
+                "title": "Group list properties to union",
+                "description": "Merge a list into a list group property. Duplicates will be removed.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "list_name": {
+                      "title": "List Name",
+                      "description": "The name of the list property to union values into.",
+                      "type": "string"
+                    },
+                    "string_values": {
+                      "title": "Values",
+                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["list_name", "string_values"]
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identify",
+      "name": "Identify",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "unique_id": {
+          "@path": "$.userId"
+        },
+        "user_profile_properties_to_set": {
+          "name": {
+            "@path": "$.traits.name"
+          },
+          "first_name": {
+            "@path": "$.traits.first_name"
+          },
+          "last_name": {
+            "@path": "$.traits.last_name"
+          },
+          "email": {
+            "@path": "$.traits.email"
+          },
+          "phone": {
+            "@path": "$.traits.phone"
+          },
+          "avatar": {
+            "@path": "$.traits.avatar"
+          },
+          "created": {
+            "@path": "$.traits.created"
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "track",
+      "name": "Track",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/mixpanel-web/metadata.json
+++ b/packages/browser-destinations/destinations/mixpanel-web/metadata.json
@@ -1,857 +1,1235 @@
 {
+  "slug": "mixpanel-web-actions",
   "name": "Mixpanel Web (actions)",
-  "basicOptions": [
-    "projectToken",
-    "name",
-    "api_host",
-    "autocapture",
-    "pageview",
-    "click",
-    "dead_click",
-    "input",
-    "rage_click",
-    "scroll",
-    "submit",
-    "capture_text_content",
-    "cross_subdomain_cookie",
-    "persistence",
-    "track_marketing",
-    "cookie_expiration",
-    "disable_persistence",
-    "ip",
-    "record_block_class",
-    "record_block_selector",
-    "record_canvas",
-    "record_heatmap_data",
-    "record_idle_timeout_ms",
-    "record_mask_text_class",
-    "record_mask_text_selector",
-    "record_max_ms",
-    "record_min_ms",
-    "record_sessions_percent"
-  ],
-  "options": {
-    "projectToken": {
-      "tags": [],
-      "default": "",
-      "description": "Your Mixpanel project token.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Project Token",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The projectToken property is required."]],
-      "uIMetadata": null
-    },
-    "name": {
-      "tags": [],
-      "default": "",
-      "description": "The name for the new mixpanel instance that you want created.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Mixpanel Instance Name",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "api_host": {
-      "tags": [],
-      "default": "https://api-js.mixpanel.com",
-      "description": "The Mixpanel API host to send data to.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "API Host",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The api_host property is required."]],
-      "uIMetadata": null
-    },
-    "autocapture": {
-      "tags": [],
-      "default": "enabled",
-      "description": "Enable or disable Mixpanel autocapture functionality. Select \"Custom\" to specify fine grained control over which events are autocaptured.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "enabled",
-          "label": "Enabled",
-          "text": "Enabled"
-        },
-        {
-          "value": "disabled",
-          "label": "Disabled",
-          "text": "Disabled"
-        },
-        {
-          "value": "custom",
-          "label": "Custom",
-          "text": "Custom"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "pageview": {
-      "tags": [],
-      "default": "full-url",
-      "description": "Capture pageview events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Pageview",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "full-url",
-          "label": "Full URL",
-          "text": "Full URL"
-        },
-        {
-          "value": "url-with-path-and-query-string",
-          "label": "URL with Path and Query String",
-          "text": "URL with Path and Query String"
-        },
-        {
-          "value": "url-with-path",
-          "label": "URL with Path",
-          "text": "URL with Path"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "projectToken": {
+        "label": "Project Token",
+        "description": "Your Mixpanel project token.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "name": {
+        "label": "Mixpanel Instance Name",
+        "description": "The name for the new mixpanel instance that you want created.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "api_host": {
+        "label": "API Host",
+        "description": "The Mixpanel API host to send data to.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": "https://api-js.mixpanel.com"
+      },
+      "autocapture": {
+        "label": "Autocapture",
+        "description": "Enable or disable Mixpanel autocapture functionality. Select \"Custom\" to specify fine grained control over which events are autocaptured.",
+        "type": "string",
+        "required": false,
+        "choices": [
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          },
+          {
+            "label": "Custom",
             "value": "custom"
           }
-        ]
+        ],
+        "default": "enabled"
       },
-      "validators": [["required", "The pageview property is required."]],
-      "uIMetadata": null
-    },
-    "click": {
-      "tags": [],
-      "default": true,
-      "description": "Capture click events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Click",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+      "pageview": {
+        "label": "Autocapture Pageview",
+        "description": "Capture pageview events automatically",
+        "type": "string",
+        "required": true,
+        "choices": [
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
-          }
-        ]
-      },
-      "validators": [["required", "The click property is required."]],
-      "uIMetadata": null
-    },
-    "dead_click": {
-      "tags": [],
-      "default": true,
-      "description": "Capture dead click events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Dead Click",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+            "label": "Full URL",
+            "value": "full-url"
+          },
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
-          }
-        ]
-      },
-      "validators": [["required", "The dead_click property is required."]],
-      "uIMetadata": null
-    },
-    "input": {
-      "tags": [],
-      "default": true,
-      "description": "Capture input events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Input",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+            "label": "URL with Path and Query String",
+            "value": "url-with-path-and-query-string"
+          },
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
+            "label": "URL with Path",
+            "value": "url-with-path"
           }
-        ]
+        ],
+        "default": "full-url"
       },
-      "validators": [["required", "The input property is required."]],
-      "uIMetadata": null
-    },
-    "rage_click": {
-      "tags": [],
-      "default": true,
-      "description": "Capture rage click events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Rage Click",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+      "click": {
+        "label": "Autocapture Click",
+        "description": "Capture click events automatically",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "dead_click": {
+        "label": "Autocapture Dead Click",
+        "description": "Capture dead click events automatically",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "input": {
+        "label": "Autocapture Input",
+        "description": "Capture input events automatically",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "rage_click": {
+        "label": "Autocapture Rage Click",
+        "description": "Capture rage click events automatically",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "scroll": {
+        "label": "Autocapture Scroll",
+        "description": "Capture scroll events automatically",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      },
+      "submit": {
+        "label": "Autocapture Submit",
+        "description": "Capture form submit events automatically",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "capture_text_content": {
+        "label": "Autocapture Capture Text Content",
+        "description": "Capture text content of elements in autocaptured events",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": false
+      },
+      "cross_subdomain_cookie": {
+        "label": "Cross Subdomain Cookie",
+        "description": "Enable or disable cross subdomain cookies for Mixpanel.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "persistence": {
+        "label": "Persistence Method",
+        "description": "Set the persistence method for Mixpanel (cookie or localStorage).",
+        "type": "string",
+        "required": false,
+        "choices": [
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
-          }
-        ]
-      },
-      "validators": [["required", "The rage_click property is required."]],
-      "uIMetadata": null
-    },
-    "scroll": {
-      "tags": [],
-      "default": true,
-      "description": "Capture scroll events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Scroll",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+            "label": "Cookie",
+            "value": "cookie"
+          },
           {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
+            "label": "Local Storage",
+            "value": "localStorage"
           }
-        ]
+        ],
+        "default": "cookie"
       },
-      "validators": [["required", "The scroll property is required."]],
-      "uIMetadata": null
-    },
-    "submit": {
-      "tags": [],
-      "default": true,
-      "description": "Capture form submit events automatically",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Submit",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
-          }
-        ]
+      "track_marketing": {
+        "label": "Track Marketing Campaigns",
+        "description": "Enable or disable tracking of marketing campaigns in Mixpanel. Includes UTM parameters and click identifiers for various ad platforms.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "capture_text_content": {
-      "tags": [],
-      "default": false,
-      "description": "Capture text content of elements in autocaptured events",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Autocapture Capture Text Content",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "autocapture",
-            "operator": "is",
-            "value": "custom"
-          }
-        ]
+      "cookie_expiration": {
+        "label": "Cookie Expiration (days)",
+        "description": "Set the cookie expiration time in days for Mixpanel cookies.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 365
       },
-      "validators": [["required", "The capture_text_content property is required."]],
-      "uIMetadata": null
-    },
-    "cross_subdomain_cookie": {
-      "tags": [],
-      "default": true,
-      "description": "Enable or disable cross subdomain cookies for Mixpanel.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cross Subdomain Cookie",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "persistence": {
-      "tags": [],
-      "default": "cookie",
-      "description": "Set the persistence method for Mixpanel (cookie or localStorage).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Persistence Method",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "cookie",
-          "label": "Cookie",
-          "text": "Cookie"
-        },
-        {
-          "value": "localStorage",
-          "label": "Local Storage",
-          "text": "Local Storage"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "track_marketing": {
-      "tags": [],
-      "default": true,
-      "description": "Enable or disable tracking of marketing campaigns in Mixpanel. Includes UTM parameters and click identifiers for various ad platforms.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Track Marketing Campaigns",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cookie_expiration": {
-      "tags": [],
-      "default": 365,
-      "description": "Set the cookie expiration time in days for Mixpanel cookies.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Cookie Expiration (days)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disable_persistence": {
-      "tags": [],
-      "default": false,
-      "description": "Disable all persistence mechanisms for Mixpanel.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Persistence",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "ip": {
-      "tags": [],
-      "default": true,
-      "description": "Enable or disable sending IP address information to Mixpanel.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Send IP Address",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_block_class": {
-      "tags": [],
-      "default": "mp-block",
-      "description": "CSS class to block elements from being recorded in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Block Class",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_block_selector": {
-      "tags": [],
-      "default": "img, video, audio",
-      "description": "CSS selector to block elements from being recorded in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Block Selector",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_canvas": {
-      "tags": [],
-      "default": false,
-      "description": "Enable or disable recording of canvas elements in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Canvas",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_heatmap_data": {
-      "tags": [],
-      "default": false,
-      "description": "Enable or disable tracking of heatmap events in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Heatmap Data",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_idle_timeout_ms": {
-      "tags": [],
-      "default": 180000,
-      "description": "Idle timeout in milliseconds for session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Idle Timeout (ms)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_mask_text_class": {
-      "tags": [],
-      "default": "mp-mask",
-      "description": "CSS class to mask text elements in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Mask Text Class",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_mask_text_selector": {
-      "tags": [],
-      "default": "*",
-      "description": "CSS selector to mask text elements in session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Mask Text Selector",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_max_ms": {
-      "tags": [],
-      "default": 86400000,
-      "description": "Maximum recording time in milliseconds for session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Max (ms)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_min_ms": {
-      "tags": [],
-      "default": 0,
-      "description": "Minimum recording time in milliseconds for session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Min (ms)",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "record_sessions_percent": {
-      "tags": [],
-      "default": 0,
-      "description": "Percentage of sessions to record for session recordings.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Record Sessions Percent",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+      "disable_persistence": {
+        "label": "Disable Persistence",
+        "description": "Disable all persistence mechanisms for Mixpanel.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "ip": {
+        "label": "Send IP Address",
+        "description": "Enable or disable sending IP address information to Mixpanel.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "record_block_class": {
+        "label": "Record Block Class",
+        "description": "CSS class to block elements from being recorded in session recordings.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "mp-block"
+      },
+      "record_block_selector": {
+        "label": "Record Block Selector",
+        "description": "CSS selector to block elements from being recorded in session recordings.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "img, video, audio"
+      },
+      "record_canvas": {
+        "label": "Record Canvas",
+        "description": "Enable or disable recording of canvas elements in session recordings.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "record_heatmap_data": {
+        "label": "Record Heatmap Data",
+        "description": "Enable or disable tracking of heatmap events in session recordings.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "record_idle_timeout_ms": {
+        "label": "Record Idle Timeout (ms)",
+        "description": "Idle timeout in milliseconds for session recordings.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 180000
+      },
+      "record_mask_text_class": {
+        "label": "Record Mask Text Class",
+        "description": "CSS class to mask text elements in session recordings.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "mp-mask"
+      },
+      "record_mask_text_selector": {
+        "label": "Record Mask Text Selector",
+        "description": "CSS selector to mask text elements in session recordings.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": "*"
+      },
+      "record_max_ms": {
+        "label": "Record Max (ms)",
+        "description": "Maximum recording time in milliseconds for session recordings.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 86400000
+      },
+      "record_min_ms": {
+        "label": "Record Min (ms)",
+        "description": "Minimum recording time in milliseconds for session recordings.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 0
+      },
+      "record_sessions_percent": {
+        "label": "Record Sessions Percent",
+        "description": "Percentage of sessions to record for session recordings.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 0
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "alias",
-      "name": "Alias",
-      "description": "Sync alias data to Mixpanel. Use this to replace a Unique ID with a new one.",
+  "audienceConfig": null,
+  "actions": {
+    "track": {
+      "title": "Track",
+      "description": "Sync Segment track events to Mixpanel.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"alias\"",
-      "fields": [
-        {
-          "fieldKey": "alias",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
+          "label": "Event Name",
+          "description": "The name of the event to track in Mixpanel.",
           "type": "string",
-          "label": "Alias ID",
-          "description": "The new ID to associate with the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "alias": {
-                "title": "Alias ID",
-                "description": "The new ID to associate with the user.",
-                "type": "string"
-              }
-            },
-            "required": ["alias"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "original",
-          "type": "string",
-          "label": "Original ID",
-          "description": "The original ID to associate with the user.",
-          "defaultValue": {
-            "@path": "$.previousId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "original": {
-                "title": "Original ID",
-                "description": "The original ID to associate with the user.",
-                "type": "string"
-              }
-            },
-            "required": ["original"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "group",
-      "name": "Group",
-      "description": "Sync Group data to Mixpanel.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "group_details",
+        "properties": {
+          "label": "Event Properties",
+          "description": "Properties to associate with the event.",
           "type": "object",
-          "label": "Group Details",
-          "description": "Details for the group to be created or updated in Mixpanel.",
-          "defaultValue": {
-            "group_key": {
-              "@path": "$.traits.group_key"
-            },
-            "group_id": {
-              "@path": "$.groupId"
-            }
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_details": {
-                "title": "Group Details",
-                "description": "Details for the group to be created or updated in Mixpanel.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "group_key": {
-                    "title": "Group Key",
-                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
-                    "type": "string"
-                  },
-                  "group_id": {
-                    "title": "Group ID",
-                    "description": "The unique ID to associate with the group.",
-                    "type": "string"
-                  }
-                },
-                "required": ["group_key", "group_id"]
-              }
-            },
-            "required": ["group_details"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_profile_properties_to_set",
-          "type": "object",
-          "label": "Group properties to Set",
-          "description": "Group Profile Properties to set on the group in Mixpanel.",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set": {
-                "title": "Group properties to Set",
-                "description": "Group Profile Properties to set on the group in Mixpanel.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "group_profile_properties_to_set_once",
-          "type": "object",
-          "label": "Group properties to set once",
-          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set_once": {
-                "title": "Group properties to set once",
-                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_profile_properties_to_union",
-          "type": "object",
-          "label": "Group list properties to union",
-          "description": "Merge a list into a list group property. Duplicates will be removed.",
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "arrayeditor",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_union": {
-                "title": "Group list properties to union",
-                "description": "Merge a list into a list group property. Duplicates will be removed.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "list_name": {
-                      "title": "List Name",
-                      "description": "The name of the list property to union values into.",
-                      "type": "string"
-                    },
-                    "string_values": {
-                      "title": "Values",
-                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": ["list_name", "string_values"]
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identify",
-      "name": "Identify",
-      "description": "Sync user profile data to Mixpanel.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "unique_id",
-          "type": "string",
+        "unique_id": {
           "label": "Unique ID",
-          "description": "The unique ID to associate with the user.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": true,
+          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the track event is sent.",
+          "type": "string",
+          "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "unique_id": {
-                "title": "Unique ID",
-                "description": "The unique ID to associate with the user.",
-                "type": "string"
-              }
-            },
-            "required": ["unique_id"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_profile_properties_to_set",
-          "type": "object",
+        "user_profile_properties_to_set": {
           "label": "User Profile Properties to Set",
           "description": "User Profile Properties to set on the user profile in Mixpanel.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "name": {
+              "label": "Name",
+              "description": "The name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "first_name": {
+              "label": "First Name",
+              "description": "The first name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "last_name": {
+              "label": "Last Name",
+              "description": "The last name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "phone": {
+              "label": "Phone",
+              "description": "The phone number of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "avatar": {
+              "label": "Avatar",
+              "description": "The avatar URL of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created": {
+              "label": "Created",
+              "description": "The creation date of the user profile.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_set_once": {
+          "label": "User Profile Properties to Set Once",
+          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_increment": {
+          "label": "User Profile Properties to Increment",
+          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_details": {
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the track event is sent.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "group_key": {
+              "label": "Group Key",
+              "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "group_id": {
+              "label": "Group ID",
+              "description": "The unique ID to associate with the group.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue:only",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_set": {
+          "label": "Group properties to Set",
+          "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_set_once": {
+          "label": "Group properties to set once",
+          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_union": {
+          "label": "Group list properties to union",
+          "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "list_name": {
+              "label": "List Name",
+              "description": "The name of the list property to union values into.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "string_values": {
+              "label": "Values",
+              "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+              "type": "string",
+              "required": true,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "arrayeditor",
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "trackPageView": {
+      "title": "Track Page View",
+      "description": "Sync Segment page events to Mixpanel.",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
+          "label": "Event Name",
+          "description": "The name of the event to track in Mixpanel.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Properties to associate with the event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "unique_id": {
+          "label": "Unique ID",
+          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the page event is sent.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_set": {
+          "label": "User Profile Properties to Set",
+          "description": "User Profile Properties to set on the user profile in Mixpanel.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "name": {
+              "label": "Name",
+              "description": "The name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "first_name": {
+              "label": "First Name",
+              "description": "The first name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "last_name": {
+              "label": "Last Name",
+              "description": "The last name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "phone": {
+              "label": "Phone",
+              "description": "The phone number of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "avatar": {
+              "label": "Avatar",
+              "description": "The avatar URL of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created": {
+              "label": "Created",
+              "description": "The creation date of the user profile.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_set_once": {
+          "label": "User Profile Properties to Set Once",
+          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_increment": {
+          "label": "User Profile Properties to Increment",
+          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_details": {
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the page event is sent.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "group_key": {
+              "label": "Group Key",
+              "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "group_id": {
+              "label": "Group ID",
+              "description": "The unique ID to associate with the group.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue:only",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_set": {
+          "label": "Group properties to Set",
+          "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_set_once": {
+          "label": "Group properties to set once",
+          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
+        },
+        "group_profile_properties_to_union": {
+          "label": "Group list properties to union",
+          "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "list_name": {
+              "label": "List Name",
+              "description": "The name of the list property to union values into.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "string_values": {
+              "label": "Values",
+              "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+              "type": "string",
+              "required": true,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "arrayeditor",
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "identify": {
+      "title": "Identify",
+      "description": "Sync user profile data to Mixpanel.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "unique_id": {
+          "label": "Unique ID",
+          "description": "The unique ID to associate with the user.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "user_profile_properties_to_set": {
+          "label": "User Profile Properties to Set",
+          "description": "User Profile Properties to set on the user profile in Mixpanel.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "name": {
               "@path": "$.traits.name"
             },
@@ -874,879 +1252,478 @@
               "@path": "$.traits.created"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_profile_properties_to_set": {
-                "title": "User Profile Properties to Set",
-                "description": "User Profile Properties to set on the user profile in Mixpanel.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "name": {
-                    "title": "Name",
-                    "description": "The name of the user.",
-                    "type": "string"
-                  },
-                  "first_name": {
-                    "title": "First Name",
-                    "description": "The first name of the user.",
-                    "type": "string"
-                  },
-                  "last_name": {
-                    "title": "Last Name",
-                    "description": "The last name of the user.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email of the user.",
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "phone": {
-                    "title": "Phone",
-                    "description": "The phone number of the user.",
-                    "type": "string"
-                  },
-                  "avatar": {
-                    "title": "Avatar",
-                    "description": "The avatar URL of the user.",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "created": {
-                    "title": "Created",
-                    "description": "The creation date of the user profile.",
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "name": {
+              "label": "Name",
+              "description": "The name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "first_name": {
+              "label": "First Name",
+              "description": "The first name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "last_name": {
+              "label": "Last Name",
+              "description": "The last name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "phone": {
+              "label": "Phone",
+              "description": "The phone number of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "avatar": {
+              "label": "Avatar",
+              "description": "The avatar URL of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "created": {
+              "label": "Created",
+              "description": "The creation date of the user profile.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_profile_properties_to_set_once",
-          "type": "object",
+        "user_profile_properties_to_set_once": {
           "label": "User Profile Properties to Set Once",
           "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_set_once": {
-                "title": "User Profile Properties to Set Once",
-                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user_profile_properties_to_increment",
-          "type": "object",
+        "user_profile_properties_to_increment": {
           "label": "User Profile Properties to Increment",
           "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_increment": {
-                "title": "User Profile Properties to Increment",
-                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "track",
-      "name": "Track",
-      "description": "Sync Segment track events to Mixpanel.",
+    "group": {
+      "title": "Group",
+      "description": "Sync Group data to Mixpanel.",
       "platform": "web",
+      "defaultSubscription": "type = \"group\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The name of the event to track in Mixpanel.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "group_details": {
+          "label": "Group Details",
+          "description": "Details for the group to be created or updated in Mixpanel.",
+          "type": "object",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event to track in Mixpanel.",
-                "type": "string"
-              }
+          "dynamic": false,
+          "default": {
+            "group_key": {
+              "@path": "$.traits.group_key"
             },
-            "required": ["event_name"]
+            "group_id": {
+              "@path": "$.groupId"
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Properties to associate with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Properties to associate with the event.",
-                "type": "object"
-              }
+          "placeholder": null,
+          "properties": {
+            "group_key": {
+              "label": "Group Key",
+              "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "group_id": {
+              "label": "Group ID",
+              "description": "The unique ID to associate with the group.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "unique_id",
-          "type": "string",
-          "label": "Unique ID",
-          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the track event is sent.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "unique_id": {
-                "title": "Unique ID",
-                "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the track event is sent.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_set",
-          "type": "object",
-          "label": "User Profile Properties to Set",
-          "description": "User Profile Properties to set on the user profile in Mixpanel.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_profile_properties_to_set": {
-                "title": "User Profile Properties to Set",
-                "description": "User Profile Properties to set on the user profile in Mixpanel.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "name": {
-                    "title": "Name",
-                    "description": "The name of the user.",
-                    "type": "string"
-                  },
-                  "first_name": {
-                    "title": "First Name",
-                    "description": "The first name of the user.",
-                    "type": "string"
-                  },
-                  "last_name": {
-                    "title": "Last Name",
-                    "description": "The last name of the user.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email of the user.",
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "phone": {
-                    "title": "Phone",
-                    "description": "The phone number of the user.",
-                    "type": "string"
-                  },
-                  "avatar": {
-                    "title": "Avatar",
-                    "description": "The avatar URL of the user.",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "created": {
-                    "title": "Created",
-                    "description": "The creation date of the user profile.",
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "required": []
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_set_once",
-          "type": "object",
-          "label": "User Profile Properties to Set Once",
-          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_set_once": {
-                "title": "User Profile Properties to Set Once",
-                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_increment",
-          "type": "object",
-          "label": "User Profile Properties to Increment",
-          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_increment": {
-                "title": "User Profile Properties to Increment",
-                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_details",
-          "type": "object",
-          "label": "Group Details",
-          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the track event is sent.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_details": {
-                "title": "Group Details",
-                "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the track event is sent.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "group_key": {
-                    "title": "Group Key",
-                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
-                    "type": "string"
-                  },
-                  "group_id": {
-                    "title": "Group ID",
-                    "description": "The unique ID to associate with the group.",
-                    "type": "string"
-                  }
-                },
-                "required": ["group_key", "group_id"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "group_profile_properties_to_set",
-          "type": "object",
+        "group_profile_properties_to_set": {
           "label": "Group properties to Set",
           "description": "Group Profile Properties to set on the group in Mixpanel.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set": {
-                "title": "Group properties to Set",
-                "description": "Group Profile Properties to set on the group in Mixpanel.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "group_profile_properties_to_set_once",
-          "type": "object",
+        "group_profile_properties_to_set_once": {
           "label": "Group properties to set once",
           "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set_once": {
-                "title": "Group properties to set once",
-                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "group_profile_properties_to_union",
-          "type": "object",
+        "group_profile_properties_to_union": {
           "label": "Group list properties to union",
           "description": "Merge a list into a list group property. Duplicates will be removed.",
+          "type": "object",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "arrayeditor",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_union": {
-                "title": "Group list properties to union",
-                "description": "Merge a list into a list group property. Duplicates will be removed.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "list_name": {
-                      "title": "List Name",
-                      "description": "The name of the list property to union values into.",
-                      "type": "string"
-                    },
-                    "string_values": {
-                      "title": "Values",
-                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": ["list_name", "string_values"]
-                }
-              }
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "list_name": {
+              "label": "List Name",
+              "description": "The name of the list property to union values into.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "string_values": {
+              "label": "Values",
+              "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
+              "type": "string",
+              "required": true,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "arrayeditor",
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackPageView",
-      "name": "Track Page View",
-      "description": "Sync Segment page events to Mixpanel.",
+    "alias": {
+      "title": "Alias",
+      "description": "Sync alias data to Mixpanel. Use this to replace a Unique ID with a new one.",
       "platform": "web",
+      "defaultSubscription": "type = \"alias\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "alias": {
+          "label": "Alias ID",
+          "description": "The new ID to associate with the user.",
           "type": "string",
-          "label": "Event Name",
-          "description": "The name of the event to track in Mixpanel.",
-          "defaultValue": {
-            "@path": "$.name"
-          },
-          "required": false,
+          "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event to track in Mixpanel.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Properties to associate with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Properties to associate with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "unique_id",
+        "original": {
+          "label": "Original ID",
+          "description": "The original ID to associate with the user.",
           "type": "string",
-          "label": "Unique ID",
-          "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the page event is sent.",
-          "required": false,
+          "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "unique_id": {
-                "title": "Unique ID",
-                "description": "The unique ID to associate with the user. Settings this value will trigger a Mixpanel identify call before immediately the page event is sent.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_set",
-          "type": "object",
-          "label": "User Profile Properties to Set",
-          "description": "User Profile Properties to set on the user profile in Mixpanel.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "user_profile_properties_to_set": {
-                "title": "User Profile Properties to Set",
-                "description": "User Profile Properties to set on the user profile in Mixpanel.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "name": {
-                    "title": "Name",
-                    "description": "The name of the user.",
-                    "type": "string"
-                  },
-                  "first_name": {
-                    "title": "First Name",
-                    "description": "The first name of the user.",
-                    "type": "string"
-                  },
-                  "last_name": {
-                    "title": "Last Name",
-                    "description": "The last name of the user.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email of the user.",
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "phone": {
-                    "title": "Phone",
-                    "description": "The phone number of the user.",
-                    "type": "string"
-                  },
-                  "avatar": {
-                    "title": "Avatar",
-                    "description": "The avatar URL of the user.",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "created": {
-                    "title": "Created",
-                    "description": "The creation date of the user profile.",
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "required": []
-              }
-            },
-            "required": []
+          "default": {
+            "@path": "$.previousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_set_once",
-          "type": "object",
-          "label": "User Profile Properties to Set Once",
-          "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_set_once": {
-                "title": "User Profile Properties to Set Once",
-                "description": "User Profile Properties to set once on the user profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "user_profile_properties_to_increment",
-          "type": "object",
-          "label": "User Profile Properties to Increment",
-          "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user_profile_properties_to_increment": {
-                "title": "User Profile Properties to Increment",
-                "description": "User Profile Properties to increment on the user profile in Mixpanel. Values must be numeric.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_details",
-          "type": "object",
-          "label": "Group Details",
-          "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the page event is sent.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue:only",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_details": {
-                "title": "Group Details",
-                "description": "Details for the group to be created or updated in Mixpanel. Setting this value will trigger a Mixpanel set_group call before the page event is sent.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "group_key": {
-                    "title": "Group Key",
-                    "description": "The Group Key / type of group to associate with the user. This group key should already be defined in your Mixpanel project.",
-                    "type": "string"
-                  },
-                  "group_id": {
-                    "title": "Group ID",
-                    "description": "The unique ID to associate with the group.",
-                    "type": "string"
-                  }
-                },
-                "required": ["group_key", "group_id"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_profile_properties_to_set",
-          "type": "object",
-          "label": "Group properties to Set",
-          "description": "Group Profile Properties to set on the group in Mixpanel.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set": {
-                "title": "Group properties to Set",
-                "description": "Group Profile Properties to set on the group in Mixpanel.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_profile_properties_to_set_once",
-          "type": "object",
-          "label": "Group properties to set once",
-          "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_set_once": {
-                "title": "Group properties to set once",
-                "description": "Group Profile Properties to set once on the group profile in Mixpanel. Values which get set once cannot be overwritten later.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "group_profile_properties_to_union",
-          "type": "object",
-          "label": "Group list properties to union",
-          "description": "Merge a list into a list group property. Duplicates will be removed.",
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "arrayeditor",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "group_profile_properties_to_union": {
-                "title": "Group list properties to union",
-                "description": "Merge a list into a list group property. Duplicates will be removed.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "list_name": {
-                      "title": "List Name",
-                      "description": "The name of the list property to union values into.",
-                      "type": "string"
-                    },
-                    "string_values": {
-                      "title": "Values",
-                      "description": "An array of string values to merge into the list. Non string lists cannot be updated. Duplicates will be removed.",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": ["list_name", "string_values"]
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identify",
+      "name": "Track",
+      "type": "automatic",
+      "partnerAction": "track",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event_name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify",
+      "type": "automatic",
+      "partnerAction": "identify",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "unique_id": {
@@ -1776,21 +1753,7 @@
           }
         }
       },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "track",
-      "name": "Track",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "event_name": {
-          "@path": "$.event"
-        },
-        "properties": {
-          "@path": "$.properties"
-        }
-      },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/moengage-web/metadata.json
+++ b/packages/browser-destinations/destinations/moengage-web/metadata.json
@@ -10,14 +10,17 @@
         "description": "Your Moengage Workspace ID.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "env": {
         "label": "Environment",
         "description": "The environment for your Moengage account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "LIVE",
@@ -28,13 +31,15 @@
             "value": "TEST"
           }
         ],
-        "default": "LIVE"
+        "default": "LIVE",
+        "depends_on": null
       },
       "moeDataCenter": {
         "label": "Datacenter",
         "description": "The datacenter for your Moengage account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "label": "DC-01",
@@ -61,103 +66,152 @@
             "value": "dc_6"
           }
         ],
-        "default": "dc_1"
+        "default": "dc_1",
+        "depends_on": null
       },
       "project_id": {
         "label": "Project ID",
         "description": "Your Moengage Project ID.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "swPath": {
         "label": "Service Worker Path",
         "description": "The path to the service worker file for MoEngage web push notifications. if provided here, you need to host this file on your server.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "enableSPA": {
         "label": "Enable Single Page Application (SPA) Support",
         "description": "Enable Single Page Application (SPA) support in the Moengage SDK. Enable this if your website is a single page application to ensure proper tracking.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "disable_onsite": {
         "label": "Disable Onsite Messaging",
         "description": "Disable Moengage from showing Onsite Messaging on your website.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "customProxyDomain": {
         "label": "Custom Proxy Domain",
         "description": "A custom domain name where the MoEngage web SDK is hosted. Data will be sent to this domain.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "bots_list": {
         "label": "Bots List",
         "description": "A comma delimited list of bot user agents to ignore when tracking events.",
         "type": "string",
         "required": false,
+        "multiple": true,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "disableCookies": {
         "label": "Disable Cookies",
         "description": "Disable Moengage from setting cookies on your website when the page loads.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "disableSdk": {
         "label": "Disable SDK",
         "description": "Disable the Moengage SDK from initializing on your website when the page loads. You can use this to conditionally load the SDK based on user consent.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "cards_enabled": {
         "label": "Enable Cards",
         "description": "Enable MoEngage Cards on your website to engage users with personalized content.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "css_selector_inbox_icon": {
         "label": "CSS Selector for Inbox Icon",
         "description": "The CSS selector for the MoEngage Inbox icon on your website. The user will click this icon to open the inbox.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "cards_enabled",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "floating_bell_icon_desktop": {
         "label": "Enable Floating Bell Icon on Desktop",
         "description": "Enable the floating bell icon for MoEngage notifications on desktop devices.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "cards_enabled",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       },
       "floating_bell_icon_mobile": {
         "label": "Enable Floating Bell Icon on Mobile",
         "description": "Enable the floating bell icon for MoEngage notifications on mobile devices.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": {
+          "conditions": [
+            {
+              "fieldKey": "cards_enabled",
+              "operator": "is",
+              "value": true
+            }
+          ]
+        }
       }
     }
   },
@@ -171,7 +225,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_name": {
           "label": "Event Name",
@@ -194,7 +248,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "attributes": {
           "label": "Attributes",
@@ -217,7 +273,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -229,7 +287,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "identifiers": {
           "label": "Identifiers",
@@ -272,7 +330,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -293,7 +353,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "mobile": {
               "label": "Mobile",
@@ -314,7 +376,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -324,7 +388,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         },
         "attributes": {
           "label": "User Attributes",
@@ -379,7 +445,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "last_name": {
               "label": "Last Name",
@@ -400,7 +468,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -421,7 +491,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "mobile": {
               "label": "Mobile",
@@ -442,7 +514,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "username": {
               "label": "Username",
@@ -463,7 +537,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "gender": {
               "label": "Gender",
@@ -484,7 +560,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "birthday": {
               "label": "Birthday",
@@ -505,7 +583,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -515,7 +595,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         }
       }
     }

--- a/packages/browser-destinations/destinations/moengage-web/metadata.json
+++ b/packages/browser-destinations/destinations/moengage-web/metadata.json
@@ -1,341 +1,245 @@
 {
+  "slug": "actions-moengage-web",
   "name": "Moengage Web",
-  "basicOptions": [
-    "app_id",
-    "env",
-    "moeDataCenter",
-    "project_id",
-    "swPath",
-    "enableSPA",
-    "disable_onsite",
-    "customProxyDomain",
-    "bots_list",
-    "disableCookies",
-    "disableSdk",
-    "cards_enabled",
-    "css_selector_inbox_icon",
-    "floating_bell_icon_desktop",
-    "floating_bell_icon_mobile"
-  ],
-  "options": {
-    "app_id": {
-      "tags": [],
-      "default": "",
-      "description": "Your Moengage Workspace ID.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Workspace ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The app_id property is required."]],
-      "uIMetadata": null
-    },
-    "env": {
-      "tags": [],
-      "default": "LIVE",
-      "description": "The environment for your Moengage account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Environment",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "LIVE",
-          "label": "LIVE",
-          "text": "LIVE"
-        },
-        {
-          "value": "TEST",
-          "label": "TEST",
-          "text": "TEST"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The env property is required."]],
-      "uIMetadata": null
-    },
-    "moeDataCenter": {
-      "tags": [],
-      "default": "dc_1",
-      "description": "The datacenter for your Moengage account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Datacenter",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "dc_1",
-          "label": "DC-01",
-          "text": "DC-01"
-        },
-        {
-          "value": "dc_2",
-          "label": "DC-02",
-          "text": "DC-02"
-        },
-        {
-          "value": "dc_3",
-          "label": "DC-03",
-          "text": "DC-03"
-        },
-        {
-          "value": "dc_4",
-          "label": "DC-04",
-          "text": "DC-04"
-        },
-        {
-          "value": "dc_5",
-          "label": "DC-05",
-          "text": "DC-05"
-        },
-        {
-          "value": "dc_6",
-          "label": "DC-06",
-          "text": "DC-06"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The moeDataCenter property is required."]],
-      "uIMetadata": null
-    },
-    "project_id": {
-      "tags": [],
-      "default": "",
-      "description": "Your Moengage Project ID.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Project ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "swPath": {
-      "tags": [],
-      "default": "",
-      "description": "The path to the service worker file for MoEngage web push notifications. if provided here, you need to host this file on your server.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Service Worker Path",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "enableSPA": {
-      "tags": [],
-      "default": false,
-      "description": "Enable Single Page Application (SPA) support in the Moengage SDK. Enable this if your website is a single page application to ensure proper tracking.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Single Page Application (SPA) Support",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disable_onsite": {
-      "tags": [],
-      "default": false,
-      "description": "Disable Moengage from showing Onsite Messaging on your website.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Onsite Messaging",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "customProxyDomain": {
-      "tags": [],
-      "default": "",
-      "description": "A custom domain name where the MoEngage web SDK is hosted. Data will be sent to this domain.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Custom Proxy Domain",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "bots_list": {
-      "tags": [],
-      "default": "",
-      "description": "A comma delimited list of bot user agents to ignore when tracking events.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Bots List",
-      "private": false,
-      "scope": "event_destination",
-      "type": "array",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableCookies": {
-      "tags": [],
-      "default": false,
-      "description": "Disable Moengage from setting cookies on your website when the page loads.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable Cookies",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableSdk": {
-      "tags": [],
-      "default": false,
-      "description": "Disable the Moengage SDK from initializing on your website when the page loads. You can use this to conditionally load the SDK based on user consent.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable SDK",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "cards_enabled": {
-      "tags": [],
-      "default": false,
-      "description": "Enable MoEngage Cards on your website to engage users with personalized content.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Cards",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "css_selector_inbox_icon": {
-      "tags": [],
-      "default": "",
-      "description": "The CSS selector for the MoEngage Inbox icon on your website. The user will click this icon to open the inbox.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "CSS Selector for Inbox Icon",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
-          {
-            "fieldKey": "cards_enabled",
-            "operator": "is",
-            "value": true
-          }
-        ]
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "app_id": {
+        "label": "Workspace ID",
+        "description": "Your Moengage Workspace ID.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
       },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "floating_bell_icon_desktop": {
-      "tags": [],
-      "default": false,
-      "description": "Enable the floating bell icon for MoEngage notifications on desktop devices.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Floating Bell Icon on Desktop",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+      "env": {
+        "label": "Environment",
+        "description": "The environment for your Moengage account.",
+        "type": "string",
+        "required": true,
+        "choices": [
           {
-            "fieldKey": "cards_enabled",
-            "operator": "is",
-            "value": true
-          }
-        ]
-      },
-      "validators": [],
-      "uIMetadata": null
-    },
-    "floating_bell_icon_mobile": {
-      "tags": [],
-      "default": false,
-      "description": "Enable the floating bell icon for MoEngage notifications on mobile devices.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Enable Floating Bell Icon on Mobile",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": {
-        "conditions": [
+            "label": "LIVE",
+            "value": "LIVE"
+          },
           {
-            "fieldKey": "cards_enabled",
-            "operator": "is",
-            "value": true
+            "label": "TEST",
+            "value": "TEST"
           }
-        ]
+        ],
+        "default": "LIVE"
       },
-      "validators": [],
-      "uIMetadata": null
+      "moeDataCenter": {
+        "label": "Datacenter",
+        "description": "The datacenter for your Moengage account.",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "label": "DC-01",
+            "value": "dc_1"
+          },
+          {
+            "label": "DC-02",
+            "value": "dc_2"
+          },
+          {
+            "label": "DC-03",
+            "value": "dc_3"
+          },
+          {
+            "label": "DC-04",
+            "value": "dc_4"
+          },
+          {
+            "label": "DC-05",
+            "value": "dc_5"
+          },
+          {
+            "label": "DC-06",
+            "value": "dc_6"
+          }
+        ],
+        "default": "dc_1"
+      },
+      "project_id": {
+        "label": "Project ID",
+        "description": "Your Moengage Project ID.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "swPath": {
+        "label": "Service Worker Path",
+        "description": "The path to the service worker file for MoEngage web push notifications. if provided here, you need to host this file on your server.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "enableSPA": {
+        "label": "Enable Single Page Application (SPA) Support",
+        "description": "Enable Single Page Application (SPA) support in the Moengage SDK. Enable this if your website is a single page application to ensure proper tracking.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "disable_onsite": {
+        "label": "Disable Onsite Messaging",
+        "description": "Disable Moengage from showing Onsite Messaging on your website.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "customProxyDomain": {
+        "label": "Custom Proxy Domain",
+        "description": "A custom domain name where the MoEngage web SDK is hosted. Data will be sent to this domain.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "bots_list": {
+        "label": "Bots List",
+        "description": "A comma delimited list of bot user agents to ignore when tracking events.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "disableCookies": {
+        "label": "Disable Cookies",
+        "description": "Disable Moengage from setting cookies on your website when the page loads.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "disableSdk": {
+        "label": "Disable SDK",
+        "description": "Disable the Moengage SDK from initializing on your website when the page loads. You can use this to conditionally load the SDK based on user consent.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "cards_enabled": {
+        "label": "Enable Cards",
+        "description": "Enable MoEngage Cards on your website to engage users with personalized content.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "css_selector_inbox_icon": {
+        "label": "CSS Selector for Inbox Icon",
+        "description": "The CSS selector for the MoEngage Inbox icon on your website. The user will click this icon to open the inbox.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "floating_bell_icon_desktop": {
+        "label": "Enable Floating Bell Icon on Desktop",
+        "description": "Enable the floating bell icon for MoEngage notifications on desktop devices.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "floating_bell_icon_mobile": {
+        "label": "Enable Floating Bell Icon on Mobile",
+        "description": "Enable the floating bell icon for MoEngage notifications on mobile devices.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Send Segment track events to Moengage.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_name": {
+          "label": "Event Name",
+          "description": "The name of the event to be tracked in Moengage.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "attributes": {
+          "label": "Attributes",
+          "description": "A dictionary of key-value pairs that will be sent as event attributes to Moengage.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Send Segment identify events to Moengage.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "identifiers",
-          "type": "object",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "identifiers": {
           "label": "Identifiers",
           "description": "Unique identifiers for the user to be identified in Moengage. This can be a user ID, email, or any other unique identifier.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "user_id": {
               "@path": "$.userId"
             },
@@ -346,54 +250,91 @@
               "@path": "$.traits.phone"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "identifiers": {
-                "title": "Identifiers",
-                "description": "Unique identifiers for the user to be identified in Moengage. This can be a user ID, email, or any other unique identifier.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "user_id": {
-                    "title": "User ID",
-                    "description": "A unique identifier for the user.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email address of the user.",
-                    "type": "string"
-                  },
-                  "mobile": {
-                    "title": "Mobile",
-                    "description": "The mobile number of the user.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "user_id": {
+              "label": "User ID",
+              "description": "A unique identifier for the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "email": {
+              "label": "Email",
+              "description": "The email address of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "mobile": {
+              "label": "Mobile",
+              "description": "The mobile number of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "attributes",
-          "type": "object",
+        "attributes": {
           "label": "User Attributes",
           "description": "A dictionary of key-value pairs that will be sent as user attributes to Moengage.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "first_name": {
               "@path": "$.traits.first_name"
             },
@@ -416,141 +357,168 @@
               "@path": "$.traits.birthday"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "attributes": {
-                "title": "User Attributes",
-                "description": "A dictionary of key-value pairs that will be sent as user attributes to Moengage.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "first_name": {
-                    "title": "First Name",
-                    "description": "The first name of the user.",
-                    "type": "string"
-                  },
-                  "last_name": {
-                    "title": "Last Name",
-                    "description": "The last name of the user.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email address of the user.",
-                    "type": "string"
-                  },
-                  "mobile": {
-                    "title": "Mobile",
-                    "description": "The mobile number of the user.",
-                    "type": "string"
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username of the user.",
-                    "type": "string"
-                  },
-                  "gender": {
-                    "title": "Gender",
-                    "description": "The gender of the user.",
-                    "type": "string"
-                  },
-                  "birthday": {
-                    "title": "Birthday",
-                    "description": "The birthday of the user in ISO 8601 format (YYYY-MM-DD).",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "first_name": {
+              "label": "First Name",
+              "description": "The first name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "last_name": {
+              "label": "Last Name",
+              "description": "The last name of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email address of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "mobile": {
+              "label": "Mobile",
+              "description": "The mobile number of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "username": {
+              "label": "Username",
+              "description": "The username of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "gender": {
+              "label": "Gender",
+              "description": "The gender of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "birthday": {
+              "label": "Birthday",
+              "description": "The birthday of the user in ISO 8601 format (YYYY-MM-DD).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Send Segment track events to Moengage.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_name",
-          "type": "string",
-          "label": "Event Name",
-          "description": "The name of the event to be tracked in Moengage.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_name": {
-                "title": "Event Name",
-                "description": "The name of the event to be tracked in Moengage.",
-                "type": "string"
-              }
-            },
-            "required": ["event_name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "attributes",
-          "type": "object",
-          "label": "Attributes",
-          "description": "A dictionary of key-value pairs that will be sent as event attributes to Moengage.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributes": {
-                "title": "Attributes",
-                "description": "A dictionary of key-value pairs that will be sent as event attributes to Moengage.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/moengage-web/metadata.json
+++ b/packages/browser-destinations/destinations/moengage-web/metadata.json
@@ -1,0 +1,556 @@
+{
+  "name": "Moengage Web",
+  "basicOptions": [
+    "app_id",
+    "env",
+    "moeDataCenter",
+    "project_id",
+    "swPath",
+    "enableSPA",
+    "disable_onsite",
+    "customProxyDomain",
+    "bots_list",
+    "disableCookies",
+    "disableSdk",
+    "cards_enabled",
+    "css_selector_inbox_icon",
+    "floating_bell_icon_desktop",
+    "floating_bell_icon_mobile"
+  ],
+  "options": {
+    "app_id": {
+      "tags": [],
+      "default": "",
+      "description": "Your Moengage Workspace ID.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Workspace ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The app_id property is required."]],
+      "uIMetadata": null
+    },
+    "env": {
+      "tags": [],
+      "default": "LIVE",
+      "description": "The environment for your Moengage account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Environment",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "LIVE",
+          "label": "LIVE",
+          "text": "LIVE"
+        },
+        {
+          "value": "TEST",
+          "label": "TEST",
+          "text": "TEST"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The env property is required."]],
+      "uIMetadata": null
+    },
+    "moeDataCenter": {
+      "tags": [],
+      "default": "dc_1",
+      "description": "The datacenter for your Moengage account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Datacenter",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "dc_1",
+          "label": "DC-01",
+          "text": "DC-01"
+        },
+        {
+          "value": "dc_2",
+          "label": "DC-02",
+          "text": "DC-02"
+        },
+        {
+          "value": "dc_3",
+          "label": "DC-03",
+          "text": "DC-03"
+        },
+        {
+          "value": "dc_4",
+          "label": "DC-04",
+          "text": "DC-04"
+        },
+        {
+          "value": "dc_5",
+          "label": "DC-05",
+          "text": "DC-05"
+        },
+        {
+          "value": "dc_6",
+          "label": "DC-06",
+          "text": "DC-06"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The moeDataCenter property is required."]],
+      "uIMetadata": null
+    },
+    "project_id": {
+      "tags": [],
+      "default": "",
+      "description": "Your Moengage Project ID.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Project ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "swPath": {
+      "tags": [],
+      "default": "",
+      "description": "The path to the service worker file for MoEngage web push notifications. if provided here, you need to host this file on your server.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Service Worker Path",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "enableSPA": {
+      "tags": [],
+      "default": false,
+      "description": "Enable Single Page Application (SPA) support in the Moengage SDK. Enable this if your website is a single page application to ensure proper tracking.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Single Page Application (SPA) Support",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disable_onsite": {
+      "tags": [],
+      "default": false,
+      "description": "Disable Moengage from showing Onsite Messaging on your website.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Onsite Messaging",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "customProxyDomain": {
+      "tags": [],
+      "default": "",
+      "description": "A custom domain name where the MoEngage web SDK is hosted. Data will be sent to this domain.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Custom Proxy Domain",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "bots_list": {
+      "tags": [],
+      "default": "",
+      "description": "A comma delimited list of bot user agents to ignore when tracking events.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Bots List",
+      "private": false,
+      "scope": "event_destination",
+      "type": "array",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableCookies": {
+      "tags": [],
+      "default": false,
+      "description": "Disable Moengage from setting cookies on your website when the page loads.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable Cookies",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableSdk": {
+      "tags": [],
+      "default": false,
+      "description": "Disable the Moengage SDK from initializing on your website when the page loads. You can use this to conditionally load the SDK based on user consent.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable SDK",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "cards_enabled": {
+      "tags": [],
+      "default": false,
+      "description": "Enable MoEngage Cards on your website to engage users with personalized content.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Cards",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "css_selector_inbox_icon": {
+      "tags": [],
+      "default": "",
+      "description": "The CSS selector for the MoEngage Inbox icon on your website. The user will click this icon to open the inbox.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "CSS Selector for Inbox Icon",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "cards_enabled",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "floating_bell_icon_desktop": {
+      "tags": [],
+      "default": false,
+      "description": "Enable the floating bell icon for MoEngage notifications on desktop devices.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Floating Bell Icon on Desktop",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "cards_enabled",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    },
+    "floating_bell_icon_mobile": {
+      "tags": [],
+      "default": false,
+      "description": "Enable the floating bell icon for MoEngage notifications on mobile devices.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Enable Floating Bell Icon on Mobile",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": {
+        "conditions": [
+          {
+            "fieldKey": "cards_enabled",
+            "operator": "is",
+            "value": true
+          }
+        ]
+      },
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Send Segment identify events to Moengage.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "identifiers",
+          "type": "object",
+          "label": "Identifiers",
+          "description": "Unique identifiers for the user to be identified in Moengage. This can be a user ID, email, or any other unique identifier.",
+          "defaultValue": {
+            "user_id": {
+              "@path": "$.userId"
+            },
+            "email": {
+              "@path": "$.traits.email"
+            },
+            "mobile": {
+              "@path": "$.traits.phone"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "identifiers": {
+                "title": "Identifiers",
+                "description": "Unique identifiers for the user to be identified in Moengage. This can be a user ID, email, or any other unique identifier.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "user_id": {
+                    "title": "User ID",
+                    "description": "A unique identifier for the user.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email address of the user.",
+                    "type": "string"
+                  },
+                  "mobile": {
+                    "title": "Mobile",
+                    "description": "The mobile number of the user.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "User Attributes",
+          "description": "A dictionary of key-value pairs that will be sent as user attributes to Moengage.",
+          "defaultValue": {
+            "first_name": {
+              "@path": "$.traits.first_name"
+            },
+            "last_name": {
+              "@path": "$.traits.last_name"
+            },
+            "email": {
+              "@path": "$.traits.email"
+            },
+            "mobile": {
+              "@path": "$.traits.phone"
+            },
+            "username": {
+              "@path": "$.traits.username"
+            },
+            "gender": {
+              "@path": "$.traits.gender"
+            },
+            "birthday": {
+              "@path": "$.traits.birthday"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "attributes": {
+                "title": "User Attributes",
+                "description": "A dictionary of key-value pairs that will be sent as user attributes to Moengage.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "first_name": {
+                    "title": "First Name",
+                    "description": "The first name of the user.",
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "title": "Last Name",
+                    "description": "The last name of the user.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email address of the user.",
+                    "type": "string"
+                  },
+                  "mobile": {
+                    "title": "Mobile",
+                    "description": "The mobile number of the user.",
+                    "type": "string"
+                  },
+                  "username": {
+                    "title": "Username",
+                    "description": "The username of the user.",
+                    "type": "string"
+                  },
+                  "gender": {
+                    "title": "Gender",
+                    "description": "The gender of the user.",
+                    "type": "string"
+                  },
+                  "birthday": {
+                    "title": "Birthday",
+                    "description": "The birthday of the user in ISO 8601 format (YYYY-MM-DD).",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send Segment track events to Moengage.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event to be tracked in Moengage.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_name": {
+                "title": "Event Name",
+                "description": "The name of the event to be tracked in Moengage.",
+                "type": "string"
+              }
+            },
+            "required": ["event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "Attributes",
+          "description": "A dictionary of key-value pairs that will be sent as event attributes to Moengage.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributes": {
+                "title": "Attributes",
+                "description": "A dictionary of key-value pairs that will be sent as event attributes to Moengage.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
@@ -11,14 +11,17 @@
         "description": "Pendo API Key",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "region": {
         "label": "Region",
         "description": "The region for your Pendo subscription.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": [
           {
             "value": "https://cdn.pendo.io",
@@ -37,31 +40,38 @@
             "label": "Japan"
           }
         ],
-        "default": "https://cdn.pendo.io"
+        "default": "https://cdn.pendo.io",
+        "depends_on": null
       },
       "cnameContentHost": {
         "label": "Optional CNAME content host",
         "description": "If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "disableUserTraitsOnLoad": {
         "label": "Disable passing Segment's user traits to Pendo on start up",
         "description": "Override sending Segment's user traits on load. This will prevent Pendo from initializing with the user traits from Segment (analytics.user().traits()). Allowing you to adjust the mapping of visitor metadata in Segment's identify event.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "disableGroupIdAndTraitsOnLoad": {
         "label": "Disable passing Segment's group id and group traits to Pendo on start up",
         "description": "Override sending Segment's group id for Pendo's account id. This will prevent Pendo from initializing with the group id from Segment (analytics.group().id()). Allowing you to adjust the mapping of account id in Segment's group event.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -75,7 +85,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event": {
           "label": "Event name",
@@ -98,7 +108,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "metadata": {
           "label": "Metadata",
@@ -121,7 +133,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -133,7 +147,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "visitorId": {
           "label": "Visitor ID",
@@ -156,7 +170,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "visitorData": {
           "label": "Visitor Metadata",
@@ -179,7 +195,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "accountId": {
           "label": "Account ID",
@@ -212,7 +230,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -224,7 +244,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "visitorId": {
           "label": "Visitor ID",
@@ -247,7 +267,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "accountId": {
           "label": "Account ID",
@@ -270,7 +292,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "accountData": {
           "label": "Account Metadata",
@@ -293,7 +317,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "parentAccountData": {
           "label": "Parent Account Metadata",
@@ -327,7 +353,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -337,7 +365,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": true
         }
       }
     }

--- a/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
@@ -1,334 +1,195 @@
 {
+  "slug": "actions-pendo-web",
   "name": "Pendo Web (actions)",
+  "mode": "device",
   "description": "Send analytics events, User profile data and Account data to Pendo via Segment track(), identify() and group() events on your browser",
-  "basicOptions": ["apiKey", "region", "cnameContentHost", "disableUserTraitsOnLoad", "disableGroupIdAndTraitsOnLoad"],
-  "options": {
-    "apiKey": {
-      "tags": [],
-      "default": "",
-      "description": "Pendo API Key",
-      "encrypt": true,
-      "hidden": false,
-      "label": "Pendo API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The apiKey property is required."]],
-      "uIMetadata": null
-    },
-    "region": {
-      "tags": [],
-      "default": "https://cdn.pendo.io",
-      "description": "The region for your Pendo subscription.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Region",
-      "private": false,
-      "scope": "event_destination",
-      "type": "select",
-      "options": [
-        {
-          "value": "https://cdn.pendo.io",
-          "label": "US (default)",
-          "text": "US (default)"
-        },
-        {
-          "value": "https://cdn.eu.pendo.io",
-          "label": "EU",
-          "text": "EU"
-        },
-        {
-          "value": "https://us1.cdn.pendo.io",
-          "label": "US restricted",
-          "text": "US restricted"
-        },
-        {
-          "value": "https://cdn.jpn.pendo.io",
-          "label": "Japan",
-          "text": "Japan"
-        }
-      ],
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The region property is required."]],
-      "uIMetadata": null
-    },
-    "cnameContentHost": {
-      "tags": [],
-      "default": "",
-      "description": "If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Optional CNAME content host",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableUserTraitsOnLoad": {
-      "tags": [],
-      "default": false,
-      "description": "Override sending Segment's user traits on load. This will prevent Pendo from initializing with the user traits from Segment (analytics.user().traits()). Allowing you to adjust the mapping of visitor metadata in Segment's identify event.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable passing Segment's user traits to Pendo on start up",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "disableGroupIdAndTraitsOnLoad": {
-      "tags": [],
-      "default": false,
-      "description": "Override sending Segment's group id for Pendo's account id. This will prevent Pendo from initializing with the group id from Segment (analytics.group().id()). Allowing you to adjust the mapping of account id in Segment's group event.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Disable passing Segment's group id and group traits to Pendo on start up",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "apiKey": {
+        "label": "Pendo API Key",
+        "description": "Pendo API Key",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "region": {
+        "label": "Region",
+        "description": "The region for your Pendo subscription.",
+        "type": "string",
+        "required": true,
+        "choices": [
+          {
+            "value": "https://cdn.pendo.io",
+            "label": "US (default)"
+          },
+          {
+            "value": "https://cdn.eu.pendo.io",
+            "label": "EU"
+          },
+          {
+            "value": "https://us1.cdn.pendo.io",
+            "label": "US restricted"
+          },
+          {
+            "value": "https://cdn.jpn.pendo.io",
+            "label": "Japan"
+          }
+        ],
+        "default": "https://cdn.pendo.io"
+      },
+      "cnameContentHost": {
+        "label": "Optional CNAME content host",
+        "description": "If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "disableUserTraitsOnLoad": {
+        "label": "Disable passing Segment's user traits to Pendo on start up",
+        "description": "Override sending Segment's user traits on load. This will prevent Pendo from initializing with the user traits from Segment (analytics.user().traits()). Allowing you to adjust the mapping of visitor metadata in Segment's identify event.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "disableGroupIdAndTraitsOnLoad": {
+        "label": "Disable passing Segment's group id and group traits to Pendo on start up",
+        "description": "Override sending Segment's group id for Pendo's account id. This will prevent Pendo from initializing with the group id from Segment (analytics.group().id()). Allowing you to adjust the mapping of account id in Segment's group event.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "group",
-      "name": "Send Group Event",
-      "description": "Send Segment group() events to Pendo",
+  "audienceConfig": null,
+  "actions": {
+    "track": {
+      "title": "Send Track Event",
+      "description": "Send Segment track() events to Pendo",
       "platform": "web",
+      "defaultSubscription": "type=\"track\"",
       "hidden": false,
-      "defaultTrigger": "type=\"group\"",
-      "fields": [
-        {
-          "fieldKey": "visitorId",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event": {
+          "label": "Event name",
+          "description": "The name of the analytics event",
           "type": "string",
-          "label": "Visitor ID",
-          "description": "Pendo Visitor ID. Maps to Segment userId",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "readOnly": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "visitorId": {
-                "title": "Visitor ID",
-                "description": "Pendo Visitor ID. Maps to Segment userId",
-                "type": "string"
-              }
-            },
-            "required": ["visitorId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "accountId",
-          "type": "string",
-          "label": "Account ID",
-          "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
           "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "accountId": {
-                "title": "Account ID",
-                "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
-                "type": "string"
-              }
-            },
-            "required": ["accountId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "accountData",
+        "metadata": {
+          "label": "Metadata",
+          "description": "Additional metadata to include in the event",
           "type": "object",
-          "label": "Account Metadata",
-          "description": "Additional Account data to send",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
           "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "accountData": {
-                "title": "Account Metadata",
-                "description": "Additional Account data to send",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "parentAccountData",
-          "type": "object",
-          "label": "Parent Account Metadata",
-          "description": "Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.",
-          "defaultValue": {
-            "@path": "$.traits.parentAccount"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "parentAccountData": {
-                "title": "Parent Account Metadata",
-                "description": "Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": true,
-                "properties": {
-                  "id": {
-                    "title": "Parent Account ID",
-                    "type": "string"
-                  }
-                },
-                "required": ["id"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "identify",
-      "name": "Send Identify Event",
+    "identify": {
+      "title": "Send Identify Event",
       "description": "Send Segment identify() events to Pendo",
       "platform": "web",
+      "defaultSubscription": "type=\"identify\"",
       "hidden": false,
-      "defaultTrigger": "type=\"identify\"",
-      "fields": [
-        {
-          "fieldKey": "visitorId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "visitorId": {
           "label": "Visitor ID",
           "description": "Pendo Visitor ID. Maps to Segment userId",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "readOnly": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "visitorId": {
-                "title": "Visitor ID",
-                "description": "Pendo Visitor ID. Maps to Segment userId",
-                "type": "string"
-              }
-            },
-            "required": ["visitorId"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": true,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "visitorData",
-          "type": "object",
+        "visitorData": {
           "label": "Visitor Metadata",
           "description": "Additional Visitor data to send",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "visitorData": {
-                "title": "Visitor Metadata",
-                "description": "Additional Visitor data to send",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "accountId",
-          "type": "string",
+        "accountId": {
           "label": "Account ID",
           "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.context.groupId"
@@ -341,128 +202,166 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
           "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "accountId": {
-                "title": "Account ID",
-                "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "track",
-      "name": "Send Track Event",
-      "description": "Send Segment track() events to Pendo",
+    "group": {
+      "title": "Send Group Event",
+      "description": "Send Segment group() events to Pendo",
       "platform": "web",
+      "defaultSubscription": "type=\"group\"",
       "hidden": false,
-      "defaultTrigger": "type=\"track\"",
-      "fields": [
-        {
-          "fieldKey": "event",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "visitorId": {
+          "label": "Visitor ID",
+          "description": "Pendo Visitor ID. Maps to Segment userId",
           "type": "string",
-          "label": "Event name",
-          "description": "The name of the analytics event",
-          "defaultValue": {
-            "@path": "$.event"
-          },
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "Event name",
-                "description": "The name of the analytics event",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "metadata",
-          "type": "object",
-          "label": "Metadata",
-          "description": "Additional metadata to include in the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
           "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "readOnly": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "metadata": {
-                "title": "Metadata",
-                "description": "Additional metadata to include in the event",
-                "type": "object"
-              }
-            },
-            "required": []
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "group",
-      "name": "Send Group Event",
-      "subscribe": "type = \"group\"",
-      "mapping": {
-        "visitorId": {
-          "@path": "$.userId"
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": true,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "accountId": {
-          "@path": "$.groupId"
+          "label": "Account ID",
+          "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "accountData": {
-          "@path": "$.traits"
+          "label": "Account Metadata",
+          "description": "Additional Account data to send",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "parentAccountData": {
-          "@path": "$.traits.parentAccount"
+          "label": "Parent Account Metadata",
+          "description": "Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.parentAccount"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "id": {
+              "label": "Parent Account ID",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    }
+  },
+  "presets": [
+    {
+      "name": "Send Track Event",
+      "type": "automatic",
+      "partnerAction": "track",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event": {
+          "@path": "$.event"
+        },
+        "metadata": {
+          "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "identify",
       "name": "Send Identify Event",
+      "type": "automatic",
+      "partnerAction": "identify",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "visitorId": {
@@ -485,21 +384,28 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "track",
-      "name": "Send Track Event",
-      "subscribe": "type = \"track\"",
+      "name": "Send Group Event",
+      "type": "automatic",
+      "partnerAction": "group",
+      "subscribe": "type = \"group\"",
       "mapping": {
-        "event": {
-          "@path": "$.event"
+        "visitorId": {
+          "@path": "$.userId"
         },
-        "metadata": {
-          "@path": "$.properties"
+        "accountId": {
+          "@path": "$.groupId"
+        },
+        "accountData": {
+          "@path": "$.traits"
+        },
+        "parentAccountData": {
+          "@path": "$.traits.parentAccount"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/metadata.json
@@ -1,0 +1,505 @@
+{
+  "name": "Pendo Web (actions)",
+  "description": "Send analytics events, User profile data and Account data to Pendo via Segment track(), identify() and group() events on your browser",
+  "basicOptions": ["apiKey", "region", "cnameContentHost", "disableUserTraitsOnLoad", "disableGroupIdAndTraitsOnLoad"],
+  "options": {
+    "apiKey": {
+      "tags": [],
+      "default": "",
+      "description": "Pendo API Key",
+      "encrypt": true,
+      "hidden": false,
+      "label": "Pendo API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The apiKey property is required."]],
+      "uIMetadata": null
+    },
+    "region": {
+      "tags": [],
+      "default": "https://cdn.pendo.io",
+      "description": "The region for your Pendo subscription.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Region",
+      "private": false,
+      "scope": "event_destination",
+      "type": "select",
+      "options": [
+        {
+          "value": "https://cdn.pendo.io",
+          "label": "US (default)",
+          "text": "US (default)"
+        },
+        {
+          "value": "https://cdn.eu.pendo.io",
+          "label": "EU",
+          "text": "EU"
+        },
+        {
+          "value": "https://us1.cdn.pendo.io",
+          "label": "US restricted",
+          "text": "US restricted"
+        },
+        {
+          "value": "https://cdn.jpn.pendo.io",
+          "label": "Japan",
+          "text": "Japan"
+        }
+      ],
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The region property is required."]],
+      "uIMetadata": null
+    },
+    "cnameContentHost": {
+      "tags": [],
+      "default": "",
+      "description": "If you are using Pendo's CNAME feature, this will update your Pendo install snippet with your content host.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Optional CNAME content host",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableUserTraitsOnLoad": {
+      "tags": [],
+      "default": false,
+      "description": "Override sending Segment's user traits on load. This will prevent Pendo from initializing with the user traits from Segment (analytics.user().traits()). Allowing you to adjust the mapping of visitor metadata in Segment's identify event.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable passing Segment's user traits to Pendo on start up",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "disableGroupIdAndTraitsOnLoad": {
+      "tags": [],
+      "default": false,
+      "description": "Override sending Segment's group id for Pendo's account id. This will prevent Pendo from initializing with the group id from Segment (analytics.group().id()). Allowing you to adjust the mapping of account id in Segment's group event.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Disable passing Segment's group id and group traits to Pendo on start up",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "group",
+      "name": "Send Group Event",
+      "description": "Send Segment group() events to Pendo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type=\"group\"",
+      "fields": [
+        {
+          "fieldKey": "visitorId",
+          "type": "string",
+          "label": "Visitor ID",
+          "description": "Pendo Visitor ID. Maps to Segment userId",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "visitorId": {
+                "title": "Visitor ID",
+                "description": "Pendo Visitor ID. Maps to Segment userId",
+                "type": "string"
+              }
+            },
+            "required": ["visitorId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "accountId",
+          "type": "string",
+          "label": "Account ID",
+          "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "accountId": {
+                "title": "Account ID",
+                "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
+                "type": "string"
+              }
+            },
+            "required": ["accountId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "accountData",
+          "type": "object",
+          "label": "Account Metadata",
+          "description": "Additional Account data to send",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "accountData": {
+                "title": "Account Metadata",
+                "description": "Additional Account data to send",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "parentAccountData",
+          "type": "object",
+          "label": "Parent Account Metadata",
+          "description": "Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.",
+          "defaultValue": {
+            "@path": "$.traits.parentAccount"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "parentAccountData": {
+                "title": "Parent Account Metadata",
+                "description": "Additional Parent Account data to send. Note: Contact Pendo to request enablement of Parent Account feature.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": true,
+                "properties": {
+                  "id": {
+                    "title": "Parent Account ID",
+                    "type": "string"
+                  }
+                },
+                "required": ["id"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identify",
+      "name": "Send Identify Event",
+      "description": "Send Segment identify() events to Pendo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type=\"identify\"",
+      "fields": [
+        {
+          "fieldKey": "visitorId",
+          "type": "string",
+          "label": "Visitor ID",
+          "description": "Pendo Visitor ID. Maps to Segment userId",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "visitorId": {
+                "title": "Visitor ID",
+                "description": "Pendo Visitor ID. Maps to Segment userId",
+                "type": "string"
+              }
+            },
+            "required": ["visitorId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "visitorData",
+          "type": "object",
+          "label": "Visitor Metadata",
+          "description": "Additional Visitor data to send",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "visitorData": {
+                "title": "Visitor Metadata",
+                "description": "Additional Visitor data to send",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "accountId",
+          "type": "string",
+          "label": "Account ID",
+          "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.groupId"
+              },
+              "then": {
+                "@path": "$.context.groupId"
+              },
+              "else": {
+                "@path": "$.groupId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "accountId": {
+                "title": "Account ID",
+                "description": "Pendo Account ID. Maps to Segment groupId.  Note: If you plan to change this, enable the setting \"Use custom Segment group trait for Pendo account id\"",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "track",
+      "name": "Send Track Event",
+      "description": "Send Segment track() events to Pendo",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type=\"track\"",
+      "fields": [
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "Event name",
+          "description": "The name of the analytics event",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "Event name",
+                "description": "The name of the analytics event",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "metadata",
+          "type": "object",
+          "label": "Metadata",
+          "description": "Additional metadata to include in the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "readOnly": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "metadata": {
+                "title": "Metadata",
+                "description": "Additional metadata to include in the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "group",
+      "name": "Send Group Event",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "visitorId": {
+          "@path": "$.userId"
+        },
+        "accountId": {
+          "@path": "$.groupId"
+        },
+        "accountData": {
+          "@path": "$.traits"
+        },
+        "parentAccountData": {
+          "@path": "$.traits.parentAccount"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identify",
+      "name": "Send Identify Event",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "visitorId": {
+          "@path": "$.userId"
+        },
+        "visitorData": {
+          "@path": "$.traits"
+        },
+        "accountId": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.groupId"
+            },
+            "then": {
+              "@path": "$.context.groupId"
+            },
+            "else": {
+              "@path": "$.groupId"
+            }
+          }
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "track",
+      "name": "Send Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "event": {
+          "@path": "$.event"
+        },
+        "metadata": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/playerzero-web/metadata.json
+++ b/packages/browser-destinations/destinations/playerzero-web/metadata.json
@@ -1,0 +1,301 @@
+{
+  "name": "PlayerZero Web",
+  "basicOptions": ["projectId"],
+  "options": {
+    "projectId": {
+      "tags": [],
+      "default": "",
+      "description": "The Project ID where you want to send data. You can find this ID on the [Project Data Collection](https://go.playerzero.app/setting/data) page.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "PlayerZero Project ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The projectId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sets the user identity",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The user's id",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The user's id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "The user's anonymous id",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Display Name",
+          "description": "The user's name",
+          "defaultValue": {
+            "@path": "$.traits.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Display Name",
+                "description": "The user's name",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The user's email",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The user's email",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be included as metadata in PlayerZero",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be included as metadata in PlayerZero",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing more information about the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing more information about the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "name": {
+          "@path": "$.traits.name"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/playerzero-web/metadata.json
+++ b/packages/browser-destinations/destinations/playerzero-web/metadata.json
@@ -10,8 +10,10 @@
         "description": "The Project ID where you want to send data. You can find this ID on the [Project Data Collection](https://go.playerzero.app/setting/data) page.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event name",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -83,7 +89,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -106,7 +112,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -129,7 +137,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "name": {
           "label": "Display Name",
@@ -152,7 +162,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -175,7 +187,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -198,7 +212,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/playerzero-web/metadata.json
+++ b/packages/browser-destinations/destinations/playerzero-web/metadata.json
@@ -1,268 +1,228 @@
 {
+  "slug": "actions-playerzero-web",
   "name": "PlayerZero Web",
-  "basicOptions": ["projectId"],
-  "options": {
-    "projectId": {
-      "tags": [],
-      "default": "",
-      "description": "The Project ID where you want to send data. You can find this ID on the [Project Data Collection](https://go.playerzero.app/setting/data) page.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "PlayerZero Project ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The projectId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "projectId": {
+        "label": "PlayerZero Project ID",
+        "description": "The Project ID where you want to send data. You can find this ID on the [Project Data Collection](https://go.playerzero.app/setting/data) page.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Sets the user identity",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "The user's id",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The user's id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "The user's anonymous id",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "The user's anonymous id",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Display Name",
-          "description": "The user's name",
-          "defaultValue": {
-            "@path": "$.traits.name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Display Name",
-                "description": "The user's name",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "email",
-          "type": "string",
-          "label": "Email",
-          "description": "The user's email",
-          "defaultValue": {
-            "@path": "$.traits.email"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The user's email",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "The Segment traits to be included as metadata in PlayerZero",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be included as metadata in PlayerZero",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Track events",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "A JSON object containing more information about the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing more information about the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Sets the user identity",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "User ID",
+          "description": "The user's id",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "The user's anonymous id",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "name": {
+          "label": "Display Name",
+          "description": "The user's name",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "email": {
+          "label": "Email",
+          "description": "The user's email",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.email"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "Traits",
+          "description": "The Segment traits to be included as metadata in PlayerZero",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
+      "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -281,21 +241,7 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
-      "name": "Track Event",
-      "subscribe": "type = \"track\"",
-      "mapping": {
-        "name": {
-          "@path": "$.event"
-        },
-        "properties": {
-          "@path": "$.properties"
-        }
-      },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/reddit-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/reddit-pixel/metadata.json
@@ -11,16 +11,20 @@
         "description": "Your Reddit Pixel ID",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "ldu": {
         "label": "Limited Data Use",
         "description": "Limited Data Use - When the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences. See [this documentation](https://business.reddithelp.com/s/article/Limited-Data-Use) for more information. If enabling this toggle, also go into each event and configure the Country and Region in the Data Processing Options for each event being sent.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -34,7 +38,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "tracking_type": {
           "label": "Tracking Type",
@@ -88,7 +92,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "products": {
           "label": "Products",
@@ -136,7 +142,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "id": {
               "label": "Product ID",
@@ -157,7 +165,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Product Name",
@@ -178,7 +188,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -188,7 +200,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user": {
           "label": "User",
@@ -267,7 +281,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "device_type": {
               "label": "Device Type",
@@ -288,7 +304,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -309,7 +327,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "externalId": {
               "label": "External ID",
@@ -330,7 +350,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "phoneNumber": {
               "label": "Phone Number",
@@ -351,7 +373,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -361,7 +385,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "data_processing_options": {
           "label": "Data Processing Options",
@@ -1383,7 +1409,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "region": {
               "label": "Region",
@@ -1404,7 +1432,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1414,7 +1444,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_metadata": {
           "label": "Event Metadata",
@@ -1492,7 +1524,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemCount": {
               "label": "Item Count",
@@ -1513,7 +1547,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "value": {
               "label": "Value Decimal",
@@ -1534,7 +1570,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1544,7 +1582,11 @@
               {
                 "fieldKey": "tracking_type",
                 "operator": "is",
-                "value": [null, null, ""]
+                "value": [
+                  null,
+                  null,
+                  ""
+                ]
               },
               {
                 "fieldKey": "tracking_type",
@@ -1578,7 +1620,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "conversion_id": {
           "label": "Conversion ID",
@@ -1601,7 +1645,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -1613,7 +1659,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "conversion_id": {
           "label": "Conversion ID",
@@ -1636,7 +1682,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_metadata": {
           "label": "Event Metadata",
@@ -1714,7 +1762,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "itemCount": {
               "label": "Item Count",
@@ -1735,7 +1785,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "value": {
               "label": "Value Decimal",
@@ -1756,7 +1808,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1766,7 +1820,11 @@
               {
                 "fieldKey": "tracking_type",
                 "operator": "is",
-                "value": [null, null, ""]
+                "value": [
+                  null,
+                  null,
+                  ""
+                ]
               },
               {
                 "fieldKey": "tracking_type",
@@ -1800,7 +1858,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "user": {
           "label": "User",
@@ -1879,7 +1939,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "device_type": {
               "label": "Device Type",
@@ -1900,7 +1962,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "email": {
               "label": "Email",
@@ -1921,7 +1985,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "externalId": {
               "label": "External ID",
@@ -1942,7 +2008,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "phoneNumber": {
               "label": "Phone Number",
@@ -1963,7 +2031,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1973,7 +2043,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "products": {
           "label": "Products",
@@ -2021,7 +2093,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "id": {
               "label": "Product ID",
@@ -2042,7 +2116,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "name": {
               "label": "Product Name",
@@ -2063,7 +2139,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2073,7 +2151,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "data_processing_options": {
           "label": "Data Processing Options",
@@ -3095,7 +3175,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "region": {
               "label": "Region",
@@ -3116,7 +3198,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -3126,7 +3210,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "custom_event_name": {
           "label": "Custom Event Name",
@@ -3147,7 +3233,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/reddit-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/reddit-pixel/metadata.json
@@ -1,0 +1,2079 @@
+{
+  "name": "Reddit Pixel",
+  "description": "The Reddit Pixel Browser Destination allows you to install the Reddit Javascript pixel onto your site and pass mapped Segment events and metadata to Reddit.",
+  "basicOptions": ["pixel_id", "ldu"],
+  "options": {
+    "pixel_id": {
+      "tags": [],
+      "default": "",
+      "description": "Your Reddit Pixel ID",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Pixel ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The pixel_id property is required."]],
+      "uIMetadata": null
+    },
+    "ldu": {
+      "tags": [],
+      "default": false,
+      "description": "Limited Data Use - When the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences. See [this documentation](https://business.reddithelp.com/s/article/Limited-Data-Use) for more information. If enabling this toggle, also go into each event and configure the Country and Region in the Data Processing Options for each event being sent.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Limited Data Use",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "reportWebEvent",
+      "name": "Reddit Pixel",
+      "description": "Send Standard Pixel Events to Reddit. This includes pagevisits, addtocarts, search, etc.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "tracking_type",
+          "type": "string",
+          "label": "Tracking Type",
+          "description": "One of Reddit Pixel's standard conversion event types. To send a Custom event to Reddit use the Custom Event Action instead.",
+          "required": true,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "Page Visit",
+              "value": "PageVisit"
+            },
+            {
+              "label": "View Content",
+              "value": "ViewContent"
+            },
+            {
+              "label": "Search",
+              "value": "Search"
+            },
+            {
+              "label": "Add to Cart",
+              "value": "AddToCart"
+            },
+            {
+              "label": "Add to Wishlist",
+              "value": "AddToWishlist"
+            },
+            {
+              "label": "Purchase",
+              "value": "Purchase"
+            },
+            {
+              "label": "Lead",
+              "value": "Lead"
+            },
+            {
+              "label": "Sign Up",
+              "value": "SignUp"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tracking_type": {
+                "title": "Tracking Type",
+                "description": "One of Reddit Pixel's standard conversion event types. To send a Custom event to Reddit use the Custom Event Action instead.",
+                "type": "string",
+                "enum": [
+                  "PageVisit",
+                  "ViewContent",
+                  "Search",
+                  "AddToCart",
+                  "AddToWishlist",
+                  "Purchase",
+                  "Lead",
+                  "SignUp"
+                ]
+              }
+            },
+            "required": ["tracking_type"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "products",
+          "type": "object",
+          "label": "Products",
+          "description": "The products associated with the conversion event.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "category": {
+                  "@path": "$.category"
+                },
+                "id": {
+                  "@path": "$.product_id"
+                },
+                "name": {
+                  "@path": "$.name"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "products": {
+                "title": "Products",
+                "description": "The products associated with the conversion event.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "category": {
+                      "title": "Category",
+                      "description": "The category the product.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Product ID",
+                      "description": "The ID representing the product in a catalog",
+                      "type": "string"
+                    },
+                    "name": {
+                      "title": "Product Name",
+                      "description": "The name of the product",
+                      "type": "string"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user",
+          "type": "object",
+          "label": "User",
+          "description": "The identifying user parameters associated with the conversion event.",
+          "defaultValue": {
+            "advertising_id": {
+              "@path": "$.context.device.advertisingId"
+            },
+            "device_type": {
+              "@path": "$.context.device.type"
+            },
+            "email": {
+              "@if": {
+                "exists": {
+                  "@path": "$.context.traits.email"
+                },
+                "then": {
+                  "@path": "$.context.traits.email"
+                },
+                "else": {
+                  "@path": "$.properties.email"
+                }
+              }
+            },
+            "externalId": {
+              "@if": {
+                "exists": {
+                  "@path": "$.userId"
+                },
+                "then": {
+                  "@path": "$.userId"
+                },
+                "else": {
+                  "@path": "$.anonymousId"
+                }
+              }
+            },
+            "phoneNumber": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.phone"
+                },
+                "then": {
+                  "@path": "$.properties.phone"
+                },
+                "else": {
+                  "@path": "$.context.traits.phone"
+                }
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user": {
+                "title": "User",
+                "description": "The identifying user parameters associated with the conversion event.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "advertising_id": {
+                    "title": "Advertising ID",
+                    "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
+                    "type": "string"
+                  },
+                  "device_type": {
+                    "title": "Device Type",
+                    "description": "The type of mobile device. e.g. iOS or Android.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email address of the user.",
+                    "type": "string"
+                  },
+                  "externalId": {
+                    "title": "External ID",
+                    "description": "An advertiser-assigned persistent identifier for the user.",
+                    "type": "string"
+                  },
+                  "phoneNumber": {
+                    "title": "Phone Number",
+                    "description": "The phone number of the user in E.164 standard format.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "data_processing_options",
+          "type": "object",
+          "label": "Data Processing Options",
+          "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "data_processing_options": {
+                "title": "Data Processing Options",
+                "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "country": {
+                    "title": "Country",
+                    "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
+                    "type": "string",
+                    "enum": [
+                      "AD",
+                      "AE",
+                      "AF",
+                      "AG",
+                      "AI",
+                      "AL",
+                      "AM",
+                      "AO",
+                      "AQ",
+                      "AR",
+                      "AS",
+                      "AT",
+                      "AU",
+                      "AW",
+                      "AX",
+                      "AZ",
+                      "BA",
+                      "BB",
+                      "BD",
+                      "BE",
+                      "BF",
+                      "BG",
+                      "BH",
+                      "BI",
+                      "BJ",
+                      "BL",
+                      "BM",
+                      "BN",
+                      "BO",
+                      "BQ",
+                      "BR",
+                      "BS",
+                      "BT",
+                      "BV",
+                      "BW",
+                      "BY",
+                      "BZ",
+                      "CA",
+                      "CC",
+                      "CD",
+                      "CF",
+                      "CG",
+                      "CH",
+                      "CI",
+                      "CK",
+                      "CL",
+                      "CM",
+                      "CN",
+                      "CO",
+                      "CR",
+                      "CU",
+                      "CV",
+                      "CW",
+                      "CX",
+                      "CY",
+                      "CZ",
+                      "DE",
+                      "DJ",
+                      "DK",
+                      "DM",
+                      "DO",
+                      "DZ",
+                      "EC",
+                      "EE",
+                      "EG",
+                      "EH",
+                      "ER",
+                      "ES",
+                      "ET",
+                      "FI",
+                      "FJ",
+                      "FK",
+                      "FM",
+                      "FO",
+                      "FR",
+                      "GA",
+                      "GB",
+                      "GD",
+                      "GE",
+                      "GF",
+                      "GG",
+                      "GH",
+                      "GI",
+                      "GL",
+                      "GM",
+                      "GN",
+                      "GP",
+                      "GQ",
+                      "GR",
+                      "GT",
+                      "GU",
+                      "GW",
+                      "GY",
+                      "HK",
+                      "HM",
+                      "HN",
+                      "HR",
+                      "HT",
+                      "HU",
+                      "ID",
+                      "IE",
+                      "IL",
+                      "IM",
+                      "IN",
+                      "IO",
+                      "IQ",
+                      "IR",
+                      "IS",
+                      "IT",
+                      "JE",
+                      "JM",
+                      "JO",
+                      "JP",
+                      "KE",
+                      "KG",
+                      "KH",
+                      "KI",
+                      "KM",
+                      "KN",
+                      "KP",
+                      "KR",
+                      "KW",
+                      "KY",
+                      "KZ",
+                      "LA",
+                      "LB",
+                      "LC",
+                      "LI",
+                      "LK",
+                      "LR",
+                      "LS",
+                      "LT",
+                      "LU",
+                      "LV",
+                      "LY",
+                      "MA",
+                      "MC",
+                      "MD",
+                      "ME",
+                      "MF",
+                      "MG",
+                      "MH",
+                      "MK",
+                      "ML",
+                      "MM",
+                      "MN",
+                      "MO",
+                      "MP",
+                      "MQ",
+                      "MR",
+                      "MS",
+                      "MT",
+                      "MU",
+                      "MV",
+                      "MW",
+                      "MX",
+                      "MY",
+                      "MZ",
+                      "NA",
+                      "NC",
+                      "NE",
+                      "NF",
+                      "NG",
+                      "NI",
+                      "NL",
+                      "NO",
+                      "NP",
+                      "NR",
+                      "NU",
+                      "NZ",
+                      "OM",
+                      "PA",
+                      "PE",
+                      "PF",
+                      "PG",
+                      "PH",
+                      "PK",
+                      "PL",
+                      "PM",
+                      "PN",
+                      "PR",
+                      "PT",
+                      "PW",
+                      "PY",
+                      "QA",
+                      "RE",
+                      "RO",
+                      "RS",
+                      "RU",
+                      "RW",
+                      "SA",
+                      "SB",
+                      "SC",
+                      "SD",
+                      "SE",
+                      "SG",
+                      "SH",
+                      "SI",
+                      "SJ",
+                      "SK",
+                      "SL",
+                      "SM",
+                      "SN",
+                      "SO",
+                      "SR",
+                      "SS",
+                      "ST",
+                      "SV",
+                      "SX",
+                      "SY",
+                      "SZ",
+                      "TC",
+                      "TD",
+                      "TF",
+                      "TG",
+                      "TH",
+                      "TJ",
+                      "TK",
+                      "TL",
+                      "TM",
+                      "TN",
+                      "TO",
+                      "TR",
+                      "TT",
+                      "TV",
+                      "TZ",
+                      "UA",
+                      "UG",
+                      "UM",
+                      "UN",
+                      "US",
+                      "UY",
+                      "UZ",
+                      "VA",
+                      "VC",
+                      "VE",
+                      "VG",
+                      "VI",
+                      "VN",
+                      "VU",
+                      "WF",
+                      "WS",
+                      "YE",
+                      "YT",
+                      "ZA",
+                      "ZM",
+                      "ZW"
+                    ]
+                  },
+                  "region": {
+                    "title": "Region",
+                    "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_metadata",
+          "type": "object",
+          "label": "Event Metadata",
+          "description": "The metadata associated with the conversion event.",
+          "defaultValue": {
+            "currency": {
+              "@path": "$.properties.currency"
+            },
+            "itemCount": {
+              "@path": "$.properties.quantity"
+            },
+            "value": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.revenue"
+                },
+                "then": {
+                  "@path": "$.properties.revenue"
+                },
+                "else": {
+                  "@path": "$.properties.total"
+                }
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_metadata": {
+                "title": "Event Metadata",
+                "description": "The metadata associated with the conversion event.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "currency": {
+                    "title": "Currency",
+                    "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
+                    "type": "string",
+                    "enum": ["AUD", "CAD", "EUR", "GBP", "NZD", "USD"]
+                  },
+                  "itemCount": {
+                    "title": "Item Count",
+                    "description": "The number of items in the event. This should only be set for revenue-related events.",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "title": "Value Decimal",
+                    "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
+                    "type": "number"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": [null, null, ""]
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "Lead"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "SignUp"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "conversion_id",
+          "type": "string",
+          "label": "Conversion ID",
+          "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
+          "defaultValue": {
+            "@path": "$.messageId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "conversion_id": {
+                "title": "Conversion ID",
+                "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "reportCustomWebEvent",
+      "name": "Reddit Pixel - Custom Event",
+      "description": "Send Custom Pixel Events to Reddit.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "conversion_id",
+          "type": "string",
+          "label": "Conversion ID",
+          "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
+          "defaultValue": {
+            "@path": "$.messageId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "conversion_id": {
+                "title": "Conversion ID",
+                "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_metadata",
+          "type": "object",
+          "label": "Event Metadata",
+          "description": "The metadata associated with the conversion event.",
+          "defaultValue": {
+            "currency": {
+              "@path": "$.properties.currency"
+            },
+            "itemCount": {
+              "@path": "$.properties.quantity"
+            },
+            "value": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.revenue"
+                },
+                "then": {
+                  "@path": "$.properties.revenue"
+                },
+                "else": {
+                  "@path": "$.properties.total"
+                }
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_metadata": {
+                "title": "Event Metadata",
+                "description": "The metadata associated with the conversion event.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "currency": {
+                    "title": "Currency",
+                    "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
+                    "type": "string",
+                    "enum": ["AUD", "CAD", "EUR", "GBP", "NZD", "USD"]
+                  },
+                  "itemCount": {
+                    "title": "Item Count",
+                    "description": "The number of items in the event. This should only be set for revenue-related events.",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "title": "Value Decimal",
+                    "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
+                    "type": "number"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": [null, null, ""]
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "AddToCart"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "AddToWishlist"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "Purchase"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "Lead"
+              },
+              {
+                "fieldKey": "tracking_type",
+                "operator": "is",
+                "value": "SignUp"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "user",
+          "type": "object",
+          "label": "User",
+          "description": "The identifying user parameters associated with the conversion event.",
+          "defaultValue": {
+            "advertising_id": {
+              "@path": "$.context.device.advertisingId"
+            },
+            "device_type": {
+              "@path": "$.context.device.type"
+            },
+            "email": {
+              "@if": {
+                "exists": {
+                  "@path": "$.context.traits.email"
+                },
+                "then": {
+                  "@path": "$.context.traits.email"
+                },
+                "else": {
+                  "@path": "$.properties.email"
+                }
+              }
+            },
+            "externalId": {
+              "@if": {
+                "exists": {
+                  "@path": "$.userId"
+                },
+                "then": {
+                  "@path": "$.userId"
+                },
+                "else": {
+                  "@path": "$.anonymousId"
+                }
+              }
+            },
+            "phoneNumber": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.phone"
+                },
+                "then": {
+                  "@path": "$.properties.phone"
+                },
+                "else": {
+                  "@path": "$.context.traits.phone"
+                }
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "user": {
+                "title": "User",
+                "description": "The identifying user parameters associated with the conversion event.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "advertising_id": {
+                    "title": "Advertising ID",
+                    "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
+                    "type": "string"
+                  },
+                  "device_type": {
+                    "title": "Device Type",
+                    "description": "The type of mobile device. e.g. iOS or Android.",
+                    "type": "string"
+                  },
+                  "email": {
+                    "title": "Email",
+                    "description": "The email address of the user.",
+                    "type": "string"
+                  },
+                  "externalId": {
+                    "title": "External ID",
+                    "description": "An advertiser-assigned persistent identifier for the user.",
+                    "type": "string"
+                  },
+                  "phoneNumber": {
+                    "title": "Phone Number",
+                    "description": "The phone number of the user in E.164 standard format.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "products",
+          "type": "object",
+          "label": "Products",
+          "description": "The products associated with the conversion event.",
+          "defaultValue": {
+            "@arrayPath": [
+              "$.properties.products",
+              {
+                "category": {
+                  "@path": "$.category"
+                },
+                "id": {
+                  "@path": "$.product_id"
+                },
+                "name": {
+                  "@path": "$.name"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "products": {
+                "title": "Products",
+                "description": "The products associated with the conversion event.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "category": {
+                      "title": "Category",
+                      "description": "The category the product.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "title": "Product ID",
+                      "description": "The ID representing the product in a catalog",
+                      "type": "string"
+                    },
+                    "name": {
+                      "title": "Product Name",
+                      "description": "The name of the product",
+                      "type": "string"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "data_processing_options",
+          "type": "object",
+          "label": "Data Processing Options",
+          "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "data_processing_options": {
+                "title": "Data Processing Options",
+                "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "country": {
+                    "title": "Country",
+                    "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
+                    "type": "string",
+                    "enum": [
+                      "AD",
+                      "AE",
+                      "AF",
+                      "AG",
+                      "AI",
+                      "AL",
+                      "AM",
+                      "AO",
+                      "AQ",
+                      "AR",
+                      "AS",
+                      "AT",
+                      "AU",
+                      "AW",
+                      "AX",
+                      "AZ",
+                      "BA",
+                      "BB",
+                      "BD",
+                      "BE",
+                      "BF",
+                      "BG",
+                      "BH",
+                      "BI",
+                      "BJ",
+                      "BL",
+                      "BM",
+                      "BN",
+                      "BO",
+                      "BQ",
+                      "BR",
+                      "BS",
+                      "BT",
+                      "BV",
+                      "BW",
+                      "BY",
+                      "BZ",
+                      "CA",
+                      "CC",
+                      "CD",
+                      "CF",
+                      "CG",
+                      "CH",
+                      "CI",
+                      "CK",
+                      "CL",
+                      "CM",
+                      "CN",
+                      "CO",
+                      "CR",
+                      "CU",
+                      "CV",
+                      "CW",
+                      "CX",
+                      "CY",
+                      "CZ",
+                      "DE",
+                      "DJ",
+                      "DK",
+                      "DM",
+                      "DO",
+                      "DZ",
+                      "EC",
+                      "EE",
+                      "EG",
+                      "EH",
+                      "ER",
+                      "ES",
+                      "ET",
+                      "FI",
+                      "FJ",
+                      "FK",
+                      "FM",
+                      "FO",
+                      "FR",
+                      "GA",
+                      "GB",
+                      "GD",
+                      "GE",
+                      "GF",
+                      "GG",
+                      "GH",
+                      "GI",
+                      "GL",
+                      "GM",
+                      "GN",
+                      "GP",
+                      "GQ",
+                      "GR",
+                      "GT",
+                      "GU",
+                      "GW",
+                      "GY",
+                      "HK",
+                      "HM",
+                      "HN",
+                      "HR",
+                      "HT",
+                      "HU",
+                      "ID",
+                      "IE",
+                      "IL",
+                      "IM",
+                      "IN",
+                      "IO",
+                      "IQ",
+                      "IR",
+                      "IS",
+                      "IT",
+                      "JE",
+                      "JM",
+                      "JO",
+                      "JP",
+                      "KE",
+                      "KG",
+                      "KH",
+                      "KI",
+                      "KM",
+                      "KN",
+                      "KP",
+                      "KR",
+                      "KW",
+                      "KY",
+                      "KZ",
+                      "LA",
+                      "LB",
+                      "LC",
+                      "LI",
+                      "LK",
+                      "LR",
+                      "LS",
+                      "LT",
+                      "LU",
+                      "LV",
+                      "LY",
+                      "MA",
+                      "MC",
+                      "MD",
+                      "ME",
+                      "MF",
+                      "MG",
+                      "MH",
+                      "MK",
+                      "ML",
+                      "MM",
+                      "MN",
+                      "MO",
+                      "MP",
+                      "MQ",
+                      "MR",
+                      "MS",
+                      "MT",
+                      "MU",
+                      "MV",
+                      "MW",
+                      "MX",
+                      "MY",
+                      "MZ",
+                      "NA",
+                      "NC",
+                      "NE",
+                      "NF",
+                      "NG",
+                      "NI",
+                      "NL",
+                      "NO",
+                      "NP",
+                      "NR",
+                      "NU",
+                      "NZ",
+                      "OM",
+                      "PA",
+                      "PE",
+                      "PF",
+                      "PG",
+                      "PH",
+                      "PK",
+                      "PL",
+                      "PM",
+                      "PN",
+                      "PR",
+                      "PT",
+                      "PW",
+                      "PY",
+                      "QA",
+                      "RE",
+                      "RO",
+                      "RS",
+                      "RU",
+                      "RW",
+                      "SA",
+                      "SB",
+                      "SC",
+                      "SD",
+                      "SE",
+                      "SG",
+                      "SH",
+                      "SI",
+                      "SJ",
+                      "SK",
+                      "SL",
+                      "SM",
+                      "SN",
+                      "SO",
+                      "SR",
+                      "SS",
+                      "ST",
+                      "SV",
+                      "SX",
+                      "SY",
+                      "SZ",
+                      "TC",
+                      "TD",
+                      "TF",
+                      "TG",
+                      "TH",
+                      "TJ",
+                      "TK",
+                      "TL",
+                      "TM",
+                      "TN",
+                      "TO",
+                      "TR",
+                      "TT",
+                      "TV",
+                      "TZ",
+                      "UA",
+                      "UG",
+                      "UM",
+                      "UN",
+                      "US",
+                      "UY",
+                      "UZ",
+                      "VA",
+                      "VC",
+                      "VE",
+                      "VG",
+                      "VI",
+                      "VN",
+                      "VU",
+                      "WF",
+                      "WS",
+                      "YE",
+                      "YT",
+                      "ZA",
+                      "ZM",
+                      "ZW"
+                    ]
+                  },
+                  "region": {
+                    "title": "Region",
+                    "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "custom_event_name",
+          "type": "string",
+          "label": "Custom Event Name",
+          "description": "A custom event name that can be passed when tracking_type is set to \"Custom\". All UTF-8 characters are accepted and custom_event_name must be at most 64 characters long.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "custom_event_name": {
+                "title": "Custom Event Name",
+                "description": "A custom event name that can be passed when tracking_type is set to \"Custom\". All UTF-8 characters are accepted and custom_event_name must be at most 64 characters long.",
+                "type": "string"
+              }
+            },
+            "required": ["custom_event_name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Add to Cart",
+      "subscribe": "type = \"track\" and event = \"Product Added\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@path": "$.properties.price"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "AddToCart"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Add to Wishlist",
+      "subscribe": "type = \"track\" and event = \"Product Added to Wishlist\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@path": "$.properties.price"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "AddToWishlist"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Lead",
+      "subscribe": "type = \"track\" and event = \"Lead Generated\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "value": {
+            "@path": "$.properties.value"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Lead"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Page Visit",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "PageVisit"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Purchase",
+      "subscribe": "type = \"track\" and event = \"Order Completed\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Purchase"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Search",
+      "subscribe": "type = \"track\" and event = \"Products Searched\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Search"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Sign Up",
+      "subscribe": "type = \"track\" and event = \"Signed Up\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "value": {
+            "@path": "$.properties.value"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "SignUp"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "View Content",
+      "subscribe": "type = \"track\" and event = \"Product Viewed\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "ViewContent"
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/reddit-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/reddit-pixel/metadata.json
@@ -1,64 +1,50 @@
 {
+  "slug": "actions-reddit-pixel",
   "name": "Reddit Pixel",
+  "mode": "device",
   "description": "The Reddit Pixel Browser Destination allows you to install the Reddit Javascript pixel onto your site and pass mapped Segment events and metadata to Reddit.",
-  "basicOptions": ["pixel_id", "ldu"],
-  "options": {
-    "pixel_id": {
-      "tags": [],
-      "default": "",
-      "description": "Your Reddit Pixel ID",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Pixel ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The pixel_id property is required."]],
-      "uIMetadata": null
-    },
-    "ldu": {
-      "tags": [],
-      "default": false,
-      "description": "Limited Data Use - When the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences. See [this documentation](https://business.reddithelp.com/s/article/Limited-Data-Use) for more information. If enabling this toggle, also go into each event and configure the Country and Region in the Data Processing Options for each event being sent.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Limited Data Use",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "pixel_id": {
+        "label": "Pixel ID",
+        "description": "Your Reddit Pixel ID",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "ldu": {
+        "label": "Limited Data Use",
+        "description": "Limited Data Use - When the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences. See [this documentation](https://business.reddithelp.com/s/article/Limited-Data-Use) for more information. If enabling this toggle, also go into each event and configure the Country and Region in the Data Processing Options for each event being sent.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "reportWebEvent",
-      "name": "Reddit Pixel",
+  "audienceConfig": null,
+  "actions": {
+    "reportWebEvent": {
+      "title": "Reddit Pixel",
       "description": "Send Standard Pixel Events to Reddit. This includes pagevisits, addtocarts, search, etc.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "tracking_type",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "tracking_type": {
           "label": "Tracking Type",
           "description": "One of Reddit Pixel's standard conversion event types. To send a Custom event to Reddit use the Custom Event Action instead.",
+          "type": "string",
           "required": true,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "label": "Page Visit",
@@ -93,41 +79,26 @@
               "value": "SignUp"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "tracking_type": {
-                "title": "Tracking Type",
-                "description": "One of Reddit Pixel's standard conversion event types. To send a Custom event to Reddit use the Custom Event Action instead.",
-                "type": "string",
-                "enum": [
-                  "PageVisit",
-                  "ViewContent",
-                  "Search",
-                  "AddToCart",
-                  "AddToWishlist",
-                  "Purchase",
-                  "Lead",
-                  "SignUp"
-                ]
-              }
-            },
-            "required": ["tracking_type"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "products",
-          "type": "object",
+        "products": {
           "label": "Products",
           "description": "The products associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -143,57 +114,91 @@
               }
             ]
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "products": {
-                "title": "Products",
-                "description": "The products associated with the conversion event.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "category": {
-                      "title": "Category",
-                      "description": "The category the product.",
-                      "type": "string"
-                    },
-                    "id": {
-                      "title": "Product ID",
-                      "description": "The ID representing the product in a catalog",
-                      "type": "string"
-                    },
-                    "name": {
-                      "title": "Product Name",
-                      "description": "The name of the product",
-                      "type": "string"
-                    }
-                  },
-                  "required": []
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "category": {
+              "label": "Category",
+              "description": "The category the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "id": {
+              "label": "Product ID",
+              "description": "The ID representing the product in a catalog",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "name": {
+              "label": "Product Name",
+              "description": "The name of the product",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user",
-          "type": "object",
+        "user": {
           "label": "User",
           "description": "The identifying user parameters associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "advertising_id": {
               "@path": "$.context.device.advertisingId"
             },
@@ -240,356 +245,1186 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user": {
-                "title": "User",
-                "description": "The identifying user parameters associated with the conversion event.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "advertising_id": {
-                    "title": "Advertising ID",
-                    "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
-                    "type": "string"
-                  },
-                  "device_type": {
-                    "title": "Device Type",
-                    "description": "The type of mobile device. e.g. iOS or Android.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email address of the user.",
-                    "type": "string"
-                  },
-                  "externalId": {
-                    "title": "External ID",
-                    "description": "An advertiser-assigned persistent identifier for the user.",
-                    "type": "string"
-                  },
-                  "phoneNumber": {
-                    "title": "Phone Number",
-                    "description": "The phone number of the user in E.164 standard format.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "advertising_id": {
+              "label": "Advertising ID",
+              "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "device_type": {
+              "label": "Device Type",
+              "description": "The type of mobile device. e.g. iOS or Android.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email address of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "externalId": {
+              "label": "External ID",
+              "description": "An advertiser-assigned persistent identifier for the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "phoneNumber": {
+              "label": "Phone Number",
+              "description": "The phone number of the user in E.164 standard format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "data_processing_options",
-          "type": "object",
+        "data_processing_options": {
           "label": "Data Processing Options",
           "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "data_processing_options": {
-                "title": "Data Processing Options",
-                "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "country": {
-                    "title": "Country",
-                    "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
-                    "type": "string",
-                    "enum": [
-                      "AD",
-                      "AE",
-                      "AF",
-                      "AG",
-                      "AI",
-                      "AL",
-                      "AM",
-                      "AO",
-                      "AQ",
-                      "AR",
-                      "AS",
-                      "AT",
-                      "AU",
-                      "AW",
-                      "AX",
-                      "AZ",
-                      "BA",
-                      "BB",
-                      "BD",
-                      "BE",
-                      "BF",
-                      "BG",
-                      "BH",
-                      "BI",
-                      "BJ",
-                      "BL",
-                      "BM",
-                      "BN",
-                      "BO",
-                      "BQ",
-                      "BR",
-                      "BS",
-                      "BT",
-                      "BV",
-                      "BW",
-                      "BY",
-                      "BZ",
-                      "CA",
-                      "CC",
-                      "CD",
-                      "CF",
-                      "CG",
-                      "CH",
-                      "CI",
-                      "CK",
-                      "CL",
-                      "CM",
-                      "CN",
-                      "CO",
-                      "CR",
-                      "CU",
-                      "CV",
-                      "CW",
-                      "CX",
-                      "CY",
-                      "CZ",
-                      "DE",
-                      "DJ",
-                      "DK",
-                      "DM",
-                      "DO",
-                      "DZ",
-                      "EC",
-                      "EE",
-                      "EG",
-                      "EH",
-                      "ER",
-                      "ES",
-                      "ET",
-                      "FI",
-                      "FJ",
-                      "FK",
-                      "FM",
-                      "FO",
-                      "FR",
-                      "GA",
-                      "GB",
-                      "GD",
-                      "GE",
-                      "GF",
-                      "GG",
-                      "GH",
-                      "GI",
-                      "GL",
-                      "GM",
-                      "GN",
-                      "GP",
-                      "GQ",
-                      "GR",
-                      "GT",
-                      "GU",
-                      "GW",
-                      "GY",
-                      "HK",
-                      "HM",
-                      "HN",
-                      "HR",
-                      "HT",
-                      "HU",
-                      "ID",
-                      "IE",
-                      "IL",
-                      "IM",
-                      "IN",
-                      "IO",
-                      "IQ",
-                      "IR",
-                      "IS",
-                      "IT",
-                      "JE",
-                      "JM",
-                      "JO",
-                      "JP",
-                      "KE",
-                      "KG",
-                      "KH",
-                      "KI",
-                      "KM",
-                      "KN",
-                      "KP",
-                      "KR",
-                      "KW",
-                      "KY",
-                      "KZ",
-                      "LA",
-                      "LB",
-                      "LC",
-                      "LI",
-                      "LK",
-                      "LR",
-                      "LS",
-                      "LT",
-                      "LU",
-                      "LV",
-                      "LY",
-                      "MA",
-                      "MC",
-                      "MD",
-                      "ME",
-                      "MF",
-                      "MG",
-                      "MH",
-                      "MK",
-                      "ML",
-                      "MM",
-                      "MN",
-                      "MO",
-                      "MP",
-                      "MQ",
-                      "MR",
-                      "MS",
-                      "MT",
-                      "MU",
-                      "MV",
-                      "MW",
-                      "MX",
-                      "MY",
-                      "MZ",
-                      "NA",
-                      "NC",
-                      "NE",
-                      "NF",
-                      "NG",
-                      "NI",
-                      "NL",
-                      "NO",
-                      "NP",
-                      "NR",
-                      "NU",
-                      "NZ",
-                      "OM",
-                      "PA",
-                      "PE",
-                      "PF",
-                      "PG",
-                      "PH",
-                      "PK",
-                      "PL",
-                      "PM",
-                      "PN",
-                      "PR",
-                      "PT",
-                      "PW",
-                      "PY",
-                      "QA",
-                      "RE",
-                      "RO",
-                      "RS",
-                      "RU",
-                      "RW",
-                      "SA",
-                      "SB",
-                      "SC",
-                      "SD",
-                      "SE",
-                      "SG",
-                      "SH",
-                      "SI",
-                      "SJ",
-                      "SK",
-                      "SL",
-                      "SM",
-                      "SN",
-                      "SO",
-                      "SR",
-                      "SS",
-                      "ST",
-                      "SV",
-                      "SX",
-                      "SY",
-                      "SZ",
-                      "TC",
-                      "TD",
-                      "TF",
-                      "TG",
-                      "TH",
-                      "TJ",
-                      "TK",
-                      "TL",
-                      "TM",
-                      "TN",
-                      "TO",
-                      "TR",
-                      "TT",
-                      "TV",
-                      "TZ",
-                      "UA",
-                      "UG",
-                      "UM",
-                      "UN",
-                      "US",
-                      "UY",
-                      "UZ",
-                      "VA",
-                      "VC",
-                      "VE",
-                      "VG",
-                      "VI",
-                      "VN",
-                      "VU",
-                      "WF",
-                      "WS",
-                      "YE",
-                      "YT",
-                      "ZA",
-                      "ZM",
-                      "ZW"
-                    ]
-                  },
-                  "region": {
-                    "title": "Region",
-                    "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
-                    "type": "string"
-                  }
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "country": {
+              "label": "Country",
+              "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "AD - Andorra",
+                  "value": "AD"
                 },
-                "required": []
-              }
+                {
+                  "label": "AE - United Arab Emirates",
+                  "value": "AE"
+                },
+                {
+                  "label": "AF - Afghanistan",
+                  "value": "AF"
+                },
+                {
+                  "label": "AG - Antigua and Barbuda",
+                  "value": "AG"
+                },
+                {
+                  "label": "AI - Anguilla",
+                  "value": "AI"
+                },
+                {
+                  "label": "AL - Albania",
+                  "value": "AL"
+                },
+                {
+                  "label": "AM - Armenia",
+                  "value": "AM"
+                },
+                {
+                  "label": "AO - Angola",
+                  "value": "AO"
+                },
+                {
+                  "label": "AQ - Antarctica",
+                  "value": "AQ"
+                },
+                {
+                  "label": "AR - Argentina",
+                  "value": "AR"
+                },
+                {
+                  "label": "AS - American Samoa",
+                  "value": "AS"
+                },
+                {
+                  "label": "AT - Austria",
+                  "value": "AT"
+                },
+                {
+                  "label": "AU - Australia",
+                  "value": "AU"
+                },
+                {
+                  "label": "AW - Aruba",
+                  "value": "AW"
+                },
+                {
+                  "label": "AX - Åland Islands",
+                  "value": "AX"
+                },
+                {
+                  "label": "AZ - Azerbaijan",
+                  "value": "AZ"
+                },
+                {
+                  "label": "BA - Bosnia and Herzegovina",
+                  "value": "BA"
+                },
+                {
+                  "label": "BB - Barbados",
+                  "value": "BB"
+                },
+                {
+                  "label": "BD - Bangladesh",
+                  "value": "BD"
+                },
+                {
+                  "label": "BE - Belgium",
+                  "value": "BE"
+                },
+                {
+                  "label": "BF - Burkina Faso",
+                  "value": "BF"
+                },
+                {
+                  "label": "BG - Bulgaria",
+                  "value": "BG"
+                },
+                {
+                  "label": "BH - Bahrain",
+                  "value": "BH"
+                },
+                {
+                  "label": "BI - Burundi",
+                  "value": "BI"
+                },
+                {
+                  "label": "BJ - Benin",
+                  "value": "BJ"
+                },
+                {
+                  "label": "BL - Saint Barthélemy",
+                  "value": "BL"
+                },
+                {
+                  "label": "BM - Bermuda",
+                  "value": "BM"
+                },
+                {
+                  "label": "BN - Brunei Darussalam",
+                  "value": "BN"
+                },
+                {
+                  "label": "BO - Bolivia (Plurinational State of)",
+                  "value": "BO"
+                },
+                {
+                  "label": "BQ - Bonaire, Sint Eustatius and Saba",
+                  "value": "BQ"
+                },
+                {
+                  "label": "BR - Brazil",
+                  "value": "BR"
+                },
+                {
+                  "label": "BS - Bahamas",
+                  "value": "BS"
+                },
+                {
+                  "label": "BT - Bhutan",
+                  "value": "BT"
+                },
+                {
+                  "label": "BV - Bouvet Island",
+                  "value": "BV"
+                },
+                {
+                  "label": "BW - Botswana",
+                  "value": "BW"
+                },
+                {
+                  "label": "BY - Belarus",
+                  "value": "BY"
+                },
+                {
+                  "label": "BZ - Belize",
+                  "value": "BZ"
+                },
+                {
+                  "label": "CA - Canada",
+                  "value": "CA"
+                },
+                {
+                  "label": "CC - Cocos (Keeling) Islands",
+                  "value": "CC"
+                },
+                {
+                  "label": "CD - Congo, Democratic Republic of the",
+                  "value": "CD"
+                },
+                {
+                  "label": "CF - Central African Republic",
+                  "value": "CF"
+                },
+                {
+                  "label": "CG - Congo",
+                  "value": "CG"
+                },
+                {
+                  "label": "CH - Switzerland",
+                  "value": "CH"
+                },
+                {
+                  "label": "CI - Côte d'Ivoire",
+                  "value": "CI"
+                },
+                {
+                  "label": "CK - Cook Islands",
+                  "value": "CK"
+                },
+                {
+                  "label": "CL - Chile",
+                  "value": "CL"
+                },
+                {
+                  "label": "CM - Cameroon",
+                  "value": "CM"
+                },
+                {
+                  "label": "CN - China",
+                  "value": "CN"
+                },
+                {
+                  "label": "CO - Colombia",
+                  "value": "CO"
+                },
+                {
+                  "label": "CR - Costa Rica",
+                  "value": "CR"
+                },
+                {
+                  "label": "CU - Cuba",
+                  "value": "CU"
+                },
+                {
+                  "label": "CV - Cabo Verde",
+                  "value": "CV"
+                },
+                {
+                  "label": "CW - Curaçao",
+                  "value": "CW"
+                },
+                {
+                  "label": "CX - Christmas Island",
+                  "value": "CX"
+                },
+                {
+                  "label": "CY - Cyprus",
+                  "value": "CY"
+                },
+                {
+                  "label": "CZ - Czechia",
+                  "value": "CZ"
+                },
+                {
+                  "label": "DE - Germany",
+                  "value": "DE"
+                },
+                {
+                  "label": "DJ - Djibouti",
+                  "value": "DJ"
+                },
+                {
+                  "label": "DK - Denmark",
+                  "value": "DK"
+                },
+                {
+                  "label": "DM - Dominica",
+                  "value": "DM"
+                },
+                {
+                  "label": "DO - Dominican Republic",
+                  "value": "DO"
+                },
+                {
+                  "label": "DZ - Algeria",
+                  "value": "DZ"
+                },
+                {
+                  "label": "EC - Ecuador",
+                  "value": "EC"
+                },
+                {
+                  "label": "EE - Estonia",
+                  "value": "EE"
+                },
+                {
+                  "label": "EG - Egypt",
+                  "value": "EG"
+                },
+                {
+                  "label": "EH - Western Sahara",
+                  "value": "EH"
+                },
+                {
+                  "label": "ER - Eritrea",
+                  "value": "ER"
+                },
+                {
+                  "label": "ES - Spain",
+                  "value": "ES"
+                },
+                {
+                  "label": "ET - Ethiopia",
+                  "value": "ET"
+                },
+                {
+                  "label": "FI - Finland",
+                  "value": "FI"
+                },
+                {
+                  "label": "FJ - Fiji",
+                  "value": "FJ"
+                },
+                {
+                  "label": "FK - Falkland Islands (Malvinas)",
+                  "value": "FK"
+                },
+                {
+                  "label": "FM - Micronesia (Federated States of)",
+                  "value": "FM"
+                },
+                {
+                  "label": "FO - Faroe Islands",
+                  "value": "FO"
+                },
+                {
+                  "label": "FR - France",
+                  "value": "FR"
+                },
+                {
+                  "label": "GA - Gabon",
+                  "value": "GA"
+                },
+                {
+                  "label": "GB - United Kingdom of Great Britain and Northern Ireland",
+                  "value": "GB"
+                },
+                {
+                  "label": "GD - Grenada",
+                  "value": "GD"
+                },
+                {
+                  "label": "GE - Georgia",
+                  "value": "GE"
+                },
+                {
+                  "label": "GF - French Guiana",
+                  "value": "GF"
+                },
+                {
+                  "label": "GG - Guernsey",
+                  "value": "GG"
+                },
+                {
+                  "label": "GH - Ghana",
+                  "value": "GH"
+                },
+                {
+                  "label": "GI - Gibraltar",
+                  "value": "GI"
+                },
+                {
+                  "label": "GL - Greenland",
+                  "value": "GL"
+                },
+                {
+                  "label": "GM - Gambia",
+                  "value": "GM"
+                },
+                {
+                  "label": "GN - Guinea",
+                  "value": "GN"
+                },
+                {
+                  "label": "GP - Guadeloupe",
+                  "value": "GP"
+                },
+                {
+                  "label": "GQ - Equatorial Guinea",
+                  "value": "GQ"
+                },
+                {
+                  "label": "GR - Greece",
+                  "value": "GR"
+                },
+                {
+                  "label": "GT - Guatemala",
+                  "value": "GT"
+                },
+                {
+                  "label": "GU - Guam",
+                  "value": "GU"
+                },
+                {
+                  "label": "GW - Guinea-Bissau",
+                  "value": "GW"
+                },
+                {
+                  "label": "GY - Guyana",
+                  "value": "GY"
+                },
+                {
+                  "label": "HK - Hong Kong",
+                  "value": "HK"
+                },
+                {
+                  "label": "HM - Heard Island and McDonald Islands",
+                  "value": "HM"
+                },
+                {
+                  "label": "HN - Honduras",
+                  "value": "HN"
+                },
+                {
+                  "label": "HR - Croatia",
+                  "value": "HR"
+                },
+                {
+                  "label": "HT - Haiti",
+                  "value": "HT"
+                },
+                {
+                  "label": "HU - Hungary",
+                  "value": "HU"
+                },
+                {
+                  "label": "ID - Indonesia",
+                  "value": "ID"
+                },
+                {
+                  "label": "IE - Ireland",
+                  "value": "IE"
+                },
+                {
+                  "label": "IL - Israel",
+                  "value": "IL"
+                },
+                {
+                  "label": "IM - Isle of Man",
+                  "value": "IM"
+                },
+                {
+                  "label": "IN - India",
+                  "value": "IN"
+                },
+                {
+                  "label": "IO - British Indian Ocean Territory",
+                  "value": "IO"
+                },
+                {
+                  "label": "IQ - Iraq",
+                  "value": "IQ"
+                },
+                {
+                  "label": "IR - Iran (Islamic Republic of)",
+                  "value": "IR"
+                },
+                {
+                  "label": "IS - Iceland",
+                  "value": "IS"
+                },
+                {
+                  "label": "IT - Italy",
+                  "value": "IT"
+                },
+                {
+                  "label": "JE - Jersey",
+                  "value": "JE"
+                },
+                {
+                  "label": "JM - Jamaica",
+                  "value": "JM"
+                },
+                {
+                  "label": "JO - Jordan",
+                  "value": "JO"
+                },
+                {
+                  "label": "JP - Japan",
+                  "value": "JP"
+                },
+                {
+                  "label": "KE - Kenya",
+                  "value": "KE"
+                },
+                {
+                  "label": "KG - Kyrgyzstan",
+                  "value": "KG"
+                },
+                {
+                  "label": "KH - Cambodia",
+                  "value": "KH"
+                },
+                {
+                  "label": "KI - Kiribati",
+                  "value": "KI"
+                },
+                {
+                  "label": "KM - Comoros",
+                  "value": "KM"
+                },
+                {
+                  "label": "KN - Saint Kitts and Nevis",
+                  "value": "KN"
+                },
+                {
+                  "label": "KP - Korea (Democratic People's Republic of)",
+                  "value": "KP"
+                },
+                {
+                  "label": "KR - Korea, Republic of",
+                  "value": "KR"
+                },
+                {
+                  "label": "KW - Kuwait",
+                  "value": "KW"
+                },
+                {
+                  "label": "KY - Cayman Islands",
+                  "value": "KY"
+                },
+                {
+                  "label": "KZ - Kazakhstan",
+                  "value": "KZ"
+                },
+                {
+                  "label": "LA - Lao People's Democratic Republic",
+                  "value": "LA"
+                },
+                {
+                  "label": "LB - Lebanon",
+                  "value": "LB"
+                },
+                {
+                  "label": "LC - Saint Lucia",
+                  "value": "LC"
+                },
+                {
+                  "label": "LI - Liechtenstein",
+                  "value": "LI"
+                },
+                {
+                  "label": "LK - Sri Lanka",
+                  "value": "LK"
+                },
+                {
+                  "label": "LR - Liberia",
+                  "value": "LR"
+                },
+                {
+                  "label": "LS - Lesotho",
+                  "value": "LS"
+                },
+                {
+                  "label": "LT - Lithuania",
+                  "value": "LT"
+                },
+                {
+                  "label": "LU - Luxembourg",
+                  "value": "LU"
+                },
+                {
+                  "label": "LV - Latvia",
+                  "value": "LV"
+                },
+                {
+                  "label": "LY - Libya",
+                  "value": "LY"
+                },
+                {
+                  "label": "MA - Morocco",
+                  "value": "MA"
+                },
+                {
+                  "label": "MC - Monaco",
+                  "value": "MC"
+                },
+                {
+                  "label": "MD - Moldova (Republic of)",
+                  "value": "MD"
+                },
+                {
+                  "label": "ME - Montenegro",
+                  "value": "ME"
+                },
+                {
+                  "label": "MF - Saint Martin (French part)",
+                  "value": "MF"
+                },
+                {
+                  "label": "MG - Madagascar",
+                  "value": "MG"
+                },
+                {
+                  "label": "MH - Marshall Islands",
+                  "value": "MH"
+                },
+                {
+                  "label": "MK - North Macedonia",
+                  "value": "MK"
+                },
+                {
+                  "label": "ML - Mali",
+                  "value": "ML"
+                },
+                {
+                  "label": "MM - Myanmar",
+                  "value": "MM"
+                },
+                {
+                  "label": "MN - Mongolia",
+                  "value": "MN"
+                },
+                {
+                  "label": "MO - Macao",
+                  "value": "MO"
+                },
+                {
+                  "label": "MP - Northern Mariana Islands",
+                  "value": "MP"
+                },
+                {
+                  "label": "MQ - Martinique",
+                  "value": "MQ"
+                },
+                {
+                  "label": "MR - Mauritania",
+                  "value": "MR"
+                },
+                {
+                  "label": "MS - Montserrat",
+                  "value": "MS"
+                },
+                {
+                  "label": "MT - Malta",
+                  "value": "MT"
+                },
+                {
+                  "label": "MU - Mauritius",
+                  "value": "MU"
+                },
+                {
+                  "label": "MV - Maldives",
+                  "value": "MV"
+                },
+                {
+                  "label": "MW - Malawi",
+                  "value": "MW"
+                },
+                {
+                  "label": "MX - Mexico",
+                  "value": "MX"
+                },
+                {
+                  "label": "MY - Malaysia",
+                  "value": "MY"
+                },
+                {
+                  "label": "MZ - Mozambique",
+                  "value": "MZ"
+                },
+                {
+                  "label": "NA - Namibia",
+                  "value": "NA"
+                },
+                {
+                  "label": "NC - New Caledonia",
+                  "value": "NC"
+                },
+                {
+                  "label": "NE - Niger",
+                  "value": "NE"
+                },
+                {
+                  "label": "NF - Norfolk Island",
+                  "value": "NF"
+                },
+                {
+                  "label": "NG - Nigeria",
+                  "value": "NG"
+                },
+                {
+                  "label": "NI - Nicaragua",
+                  "value": "NI"
+                },
+                {
+                  "label": "NL - Netherlands",
+                  "value": "NL"
+                },
+                {
+                  "label": "NO - Norway",
+                  "value": "NO"
+                },
+                {
+                  "label": "NP - Nepal",
+                  "value": "NP"
+                },
+                {
+                  "label": "NR - Nauru",
+                  "value": "NR"
+                },
+                {
+                  "label": "NU - Niue",
+                  "value": "NU"
+                },
+                {
+                  "label": "NZ - New Zealand",
+                  "value": "NZ"
+                },
+                {
+                  "label": "OM - Oman",
+                  "value": "OM"
+                },
+                {
+                  "label": "PA - Panama",
+                  "value": "PA"
+                },
+                {
+                  "label": "PE - Peru",
+                  "value": "PE"
+                },
+                {
+                  "label": "PF - French Polynesia",
+                  "value": "PF"
+                },
+                {
+                  "label": "PG - Papua New Guinea",
+                  "value": "PG"
+                },
+                {
+                  "label": "PH - Philippines",
+                  "value": "PH"
+                },
+                {
+                  "label": "PK - Pakistan",
+                  "value": "PK"
+                },
+                {
+                  "label": "PL - Poland",
+                  "value": "PL"
+                },
+                {
+                  "label": "PM - Saint Pierre and Miquelon",
+                  "value": "PM"
+                },
+                {
+                  "label": "PN - Pitcairn",
+                  "value": "PN"
+                },
+                {
+                  "label": "PR - Puerto Rico",
+                  "value": "PR"
+                },
+                {
+                  "label": "PT - Portugal",
+                  "value": "PT"
+                },
+                {
+                  "label": "PW - Palau",
+                  "value": "PW"
+                },
+                {
+                  "label": "PY - Paraguay",
+                  "value": "PY"
+                },
+                {
+                  "label": "QA - Qatar",
+                  "value": "QA"
+                },
+                {
+                  "label": "RE - Réunion",
+                  "value": "RE"
+                },
+                {
+                  "label": "RO - Romania",
+                  "value": "RO"
+                },
+                {
+                  "label": "RS - Serbia",
+                  "value": "RS"
+                },
+                {
+                  "label": "RU - Russian Federation",
+                  "value": "RU"
+                },
+                {
+                  "label": "RW - Rwanda",
+                  "value": "RW"
+                },
+                {
+                  "label": "SA - Saudi Arabia",
+                  "value": "SA"
+                },
+                {
+                  "label": "SB - Solomon Islands",
+                  "value": "SB"
+                },
+                {
+                  "label": "SC - Seychelles",
+                  "value": "SC"
+                },
+                {
+                  "label": "SD - Sudan",
+                  "value": "SD"
+                },
+                {
+                  "label": "SE - Sweden",
+                  "value": "SE"
+                },
+                {
+                  "label": "SG - Singapore",
+                  "value": "SG"
+                },
+                {
+                  "label": "SH - Saint Helena",
+                  "value": "SH"
+                },
+                {
+                  "label": "SI - Slovenia",
+                  "value": "SI"
+                },
+                {
+                  "label": "SJ - Svalbard and Jan Mayen",
+                  "value": "SJ"
+                },
+                {
+                  "label": "SK - Slovakia",
+                  "value": "SK"
+                },
+                {
+                  "label": "SL - Sierra Leone",
+                  "value": "SL"
+                },
+                {
+                  "label": "SM - San Marino",
+                  "value": "SM"
+                },
+                {
+                  "label": "SN - Senegal",
+                  "value": "SN"
+                },
+                {
+                  "label": "SO - Somalia",
+                  "value": "SO"
+                },
+                {
+                  "label": "SR - Suriname",
+                  "value": "SR"
+                },
+                {
+                  "label": "SS - South Sudan",
+                  "value": "SS"
+                },
+                {
+                  "label": "ST - São Tomé and Príncipe",
+                  "value": "ST"
+                },
+                {
+                  "label": "SV - El Salvador",
+                  "value": "SV"
+                },
+                {
+                  "label": "SX - Sint Maarten (Dutch part)",
+                  "value": "SX"
+                },
+                {
+                  "label": "SY - Syrian Arab Republic",
+                  "value": "SY"
+                },
+                {
+                  "label": "SZ - Eswatini",
+                  "value": "SZ"
+                },
+                {
+                  "label": "TC - Turks and Caicos Islands",
+                  "value": "TC"
+                },
+                {
+                  "label": "TD - Chad",
+                  "value": "TD"
+                },
+                {
+                  "label": "TF - French Southern Territories",
+                  "value": "TF"
+                },
+                {
+                  "label": "TG - Togo",
+                  "value": "TG"
+                },
+                {
+                  "label": "TH - Thailand",
+                  "value": "TH"
+                },
+                {
+                  "label": "TJ - Tajikistan",
+                  "value": "TJ"
+                },
+                {
+                  "label": "TK - Tokelau",
+                  "value": "TK"
+                },
+                {
+                  "label": "TL - Timor-Leste",
+                  "value": "TL"
+                },
+                {
+                  "label": "TM - Turkmenistan",
+                  "value": "TM"
+                },
+                {
+                  "label": "TN - Tunisia",
+                  "value": "TN"
+                },
+                {
+                  "label": "TO - Tonga",
+                  "value": "TO"
+                },
+                {
+                  "label": "TR - Turkey",
+                  "value": "TR"
+                },
+                {
+                  "label": "TT - Trinidad and Tobago",
+                  "value": "TT"
+                },
+                {
+                  "label": "TV - Tuvalu",
+                  "value": "TV"
+                },
+                {
+                  "label": "TZ - Tanzania, United Republic of",
+                  "value": "TZ"
+                },
+                {
+                  "label": "UA - Ukraine",
+                  "value": "UA"
+                },
+                {
+                  "label": "UG - Uganda",
+                  "value": "UG"
+                },
+                {
+                  "label": "UM - United States Minor Outlying Islands",
+                  "value": "UM"
+                },
+                {
+                  "label": "UN - United Nations",
+                  "value": "UN"
+                },
+                {
+                  "label": "US - United States of America",
+                  "value": "US"
+                },
+                {
+                  "label": "UY - Uruguay",
+                  "value": "UY"
+                },
+                {
+                  "label": "UZ - Uzbekistan",
+                  "value": "UZ"
+                },
+                {
+                  "label": "VA - Holy See",
+                  "value": "VA"
+                },
+                {
+                  "label": "VC - Saint Vincent and the Grenadines",
+                  "value": "VC"
+                },
+                {
+                  "label": "VE - Venezuela (Bolivarian Republic of)",
+                  "value": "VE"
+                },
+                {
+                  "label": "VG - Virgin Islands (British)",
+                  "value": "VG"
+                },
+                {
+                  "label": "VI - Virgin Islands (U.S.)",
+                  "value": "VI"
+                },
+                {
+                  "label": "VN - Viet Nam",
+                  "value": "VN"
+                },
+                {
+                  "label": "VU - Vanuatu",
+                  "value": "VU"
+                },
+                {
+                  "label": "WF - Wallis and Futuna",
+                  "value": "WF"
+                },
+                {
+                  "label": "WS - Samoa",
+                  "value": "WS"
+                },
+                {
+                  "label": "YE - Yemen",
+                  "value": "YE"
+                },
+                {
+                  "label": "YT - Mayotte",
+                  "value": "YT"
+                },
+                {
+                  "label": "ZA - South Africa",
+                  "value": "ZA"
+                },
+                {
+                  "label": "ZM - Zambia",
+                  "value": "ZM"
+                },
+                {
+                  "label": "ZW - Zimbabwe",
+                  "value": "ZW"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "region": {
+              "label": "Region",
+              "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event_metadata",
-          "type": "object",
+        "event_metadata": {
           "label": "Event Metadata",
           "description": "The metadata associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "currency": {
               "@path": "$.properties.currency"
             },
@@ -610,47 +1445,100 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_metadata": {
-                "title": "Event Metadata",
-                "description": "The metadata associated with the conversion event.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "currency": {
-                    "title": "Currency",
-                    "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
-                    "type": "string",
-                    "enum": ["AUD", "CAD", "EUR", "GBP", "NZD", "USD"]
-                  },
-                  "itemCount": {
-                    "title": "Item Count",
-                    "description": "The number of items in the event. This should only be set for revenue-related events.",
-                    "type": "integer"
-                  },
-                  "value": {
-                    "title": "Value Decimal",
-                    "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
-                    "type": "number"
-                  }
+          "placeholder": null,
+          "properties": {
+            "currency": {
+              "label": "Currency",
+              "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "AUD - Australian Dollar",
+                  "value": "AUD"
                 },
-                "required": []
-              }
+                {
+                  "label": "CAD - Canadian Dollar",
+                  "value": "CAD"
+                },
+                {
+                  "label": "EUR - Euro",
+                  "value": "EUR"
+                },
+                {
+                  "label": "GBP - Pound Sterling",
+                  "value": "GBP"
+                },
+                {
+                  "label": "NZD - New Zealand Dollar",
+                  "value": "NZD"
+                },
+                {
+                  "label": "USD - US Dollar",
+                  "value": "USD"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "itemCount": {
+              "label": "Item Count",
+              "description": "The number of items in the event. This should only be set for revenue-related events.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "value": {
+              "label": "Value Decimal",
+              "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": {
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -685,84 +1573,80 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "conversion_id",
-          "type": "string",
+        "conversion_id": {
           "label": "Conversion ID",
           "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
-          "defaultValue": {
-            "@path": "$.messageId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "conversion_id": {
-                "title": "Conversion ID",
-                "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "reportCustomWebEvent",
-      "name": "Reddit Pixel - Custom Event",
+    "reportCustomWebEvent": {
+      "title": "Reddit Pixel - Custom Event",
       "description": "Send Custom Pixel Events to Reddit.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "conversion_id",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "conversion_id": {
           "label": "Conversion ID",
           "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
-          "defaultValue": {
-            "@path": "$.messageId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "conversion_id": {
-                "title": "Conversion ID",
-                "description": "The unique conversion ID that corresponds to a distinct conversion event. This is used for deduplication. If you are using both Reddit Pixel and CAPI integrations, this field is required in order to dedupe the same events across both sources.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event_metadata",
-          "type": "object",
+        "event_metadata": {
           "label": "Event Metadata",
           "description": "The metadata associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "currency": {
               "@path": "$.properties.currency"
             },
@@ -783,47 +1667,100 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_metadata": {
-                "title": "Event Metadata",
-                "description": "The metadata associated with the conversion event.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "currency": {
-                    "title": "Currency",
-                    "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
-                    "type": "string",
-                    "enum": ["AUD", "CAD", "EUR", "GBP", "NZD", "USD"]
-                  },
-                  "itemCount": {
-                    "title": "Item Count",
-                    "description": "The number of items in the event. This should only be set for revenue-related events.",
-                    "type": "integer"
-                  },
-                  "value": {
-                    "title": "Value Decimal",
-                    "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
-                    "type": "number"
-                  }
+          "placeholder": null,
+          "properties": {
+            "currency": {
+              "label": "Currency",
+              "description": "The currency for the value provided. This must be a three-character ISO 4217 currency code. This should only be set for revenue-related events.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "AUD - Australian Dollar",
+                  "value": "AUD"
                 },
-                "required": []
-              }
+                {
+                  "label": "CAD - Canadian Dollar",
+                  "value": "CAD"
+                },
+                {
+                  "label": "EUR - Euro",
+                  "value": "EUR"
+                },
+                {
+                  "label": "GBP - Pound Sterling",
+                  "value": "GBP"
+                },
+                {
+                  "label": "NZD - New Zealand Dollar",
+                  "value": "NZD"
+                },
+                {
+                  "label": "USD - US Dollar",
+                  "value": "USD"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "itemCount": {
+              "label": "Item Count",
+              "description": "The number of items in the event. This should only be set for revenue-related events.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "value": {
+              "label": "Value Decimal",
+              "description": "The value of the transaction in the base unit of the currency. This should only be set for revenue-related events.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": {
+          "category": null,
+          "depends_on": {
             "match": "any",
             "conditions": [
               {
@@ -858,14 +1795,22 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "user",
-          "type": "object",
+        "user": {
           "label": "User",
           "description": "The identifying user parameters associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "advertising_id": {
               "@path": "$.context.device.advertisingId"
             },
@@ -912,64 +1857,133 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "user": {
-                "title": "User",
-                "description": "The identifying user parameters associated with the conversion event.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "advertising_id": {
-                    "title": "Advertising ID",
-                    "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
-                    "type": "string"
-                  },
-                  "device_type": {
-                    "title": "Device Type",
-                    "description": "The type of mobile device. e.g. iOS or Android.",
-                    "type": "string"
-                  },
-                  "email": {
-                    "title": "Email",
-                    "description": "The email address of the user.",
-                    "type": "string"
-                  },
-                  "externalId": {
-                    "title": "External ID",
-                    "description": "An advertiser-assigned persistent identifier for the user.",
-                    "type": "string"
-                  },
-                  "phoneNumber": {
-                    "title": "Phone Number",
-                    "description": "The phone number of the user in E.164 standard format.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "advertising_id": {
+              "label": "Advertising ID",
+              "description": "The mobile advertising ID for the user. This can be the iOS IDFA, Android AAID.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "device_type": {
+              "label": "Device Type",
+              "description": "The type of mobile device. e.g. iOS or Android.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "email": {
+              "label": "Email",
+              "description": "The email address of the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "externalId": {
+              "label": "External ID",
+              "description": "An advertiser-assigned persistent identifier for the user.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "phoneNumber": {
+              "label": "Phone Number",
+              "description": "The phone number of the user in E.164 standard format.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "products",
-          "type": "object",
+        "products": {
           "label": "Products",
           "description": "The products associated with the conversion event.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@arrayPath": [
               "$.properties.products",
               {
@@ -985,632 +1999,1164 @@
               }
             ]
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "products": {
-                "title": "Products",
-                "description": "The products associated with the conversion event.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "category": {
-                      "title": "Category",
-                      "description": "The category the product.",
-                      "type": "string"
-                    },
-                    "id": {
-                      "title": "Product ID",
-                      "description": "The ID representing the product in a catalog",
-                      "type": "string"
-                    },
-                    "name": {
-                      "title": "Product Name",
-                      "description": "The name of the product",
-                      "type": "string"
-                    }
-                  },
-                  "required": []
-                }
-              }
+          "placeholder": null,
+          "properties": {
+            "category": {
+              "label": "Category",
+              "description": "The category the product.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "id": {
+              "label": "Product ID",
+              "description": "The ID representing the product in a catalog",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "name": {
+              "label": "Product Name",
+              "description": "The name of the product",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "data_processing_options",
-          "type": "object",
+        "data_processing_options": {
           "label": "Data Processing Options",
           "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "data_processing_options": {
-                "title": "Data Processing Options",
-                "description": "A structure of data processing options to specify the processing type for the event. This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "country": {
-                    "title": "Country",
-                    "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
-                    "type": "string",
-                    "enum": [
-                      "AD",
-                      "AE",
-                      "AF",
-                      "AG",
-                      "AI",
-                      "AL",
-                      "AM",
-                      "AO",
-                      "AQ",
-                      "AR",
-                      "AS",
-                      "AT",
-                      "AU",
-                      "AW",
-                      "AX",
-                      "AZ",
-                      "BA",
-                      "BB",
-                      "BD",
-                      "BE",
-                      "BF",
-                      "BG",
-                      "BH",
-                      "BI",
-                      "BJ",
-                      "BL",
-                      "BM",
-                      "BN",
-                      "BO",
-                      "BQ",
-                      "BR",
-                      "BS",
-                      "BT",
-                      "BV",
-                      "BW",
-                      "BY",
-                      "BZ",
-                      "CA",
-                      "CC",
-                      "CD",
-                      "CF",
-                      "CG",
-                      "CH",
-                      "CI",
-                      "CK",
-                      "CL",
-                      "CM",
-                      "CN",
-                      "CO",
-                      "CR",
-                      "CU",
-                      "CV",
-                      "CW",
-                      "CX",
-                      "CY",
-                      "CZ",
-                      "DE",
-                      "DJ",
-                      "DK",
-                      "DM",
-                      "DO",
-                      "DZ",
-                      "EC",
-                      "EE",
-                      "EG",
-                      "EH",
-                      "ER",
-                      "ES",
-                      "ET",
-                      "FI",
-                      "FJ",
-                      "FK",
-                      "FM",
-                      "FO",
-                      "FR",
-                      "GA",
-                      "GB",
-                      "GD",
-                      "GE",
-                      "GF",
-                      "GG",
-                      "GH",
-                      "GI",
-                      "GL",
-                      "GM",
-                      "GN",
-                      "GP",
-                      "GQ",
-                      "GR",
-                      "GT",
-                      "GU",
-                      "GW",
-                      "GY",
-                      "HK",
-                      "HM",
-                      "HN",
-                      "HR",
-                      "HT",
-                      "HU",
-                      "ID",
-                      "IE",
-                      "IL",
-                      "IM",
-                      "IN",
-                      "IO",
-                      "IQ",
-                      "IR",
-                      "IS",
-                      "IT",
-                      "JE",
-                      "JM",
-                      "JO",
-                      "JP",
-                      "KE",
-                      "KG",
-                      "KH",
-                      "KI",
-                      "KM",
-                      "KN",
-                      "KP",
-                      "KR",
-                      "KW",
-                      "KY",
-                      "KZ",
-                      "LA",
-                      "LB",
-                      "LC",
-                      "LI",
-                      "LK",
-                      "LR",
-                      "LS",
-                      "LT",
-                      "LU",
-                      "LV",
-                      "LY",
-                      "MA",
-                      "MC",
-                      "MD",
-                      "ME",
-                      "MF",
-                      "MG",
-                      "MH",
-                      "MK",
-                      "ML",
-                      "MM",
-                      "MN",
-                      "MO",
-                      "MP",
-                      "MQ",
-                      "MR",
-                      "MS",
-                      "MT",
-                      "MU",
-                      "MV",
-                      "MW",
-                      "MX",
-                      "MY",
-                      "MZ",
-                      "NA",
-                      "NC",
-                      "NE",
-                      "NF",
-                      "NG",
-                      "NI",
-                      "NL",
-                      "NO",
-                      "NP",
-                      "NR",
-                      "NU",
-                      "NZ",
-                      "OM",
-                      "PA",
-                      "PE",
-                      "PF",
-                      "PG",
-                      "PH",
-                      "PK",
-                      "PL",
-                      "PM",
-                      "PN",
-                      "PR",
-                      "PT",
-                      "PW",
-                      "PY",
-                      "QA",
-                      "RE",
-                      "RO",
-                      "RS",
-                      "RU",
-                      "RW",
-                      "SA",
-                      "SB",
-                      "SC",
-                      "SD",
-                      "SE",
-                      "SG",
-                      "SH",
-                      "SI",
-                      "SJ",
-                      "SK",
-                      "SL",
-                      "SM",
-                      "SN",
-                      "SO",
-                      "SR",
-                      "SS",
-                      "ST",
-                      "SV",
-                      "SX",
-                      "SY",
-                      "SZ",
-                      "TC",
-                      "TD",
-                      "TF",
-                      "TG",
-                      "TH",
-                      "TJ",
-                      "TK",
-                      "TL",
-                      "TM",
-                      "TN",
-                      "TO",
-                      "TR",
-                      "TT",
-                      "TV",
-                      "TZ",
-                      "UA",
-                      "UG",
-                      "UM",
-                      "UN",
-                      "US",
-                      "UY",
-                      "UZ",
-                      "VA",
-                      "VC",
-                      "VE",
-                      "VG",
-                      "VI",
-                      "VN",
-                      "VU",
-                      "WF",
-                      "WS",
-                      "YE",
-                      "YT",
-                      "ZA",
-                      "ZM",
-                      "ZW"
-                    ]
-                  },
-                  "region": {
-                    "title": "Region",
-                    "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
-                    "type": "string"
-                  }
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "country": {
+              "label": "Country",
+              "description": "Country Code of the user. We support ISO 3166-1 alpha-2 country code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "AD - Andorra",
+                  "value": "AD"
                 },
-                "required": []
-              }
+                {
+                  "label": "AE - United Arab Emirates",
+                  "value": "AE"
+                },
+                {
+                  "label": "AF - Afghanistan",
+                  "value": "AF"
+                },
+                {
+                  "label": "AG - Antigua and Barbuda",
+                  "value": "AG"
+                },
+                {
+                  "label": "AI - Anguilla",
+                  "value": "AI"
+                },
+                {
+                  "label": "AL - Albania",
+                  "value": "AL"
+                },
+                {
+                  "label": "AM - Armenia",
+                  "value": "AM"
+                },
+                {
+                  "label": "AO - Angola",
+                  "value": "AO"
+                },
+                {
+                  "label": "AQ - Antarctica",
+                  "value": "AQ"
+                },
+                {
+                  "label": "AR - Argentina",
+                  "value": "AR"
+                },
+                {
+                  "label": "AS - American Samoa",
+                  "value": "AS"
+                },
+                {
+                  "label": "AT - Austria",
+                  "value": "AT"
+                },
+                {
+                  "label": "AU - Australia",
+                  "value": "AU"
+                },
+                {
+                  "label": "AW - Aruba",
+                  "value": "AW"
+                },
+                {
+                  "label": "AX - Åland Islands",
+                  "value": "AX"
+                },
+                {
+                  "label": "AZ - Azerbaijan",
+                  "value": "AZ"
+                },
+                {
+                  "label": "BA - Bosnia and Herzegovina",
+                  "value": "BA"
+                },
+                {
+                  "label": "BB - Barbados",
+                  "value": "BB"
+                },
+                {
+                  "label": "BD - Bangladesh",
+                  "value": "BD"
+                },
+                {
+                  "label": "BE - Belgium",
+                  "value": "BE"
+                },
+                {
+                  "label": "BF - Burkina Faso",
+                  "value": "BF"
+                },
+                {
+                  "label": "BG - Bulgaria",
+                  "value": "BG"
+                },
+                {
+                  "label": "BH - Bahrain",
+                  "value": "BH"
+                },
+                {
+                  "label": "BI - Burundi",
+                  "value": "BI"
+                },
+                {
+                  "label": "BJ - Benin",
+                  "value": "BJ"
+                },
+                {
+                  "label": "BL - Saint Barthélemy",
+                  "value": "BL"
+                },
+                {
+                  "label": "BM - Bermuda",
+                  "value": "BM"
+                },
+                {
+                  "label": "BN - Brunei Darussalam",
+                  "value": "BN"
+                },
+                {
+                  "label": "BO - Bolivia (Plurinational State of)",
+                  "value": "BO"
+                },
+                {
+                  "label": "BQ - Bonaire, Sint Eustatius and Saba",
+                  "value": "BQ"
+                },
+                {
+                  "label": "BR - Brazil",
+                  "value": "BR"
+                },
+                {
+                  "label": "BS - Bahamas",
+                  "value": "BS"
+                },
+                {
+                  "label": "BT - Bhutan",
+                  "value": "BT"
+                },
+                {
+                  "label": "BV - Bouvet Island",
+                  "value": "BV"
+                },
+                {
+                  "label": "BW - Botswana",
+                  "value": "BW"
+                },
+                {
+                  "label": "BY - Belarus",
+                  "value": "BY"
+                },
+                {
+                  "label": "BZ - Belize",
+                  "value": "BZ"
+                },
+                {
+                  "label": "CA - Canada",
+                  "value": "CA"
+                },
+                {
+                  "label": "CC - Cocos (Keeling) Islands",
+                  "value": "CC"
+                },
+                {
+                  "label": "CD - Congo, Democratic Republic of the",
+                  "value": "CD"
+                },
+                {
+                  "label": "CF - Central African Republic",
+                  "value": "CF"
+                },
+                {
+                  "label": "CG - Congo",
+                  "value": "CG"
+                },
+                {
+                  "label": "CH - Switzerland",
+                  "value": "CH"
+                },
+                {
+                  "label": "CI - Côte d'Ivoire",
+                  "value": "CI"
+                },
+                {
+                  "label": "CK - Cook Islands",
+                  "value": "CK"
+                },
+                {
+                  "label": "CL - Chile",
+                  "value": "CL"
+                },
+                {
+                  "label": "CM - Cameroon",
+                  "value": "CM"
+                },
+                {
+                  "label": "CN - China",
+                  "value": "CN"
+                },
+                {
+                  "label": "CO - Colombia",
+                  "value": "CO"
+                },
+                {
+                  "label": "CR - Costa Rica",
+                  "value": "CR"
+                },
+                {
+                  "label": "CU - Cuba",
+                  "value": "CU"
+                },
+                {
+                  "label": "CV - Cabo Verde",
+                  "value": "CV"
+                },
+                {
+                  "label": "CW - Curaçao",
+                  "value": "CW"
+                },
+                {
+                  "label": "CX - Christmas Island",
+                  "value": "CX"
+                },
+                {
+                  "label": "CY - Cyprus",
+                  "value": "CY"
+                },
+                {
+                  "label": "CZ - Czechia",
+                  "value": "CZ"
+                },
+                {
+                  "label": "DE - Germany",
+                  "value": "DE"
+                },
+                {
+                  "label": "DJ - Djibouti",
+                  "value": "DJ"
+                },
+                {
+                  "label": "DK - Denmark",
+                  "value": "DK"
+                },
+                {
+                  "label": "DM - Dominica",
+                  "value": "DM"
+                },
+                {
+                  "label": "DO - Dominican Republic",
+                  "value": "DO"
+                },
+                {
+                  "label": "DZ - Algeria",
+                  "value": "DZ"
+                },
+                {
+                  "label": "EC - Ecuador",
+                  "value": "EC"
+                },
+                {
+                  "label": "EE - Estonia",
+                  "value": "EE"
+                },
+                {
+                  "label": "EG - Egypt",
+                  "value": "EG"
+                },
+                {
+                  "label": "EH - Western Sahara",
+                  "value": "EH"
+                },
+                {
+                  "label": "ER - Eritrea",
+                  "value": "ER"
+                },
+                {
+                  "label": "ES - Spain",
+                  "value": "ES"
+                },
+                {
+                  "label": "ET - Ethiopia",
+                  "value": "ET"
+                },
+                {
+                  "label": "FI - Finland",
+                  "value": "FI"
+                },
+                {
+                  "label": "FJ - Fiji",
+                  "value": "FJ"
+                },
+                {
+                  "label": "FK - Falkland Islands (Malvinas)",
+                  "value": "FK"
+                },
+                {
+                  "label": "FM - Micronesia (Federated States of)",
+                  "value": "FM"
+                },
+                {
+                  "label": "FO - Faroe Islands",
+                  "value": "FO"
+                },
+                {
+                  "label": "FR - France",
+                  "value": "FR"
+                },
+                {
+                  "label": "GA - Gabon",
+                  "value": "GA"
+                },
+                {
+                  "label": "GB - United Kingdom of Great Britain and Northern Ireland",
+                  "value": "GB"
+                },
+                {
+                  "label": "GD - Grenada",
+                  "value": "GD"
+                },
+                {
+                  "label": "GE - Georgia",
+                  "value": "GE"
+                },
+                {
+                  "label": "GF - French Guiana",
+                  "value": "GF"
+                },
+                {
+                  "label": "GG - Guernsey",
+                  "value": "GG"
+                },
+                {
+                  "label": "GH - Ghana",
+                  "value": "GH"
+                },
+                {
+                  "label": "GI - Gibraltar",
+                  "value": "GI"
+                },
+                {
+                  "label": "GL - Greenland",
+                  "value": "GL"
+                },
+                {
+                  "label": "GM - Gambia",
+                  "value": "GM"
+                },
+                {
+                  "label": "GN - Guinea",
+                  "value": "GN"
+                },
+                {
+                  "label": "GP - Guadeloupe",
+                  "value": "GP"
+                },
+                {
+                  "label": "GQ - Equatorial Guinea",
+                  "value": "GQ"
+                },
+                {
+                  "label": "GR - Greece",
+                  "value": "GR"
+                },
+                {
+                  "label": "GT - Guatemala",
+                  "value": "GT"
+                },
+                {
+                  "label": "GU - Guam",
+                  "value": "GU"
+                },
+                {
+                  "label": "GW - Guinea-Bissau",
+                  "value": "GW"
+                },
+                {
+                  "label": "GY - Guyana",
+                  "value": "GY"
+                },
+                {
+                  "label": "HK - Hong Kong",
+                  "value": "HK"
+                },
+                {
+                  "label": "HM - Heard Island and McDonald Islands",
+                  "value": "HM"
+                },
+                {
+                  "label": "HN - Honduras",
+                  "value": "HN"
+                },
+                {
+                  "label": "HR - Croatia",
+                  "value": "HR"
+                },
+                {
+                  "label": "HT - Haiti",
+                  "value": "HT"
+                },
+                {
+                  "label": "HU - Hungary",
+                  "value": "HU"
+                },
+                {
+                  "label": "ID - Indonesia",
+                  "value": "ID"
+                },
+                {
+                  "label": "IE - Ireland",
+                  "value": "IE"
+                },
+                {
+                  "label": "IL - Israel",
+                  "value": "IL"
+                },
+                {
+                  "label": "IM - Isle of Man",
+                  "value": "IM"
+                },
+                {
+                  "label": "IN - India",
+                  "value": "IN"
+                },
+                {
+                  "label": "IO - British Indian Ocean Territory",
+                  "value": "IO"
+                },
+                {
+                  "label": "IQ - Iraq",
+                  "value": "IQ"
+                },
+                {
+                  "label": "IR - Iran (Islamic Republic of)",
+                  "value": "IR"
+                },
+                {
+                  "label": "IS - Iceland",
+                  "value": "IS"
+                },
+                {
+                  "label": "IT - Italy",
+                  "value": "IT"
+                },
+                {
+                  "label": "JE - Jersey",
+                  "value": "JE"
+                },
+                {
+                  "label": "JM - Jamaica",
+                  "value": "JM"
+                },
+                {
+                  "label": "JO - Jordan",
+                  "value": "JO"
+                },
+                {
+                  "label": "JP - Japan",
+                  "value": "JP"
+                },
+                {
+                  "label": "KE - Kenya",
+                  "value": "KE"
+                },
+                {
+                  "label": "KG - Kyrgyzstan",
+                  "value": "KG"
+                },
+                {
+                  "label": "KH - Cambodia",
+                  "value": "KH"
+                },
+                {
+                  "label": "KI - Kiribati",
+                  "value": "KI"
+                },
+                {
+                  "label": "KM - Comoros",
+                  "value": "KM"
+                },
+                {
+                  "label": "KN - Saint Kitts and Nevis",
+                  "value": "KN"
+                },
+                {
+                  "label": "KP - Korea (Democratic People's Republic of)",
+                  "value": "KP"
+                },
+                {
+                  "label": "KR - Korea, Republic of",
+                  "value": "KR"
+                },
+                {
+                  "label": "KW - Kuwait",
+                  "value": "KW"
+                },
+                {
+                  "label": "KY - Cayman Islands",
+                  "value": "KY"
+                },
+                {
+                  "label": "KZ - Kazakhstan",
+                  "value": "KZ"
+                },
+                {
+                  "label": "LA - Lao People's Democratic Republic",
+                  "value": "LA"
+                },
+                {
+                  "label": "LB - Lebanon",
+                  "value": "LB"
+                },
+                {
+                  "label": "LC - Saint Lucia",
+                  "value": "LC"
+                },
+                {
+                  "label": "LI - Liechtenstein",
+                  "value": "LI"
+                },
+                {
+                  "label": "LK - Sri Lanka",
+                  "value": "LK"
+                },
+                {
+                  "label": "LR - Liberia",
+                  "value": "LR"
+                },
+                {
+                  "label": "LS - Lesotho",
+                  "value": "LS"
+                },
+                {
+                  "label": "LT - Lithuania",
+                  "value": "LT"
+                },
+                {
+                  "label": "LU - Luxembourg",
+                  "value": "LU"
+                },
+                {
+                  "label": "LV - Latvia",
+                  "value": "LV"
+                },
+                {
+                  "label": "LY - Libya",
+                  "value": "LY"
+                },
+                {
+                  "label": "MA - Morocco",
+                  "value": "MA"
+                },
+                {
+                  "label": "MC - Monaco",
+                  "value": "MC"
+                },
+                {
+                  "label": "MD - Moldova (Republic of)",
+                  "value": "MD"
+                },
+                {
+                  "label": "ME - Montenegro",
+                  "value": "ME"
+                },
+                {
+                  "label": "MF - Saint Martin (French part)",
+                  "value": "MF"
+                },
+                {
+                  "label": "MG - Madagascar",
+                  "value": "MG"
+                },
+                {
+                  "label": "MH - Marshall Islands",
+                  "value": "MH"
+                },
+                {
+                  "label": "MK - North Macedonia",
+                  "value": "MK"
+                },
+                {
+                  "label": "ML - Mali",
+                  "value": "ML"
+                },
+                {
+                  "label": "MM - Myanmar",
+                  "value": "MM"
+                },
+                {
+                  "label": "MN - Mongolia",
+                  "value": "MN"
+                },
+                {
+                  "label": "MO - Macao",
+                  "value": "MO"
+                },
+                {
+                  "label": "MP - Northern Mariana Islands",
+                  "value": "MP"
+                },
+                {
+                  "label": "MQ - Martinique",
+                  "value": "MQ"
+                },
+                {
+                  "label": "MR - Mauritania",
+                  "value": "MR"
+                },
+                {
+                  "label": "MS - Montserrat",
+                  "value": "MS"
+                },
+                {
+                  "label": "MT - Malta",
+                  "value": "MT"
+                },
+                {
+                  "label": "MU - Mauritius",
+                  "value": "MU"
+                },
+                {
+                  "label": "MV - Maldives",
+                  "value": "MV"
+                },
+                {
+                  "label": "MW - Malawi",
+                  "value": "MW"
+                },
+                {
+                  "label": "MX - Mexico",
+                  "value": "MX"
+                },
+                {
+                  "label": "MY - Malaysia",
+                  "value": "MY"
+                },
+                {
+                  "label": "MZ - Mozambique",
+                  "value": "MZ"
+                },
+                {
+                  "label": "NA - Namibia",
+                  "value": "NA"
+                },
+                {
+                  "label": "NC - New Caledonia",
+                  "value": "NC"
+                },
+                {
+                  "label": "NE - Niger",
+                  "value": "NE"
+                },
+                {
+                  "label": "NF - Norfolk Island",
+                  "value": "NF"
+                },
+                {
+                  "label": "NG - Nigeria",
+                  "value": "NG"
+                },
+                {
+                  "label": "NI - Nicaragua",
+                  "value": "NI"
+                },
+                {
+                  "label": "NL - Netherlands",
+                  "value": "NL"
+                },
+                {
+                  "label": "NO - Norway",
+                  "value": "NO"
+                },
+                {
+                  "label": "NP - Nepal",
+                  "value": "NP"
+                },
+                {
+                  "label": "NR - Nauru",
+                  "value": "NR"
+                },
+                {
+                  "label": "NU - Niue",
+                  "value": "NU"
+                },
+                {
+                  "label": "NZ - New Zealand",
+                  "value": "NZ"
+                },
+                {
+                  "label": "OM - Oman",
+                  "value": "OM"
+                },
+                {
+                  "label": "PA - Panama",
+                  "value": "PA"
+                },
+                {
+                  "label": "PE - Peru",
+                  "value": "PE"
+                },
+                {
+                  "label": "PF - French Polynesia",
+                  "value": "PF"
+                },
+                {
+                  "label": "PG - Papua New Guinea",
+                  "value": "PG"
+                },
+                {
+                  "label": "PH - Philippines",
+                  "value": "PH"
+                },
+                {
+                  "label": "PK - Pakistan",
+                  "value": "PK"
+                },
+                {
+                  "label": "PL - Poland",
+                  "value": "PL"
+                },
+                {
+                  "label": "PM - Saint Pierre and Miquelon",
+                  "value": "PM"
+                },
+                {
+                  "label": "PN - Pitcairn",
+                  "value": "PN"
+                },
+                {
+                  "label": "PR - Puerto Rico",
+                  "value": "PR"
+                },
+                {
+                  "label": "PT - Portugal",
+                  "value": "PT"
+                },
+                {
+                  "label": "PW - Palau",
+                  "value": "PW"
+                },
+                {
+                  "label": "PY - Paraguay",
+                  "value": "PY"
+                },
+                {
+                  "label": "QA - Qatar",
+                  "value": "QA"
+                },
+                {
+                  "label": "RE - Réunion",
+                  "value": "RE"
+                },
+                {
+                  "label": "RO - Romania",
+                  "value": "RO"
+                },
+                {
+                  "label": "RS - Serbia",
+                  "value": "RS"
+                },
+                {
+                  "label": "RU - Russian Federation",
+                  "value": "RU"
+                },
+                {
+                  "label": "RW - Rwanda",
+                  "value": "RW"
+                },
+                {
+                  "label": "SA - Saudi Arabia",
+                  "value": "SA"
+                },
+                {
+                  "label": "SB - Solomon Islands",
+                  "value": "SB"
+                },
+                {
+                  "label": "SC - Seychelles",
+                  "value": "SC"
+                },
+                {
+                  "label": "SD - Sudan",
+                  "value": "SD"
+                },
+                {
+                  "label": "SE - Sweden",
+                  "value": "SE"
+                },
+                {
+                  "label": "SG - Singapore",
+                  "value": "SG"
+                },
+                {
+                  "label": "SH - Saint Helena",
+                  "value": "SH"
+                },
+                {
+                  "label": "SI - Slovenia",
+                  "value": "SI"
+                },
+                {
+                  "label": "SJ - Svalbard and Jan Mayen",
+                  "value": "SJ"
+                },
+                {
+                  "label": "SK - Slovakia",
+                  "value": "SK"
+                },
+                {
+                  "label": "SL - Sierra Leone",
+                  "value": "SL"
+                },
+                {
+                  "label": "SM - San Marino",
+                  "value": "SM"
+                },
+                {
+                  "label": "SN - Senegal",
+                  "value": "SN"
+                },
+                {
+                  "label": "SO - Somalia",
+                  "value": "SO"
+                },
+                {
+                  "label": "SR - Suriname",
+                  "value": "SR"
+                },
+                {
+                  "label": "SS - South Sudan",
+                  "value": "SS"
+                },
+                {
+                  "label": "ST - São Tomé and Príncipe",
+                  "value": "ST"
+                },
+                {
+                  "label": "SV - El Salvador",
+                  "value": "SV"
+                },
+                {
+                  "label": "SX - Sint Maarten (Dutch part)",
+                  "value": "SX"
+                },
+                {
+                  "label": "SY - Syrian Arab Republic",
+                  "value": "SY"
+                },
+                {
+                  "label": "SZ - Eswatini",
+                  "value": "SZ"
+                },
+                {
+                  "label": "TC - Turks and Caicos Islands",
+                  "value": "TC"
+                },
+                {
+                  "label": "TD - Chad",
+                  "value": "TD"
+                },
+                {
+                  "label": "TF - French Southern Territories",
+                  "value": "TF"
+                },
+                {
+                  "label": "TG - Togo",
+                  "value": "TG"
+                },
+                {
+                  "label": "TH - Thailand",
+                  "value": "TH"
+                },
+                {
+                  "label": "TJ - Tajikistan",
+                  "value": "TJ"
+                },
+                {
+                  "label": "TK - Tokelau",
+                  "value": "TK"
+                },
+                {
+                  "label": "TL - Timor-Leste",
+                  "value": "TL"
+                },
+                {
+                  "label": "TM - Turkmenistan",
+                  "value": "TM"
+                },
+                {
+                  "label": "TN - Tunisia",
+                  "value": "TN"
+                },
+                {
+                  "label": "TO - Tonga",
+                  "value": "TO"
+                },
+                {
+                  "label": "TR - Turkey",
+                  "value": "TR"
+                },
+                {
+                  "label": "TT - Trinidad and Tobago",
+                  "value": "TT"
+                },
+                {
+                  "label": "TV - Tuvalu",
+                  "value": "TV"
+                },
+                {
+                  "label": "TZ - Tanzania, United Republic of",
+                  "value": "TZ"
+                },
+                {
+                  "label": "UA - Ukraine",
+                  "value": "UA"
+                },
+                {
+                  "label": "UG - Uganda",
+                  "value": "UG"
+                },
+                {
+                  "label": "UM - United States Minor Outlying Islands",
+                  "value": "UM"
+                },
+                {
+                  "label": "UN - United Nations",
+                  "value": "UN"
+                },
+                {
+                  "label": "US - United States of America",
+                  "value": "US"
+                },
+                {
+                  "label": "UY - Uruguay",
+                  "value": "UY"
+                },
+                {
+                  "label": "UZ - Uzbekistan",
+                  "value": "UZ"
+                },
+                {
+                  "label": "VA - Holy See",
+                  "value": "VA"
+                },
+                {
+                  "label": "VC - Saint Vincent and the Grenadines",
+                  "value": "VC"
+                },
+                {
+                  "label": "VE - Venezuela (Bolivarian Republic of)",
+                  "value": "VE"
+                },
+                {
+                  "label": "VG - Virgin Islands (British)",
+                  "value": "VG"
+                },
+                {
+                  "label": "VI - Virgin Islands (U.S.)",
+                  "value": "VI"
+                },
+                {
+                  "label": "VN - Viet Nam",
+                  "value": "VN"
+                },
+                {
+                  "label": "VU - Vanuatu",
+                  "value": "VU"
+                },
+                {
+                  "label": "WF - Wallis and Futuna",
+                  "value": "WF"
+                },
+                {
+                  "label": "WS - Samoa",
+                  "value": "WS"
+                },
+                {
+                  "label": "YE - Yemen",
+                  "value": "YE"
+                },
+                {
+                  "label": "YT - Mayotte",
+                  "value": "YT"
+                },
+                {
+                  "label": "ZA - South Africa",
+                  "value": "ZA"
+                },
+                {
+                  "label": "ZM - Zambia",
+                  "value": "ZM"
+                },
+                {
+                  "label": "ZW - Zimbabwe",
+                  "value": "ZW"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "region": {
+              "label": "Region",
+              "description": "Region Code of the user. We support ISO 3166-2 region code, ex: \"US-CA, US-NY, etc.\" or just the region code without country prefix, e.g. \"CA, NY, etc.\". This is only used for LDU - when the LDU flag is enabled, it may impact campaign performance and limit the size of targetable audiences.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "custom_event_name",
-          "type": "string",
+        "custom_event_name": {
           "label": "Custom Event Name",
           "description": "A custom event name that can be passed when tracking_type is set to \"Custom\". All UTF-8 characters are accepted and custom_event_name must be at most 64 characters long.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_event_name": {
-                "title": "Custom Event Name",
-                "description": "A custom event name that can be passed when tracking_type is set to \"Custom\". All UTF-8 characters are accepted and custom_event_name must be at most 64 characters long.",
-                "type": "string"
-              }
-            },
-            "required": ["custom_event_name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "reportWebEvent",
-      "name": "Add to Cart",
-      "subscribe": "type = \"track\" and event = \"Product Added\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "itemCount": {
-            "@path": "$.properties.quantity"
-          },
-          "value": {
-            "@path": "$.properties.price"
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "AddToCart"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Add to Wishlist",
-      "subscribe": "type = \"track\" and event = \"Product Added to Wishlist\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "itemCount": {
-            "@path": "$.properties.quantity"
-          },
-          "value": {
-            "@path": "$.properties.price"
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "AddToWishlist"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Lead",
-      "subscribe": "type = \"track\" and event = \"Lead Generated\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "value": {
-            "@path": "$.properties.value"
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "Lead"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
       "name": "Page Visit",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "type = \"page\"",
       "mapping": {
         "products": {
@@ -1702,286 +3248,12 @@
         },
         "tracking_type": "PageVisit"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "reportWebEvent",
-      "name": "Purchase",
-      "subscribe": "type = \"track\" and event = \"Order Completed\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "itemCount": {
-            "@path": "$.properties.quantity"
-          },
-          "value": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.revenue"
-              },
-              "then": {
-                "@path": "$.properties.revenue"
-              },
-              "else": {
-                "@path": "$.properties.total"
-              }
-            }
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "Purchase"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Search",
-      "subscribe": "type = \"track\" and event = \"Products Searched\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "itemCount": {
-            "@path": "$.properties.quantity"
-          },
-          "value": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.revenue"
-              },
-              "then": {
-                "@path": "$.properties.revenue"
-              },
-              "else": {
-                "@path": "$.properties.total"
-              }
-            }
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "Search"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Sign Up",
-      "subscribe": "type = \"track\" and event = \"Signed Up\"",
-      "mapping": {
-        "products": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "category": {
-                "@path": "$.category"
-              },
-              "id": {
-                "@path": "$.product_id"
-              },
-              "name": {
-                "@path": "$.name"
-              }
-            }
-          ]
-        },
-        "user": {
-          "advertising_id": {
-            "@path": "$.context.device.advertisingId"
-          },
-          "device_type": {
-            "@path": "$.context.device.type"
-          },
-          "email": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "externalId": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "phoneNumber": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.phone"
-              },
-              "then": {
-                "@path": "$.properties.phone"
-              },
-              "else": {
-                "@path": "$.context.traits.phone"
-              }
-            }
-          }
-        },
-        "event_metadata": {
-          "currency": {
-            "@path": "$.properties.currency"
-          },
-          "value": {
-            "@path": "$.properties.value"
-          }
-        },
-        "conversion_id": {
-          "@path": "$.messageId"
-        },
-        "tracking_type": "SignUp"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
       "name": "View Content",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "type = \"track\" and event = \"Product Viewed\"",
       "mapping": {
         "products": {
@@ -2073,7 +3345,543 @@
         },
         "tracking_type": "ViewContent"
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Search",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Products Searched\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Search"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Add to Cart",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Product Added\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@path": "$.properties.price"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "AddToCart"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Add to Wishlist",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Product Added to Wishlist\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@path": "$.properties.price"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "AddToWishlist"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Purchase",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Order Completed\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "itemCount": {
+            "@path": "$.properties.quantity"
+          },
+          "value": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.revenue"
+              },
+              "then": {
+                "@path": "$.properties.revenue"
+              },
+              "else": {
+                "@path": "$.properties.total"
+              }
+            }
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Purchase"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Lead",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Lead Generated\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "value": {
+            "@path": "$.properties.value"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "Lead"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Sign Up",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "type = \"track\" and event = \"Signed Up\"",
+      "mapping": {
+        "products": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "category": {
+                "@path": "$.category"
+              },
+              "id": {
+                "@path": "$.product_id"
+              },
+              "name": {
+                "@path": "$.name"
+              }
+            }
+          ]
+        },
+        "user": {
+          "advertising_id": {
+            "@path": "$.context.device.advertisingId"
+          },
+          "device_type": {
+            "@path": "$.context.device.type"
+          },
+          "email": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "externalId": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "phoneNumber": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          }
+        },
+        "event_metadata": {
+          "currency": {
+            "@path": "$.properties.currency"
+          },
+          "value": {
+            "@path": "$.properties.value"
+          }
+        },
+        "conversion_id": {
+          "@path": "$.messageId"
+        },
+        "tracking_type": "SignUp"
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/replaybird/metadata.json
+++ b/packages/browser-destinations/destinations/replaybird/metadata.json
@@ -1,117 +1,41 @@
 {
+  "slug": "actions-replaybird-web",
   "name": "ReplayBird Web (Actions)",
-  "basicOptions": ["apiKey"],
-  "options": {
-    "apiKey": {
-      "tags": [],
-      "default": "",
-      "description": "The api key for replaybird",
-      "encrypt": true,
-      "hidden": false,
-      "label": "API Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The apiKey property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "apiKey": {
+        "label": "API Key",
+        "description": "The api key for replaybird",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Sets user identifier and user profile details",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User Id",
-          "description": "A unique ID for a known user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User Id",
-                "description": "A unique ID for a known user",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "User Traits",
-          "description": "The Segment traits to be forwarded to ReplayBird",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Traits",
-                "description": "The Segment traits to be forwarded to ReplayBird",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Send Track Events",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Send Track Events",
       "description": "Send Segment track() events and / or Segment page() events to ReplayBird",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" or type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" or type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event Name",
           "description": "The track() event name or page() name for the event.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.event"
@@ -124,139 +48,153 @@
               }
             }
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event Name",
-                "description": "The track() event name or page() name for the event.",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "A JSON object containing additional information about the event that will be indexed by replaybird.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "A JSON object containing additional information about the event that will be indexed by replaybird.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "A unique ID for a known user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "A unique ID for a known user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "A unique ID for a anonymous user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "A unique ID for a anonymous user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Sets user identifier and user profile details",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
         "userId": {
-          "@path": "$.userId"
+          "label": "User Id",
+          "description": "A unique ID for a known user",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "User Traits",
+          "description": "The Segment traits to be forwarded to ReplayBird",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
-    },
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\" or type = \"page\"",
       "mapping": {
         "name": {
@@ -282,7 +220,22 @@
           "@path": "$.anonymousId"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/replaybird/metadata.json
+++ b/packages/browser-destinations/destinations/replaybird/metadata.json
@@ -10,8 +10,10 @@
         "description": "The api key for replaybird",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event Name",
@@ -58,7 +60,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -81,7 +85,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -104,7 +110,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -127,7 +135,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -139,7 +149,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User Id",
@@ -162,7 +172,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Traits",
@@ -185,7 +197,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/replaybird/metadata.json
+++ b/packages/browser-destinations/destinations/replaybird/metadata.json
@@ -1,0 +1,288 @@
+{
+  "name": "ReplayBird Web (Actions)",
+  "basicOptions": ["apiKey"],
+  "options": {
+    "apiKey": {
+      "tags": [],
+      "default": "",
+      "description": "The api key for replaybird",
+      "encrypt": true,
+      "hidden": false,
+      "label": "API Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The apiKey property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sets user identifier and user profile details",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User Id",
+          "description": "A unique ID for a known user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User Id",
+                "description": "A unique ID for a known user",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Traits",
+          "description": "The Segment traits to be forwarded to ReplayBird",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Traits",
+                "description": "The Segment traits to be forwarded to ReplayBird",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Send Track Events",
+      "description": "Send Segment track() events and / or Segment page() events to ReplayBird",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" or type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The track() event name or page() name for the event.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.event"
+              },
+              "then": {
+                "@path": "$.event"
+              },
+              "else": {
+                "@path": "$.name"
+              }
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event Name",
+                "description": "The track() event name or page() name for the event.",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "A JSON object containing additional information about the event that will be indexed by replaybird.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "A JSON object containing additional information about the event that will be indexed by replaybird.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "A unique ID for a known user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "A unique ID for a known user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "A unique ID for a anonymous user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "A unique ID for a anonymous user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\" or type = \"page\"",
+      "mapping": {
+        "name": {
+          "@if": {
+            "exists": {
+              "@path": "$.event"
+            },
+            "then": {
+              "@path": "$.event"
+            },
+            "else": {
+              "@path": "$.name"
+            }
+          }
+        },
+        "properties": {
+          "@path": "$.properties"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/rupt/metadata.json
+++ b/packages/browser-destinations/destinations/rupt/metadata.json
@@ -1,137 +1,96 @@
 {
+  "slug": "actions-rupt",
   "name": "Rupt",
-  "basicOptions": ["client_id", "new_account_url", "logout_url", "success_url", "suspended_url"],
-  "options": {
-    "client_id": {
-      "tags": [],
-      "default": "",
-      "description": "The API client id of your Rupt project.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Client ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The client_id property is required."]],
-      "uIMetadata": null
-    },
-    "new_account_url": {
-      "tags": [],
-      "default": "",
-      "description": "A URL to redirect the user to if they want to stop account sharing and create a new account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "New Account URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The new_account_url property is required."]],
-      "uIMetadata": null
-    },
-    "logout_url": {
-      "tags": [],
-      "default": "",
-      "description": "A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Logout URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "success_url": {
-      "tags": [],
-      "default": "",
-      "description": "A URL to redirect the user to if they are successfully verified and are within the device limit.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Success URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "suspended_url": {
-      "tags": [],
-      "default": "",
-      "description": "A URL to redirect the user to if they are suspended.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Suspended URL",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "client_id": {
+        "label": "Client ID",
+        "description": "The API client id of your Rupt project.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "new_account_url": {
+        "label": "New Account URL",
+        "description": "A URL to redirect the user to if they want to stop account sharing and create a new account.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "logout_url": {
+        "label": "Logout URL",
+        "description": "A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "success_url": {
+        "label": "Success URL",
+        "description": "A URL to redirect the user to if they are successfully verified and are within the device limit.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "suspended_url": {
+        "label": "Suspended URL",
+        "description": "A URL to redirect the user to if they are suspended.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "attach",
-      "name": "Attach Device",
+  "audienceConfig": null,
+  "actions": {
+    "attach": {
+      "title": "Attach Device",
       "description": "Attach a device to an account.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "account",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "account": {
           "label": "Account",
           "description": "The account to attach the device to.",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "account": {
-                "title": "Account",
-                "description": "The account to attach the device to.",
-                "type": "string"
-              }
-            },
-            "required": ["account"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "The email of the user to attach the device to.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.context.traits.email"
@@ -144,34 +103,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "The email of the user to attach the device to.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "phone",
-          "type": "string",
+        "phone": {
           "label": "Phone",
           "description": "The phone number of the user to attach the device to.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.context.traits.phone"
@@ -184,90 +136,68 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "phone": {
-                "title": "Phone",
-                "description": "The phone number of the user to attach the device to.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "metadata",
-          "type": "object",
+        "metadata": {
           "label": "Metadata",
           "description": "Metadata to attach to the device.",
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "metadata": {
-                "title": "Metadata",
-                "description": "Metadata to attach to the device.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "include_page",
-          "type": "boolean",
+        "include_page": {
           "label": "Include Page",
           "description": "Whether to include the page (url) in the attach request",
+          "type": "boolean",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "include_page": {
-                "title": "Include Page",
-                "description": "Whether to include the page (url) in the attach request",
-                "type": "boolean"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "attach",
       "name": "Attach Device",
+      "type": "automatic",
+      "partnerAction": "attach",
       "subscribe": "type = 'page'",
       "mapping": {
         "account": {
@@ -300,7 +230,7 @@
           }
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/rupt/metadata.json
+++ b/packages/browser-destinations/destinations/rupt/metadata.json
@@ -1,0 +1,306 @@
+{
+  "name": "Rupt",
+  "basicOptions": ["client_id", "new_account_url", "logout_url", "success_url", "suspended_url"],
+  "options": {
+    "client_id": {
+      "tags": [],
+      "default": "",
+      "description": "The API client id of your Rupt project.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Client ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The client_id property is required."]],
+      "uIMetadata": null
+    },
+    "new_account_url": {
+      "tags": [],
+      "default": "",
+      "description": "A URL to redirect the user to if they want to stop account sharing and create a new account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "New Account URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The new_account_url property is required."]],
+      "uIMetadata": null
+    },
+    "logout_url": {
+      "tags": [],
+      "default": "",
+      "description": "A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Logout URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "success_url": {
+      "tags": [],
+      "default": "",
+      "description": "A URL to redirect the user to if they are successfully verified and are within the device limit.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Success URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "suspended_url": {
+      "tags": [],
+      "default": "",
+      "description": "A URL to redirect the user to if they are suspended.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Suspended URL",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "attach",
+      "name": "Attach Device",
+      "description": "Attach a device to an account.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "account",
+          "type": "string",
+          "label": "Account",
+          "description": "The account to attach the device to.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "account": {
+                "title": "Account",
+                "description": "The account to attach the device to.",
+                "type": "string"
+              }
+            },
+            "required": ["account"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "The email of the user to attach the device to.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.email"
+              },
+              "then": {
+                "@path": "$.context.traits.email"
+              },
+              "else": {
+                "@path": "$.properties.email"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "The email of the user to attach the device to.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "phone",
+          "type": "string",
+          "label": "Phone",
+          "description": "The phone number of the user to attach the device to.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.context.traits.phone"
+              },
+              "then": {
+                "@path": "$.context.traits.phone"
+              },
+              "else": {
+                "@path": "$.properties.phone"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "phone": {
+                "title": "Phone",
+                "description": "The phone number of the user to attach the device to.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "metadata",
+          "type": "object",
+          "label": "Metadata",
+          "description": "Metadata to attach to the device.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "metadata": {
+                "title": "Metadata",
+                "description": "Metadata to attach to the device.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "include_page",
+          "type": "boolean",
+          "label": "Include Page",
+          "description": "Whether to include the page (url) in the attach request",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "include_page": {
+                "title": "Include Page",
+                "description": "Whether to include the page (url) in the attach request",
+                "type": "boolean"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "attach",
+      "name": "Attach Device",
+      "subscribe": "type = 'page'",
+      "mapping": {
+        "account": {
+          "@path": "$.userId"
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.traits.email"
+            },
+            "then": {
+              "@path": "$.context.traits.email"
+            },
+            "else": {
+              "@path": "$.properties.email"
+            }
+          }
+        },
+        "phone": {
+          "@if": {
+            "exists": {
+              "@path": "$.context.traits.phone"
+            },
+            "then": {
+              "@path": "$.context.traits.phone"
+            },
+            "else": {
+              "@path": "$.properties.phone"
+            }
+          }
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/rupt/metadata.json
+++ b/packages/browser-destinations/destinations/rupt/metadata.json
@@ -10,40 +10,50 @@
         "description": "The API client id of your Rupt project.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "new_account_url": {
         "label": "New Account URL",
         "description": "A URL to redirect the user to if they want to stop account sharing and create a new account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "logout_url": {
         "label": "Logout URL",
         "description": "A URL to redirect the user to if they choose to logout or if they are removed by a verified owner.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "success_url": {
         "label": "Success URL",
         "description": "A URL to redirect the user to if they are successfully verified and are within the device limit.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "suspended_url": {
         "label": "Suspended URL",
         "description": "A URL to redirect the user to if they are suspended.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -57,7 +67,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "account": {
           "label": "Account",
@@ -80,7 +90,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -113,7 +125,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "phone": {
           "label": "Phone",
@@ -146,7 +160,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "metadata": {
           "label": "Metadata",
@@ -167,7 +183,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "include_page": {
           "label": "Include Page",
@@ -188,7 +206,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/screeb/metadata.json
+++ b/packages/browser-destinations/destinations/screeb/metadata.json
@@ -1,409 +1,306 @@
 {
+  "slug": "actions-screeb-web",
   "name": "Screeb Web (Actions)",
-  "basicOptions": ["websiteId"],
-  "options": {
-    "websiteId": {
-      "tags": [],
-      "default": "",
-      "description": "Your website ID (given in Screeb app).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Website ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The websiteId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "websiteId": {
+        "label": "Website ID",
+        "description": "Your website ID (given in Screeb app).",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "alias",
-      "name": "Alias",
-      "description": "Update user identity with new user ID.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"alias\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
-          "label": "User ID",
-          "description": "New unique identifier for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "New unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "New anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "New anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "group",
-      "name": "Group",
-      "description": "Set user group and/or attributes.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
-          "label": "Group ID",
-          "description": "The group id",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Group ID",
-                "description": "The group id",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "groupType",
-          "type": "string",
-          "label": "Group type",
-          "description": "The group type",
-          "defaultValue": {
-            "@path": "$.traits.group_type"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupType": {
-                "title": "Group type",
-                "description": "The group type",
-                "type": "string"
-              }
-            },
-            "required": ["groupType"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Traits",
-          "description": "Traits to associate with the group",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Traits",
-                "description": "Traits to associate with the group",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identify",
-      "name": "Identify",
+  "audienceConfig": null,
+  "actions": {
+    "identify": {
+      "title": "Identify",
       "description": "Set user ID and/or attributes.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "Unique identifier for the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
-          "label": "Anonymous ID",
-          "description": "Anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "User Attributes",
-          "description": "The Segment user traits to be forwarded to Screeb and set as attributes",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "User Attributes",
-                "description": "The Segment user traits to be forwarded to Screeb and set as attributes",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "track",
-      "name": "Track",
-      "description": "Track event to potentially filter user studies (microsurveys) later, or trigger a study now.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\" and event != \"Signed Out\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Event name",
-          "description": "The event name that will be shown on Screeb's dashboard",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event name",
-                "description": "The event name that will be shown on Screeb's dashboard",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Event Properties",
-          "description": "Object containing the properties of the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Object containing the properties of the event",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "alias",
-      "name": "Alias",
-      "subscribe": "type = \"alias\"",
-      "mapping": {
-        "userId": {
-          "@path": "$.userId"
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "anonymousId": {
-          "@path": "$.anonymousId"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "group",
-      "name": "Group",
-      "subscribe": "type = \"group\"",
-      "mapping": {
-        "groupId": {
-          "@path": "$.groupId"
-        },
-        "groupType": {
-          "@path": "$.traits.group_type"
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "properties": {
-          "@path": "$.traits"
+          "label": "User Attributes",
+          "description": "The Segment user traits to be forwarded to Screeb and set as attributes",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
+      }
     },
+    "track": {
+      "title": "Track",
+      "description": "Track event to potentially filter user studies (microsurveys) later, or trigger a study now.",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\" and event != \"Signed Out\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Event name",
+          "description": "The event name that will be shown on Screeb's dashboard",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "group": {
+      "title": "Group",
+      "description": "Set user group and/or attributes.",
+      "platform": "web",
+      "defaultSubscription": "type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "groupId": {
+          "label": "Group ID",
+          "description": "The group id",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "groupType": {
+          "label": "Group type",
+          "description": "The group type",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.group_type"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Traits",
+          "description": "Traits to associate with the group",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "alias": {
+      "title": "Alias",
+      "description": "Update user identity with new user ID.",
+      "platform": "web",
+      "defaultSubscription": "type = \"alias\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
+          "label": "User ID",
+          "description": "New unique identifier for the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "New anonymous identifier for the user",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "identify",
       "name": "Identify",
+      "type": "automatic",
+      "partnerAction": "identify",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -416,11 +313,12 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "track",
       "name": "Track",
+      "type": "automatic",
+      "partnerAction": "track",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -430,7 +328,40 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Group",
+      "type": "automatic",
+      "partnerAction": "group",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "groupType": {
+          "@path": "$.traits.group_type"
+        },
+        "properties": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Alias",
+      "type": "automatic",
+      "partnerAction": "alias",
+      "subscribe": "type = \"alias\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/screeb/metadata.json
+++ b/packages/browser-destinations/destinations/screeb/metadata.json
@@ -10,8 +10,10 @@
         "description": "Your website ID (given in Screeb app).",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "User Attributes",
@@ -94,7 +100,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -106,7 +114,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event name",
@@ -129,7 +137,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -152,7 +162,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -164,7 +176,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Group ID",
@@ -187,7 +199,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "groupType": {
           "label": "Group type",
@@ -210,7 +224,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Traits",
@@ -233,7 +249,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -245,7 +263,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -268,7 +286,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -291,7 +311,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/screeb/metadata.json
+++ b/packages/browser-destinations/destinations/screeb/metadata.json
@@ -1,0 +1,436 @@
+{
+  "name": "Screeb Web (Actions)",
+  "basicOptions": ["websiteId"],
+  "options": {
+    "websiteId": {
+      "tags": [],
+      "default": "",
+      "description": "Your website ID (given in Screeb app).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Website ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The websiteId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "alias",
+      "name": "Alias",
+      "description": "Update user identity with new user ID.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"alias\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "New unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "New unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "New anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "New anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "group",
+      "name": "Group",
+      "description": "Set user group and/or attributes.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Group ID",
+          "description": "The group id",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Group ID",
+                "description": "The group id",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "groupType",
+          "type": "string",
+          "label": "Group type",
+          "description": "The group type",
+          "defaultValue": {
+            "@path": "$.traits.group_type"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupType": {
+                "title": "Group type",
+                "description": "The group type",
+                "type": "string"
+              }
+            },
+            "required": ["groupType"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Traits",
+          "description": "Traits to associate with the group",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Traits",
+                "description": "Traits to associate with the group",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Set user ID and/or attributes.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "User Attributes",
+          "description": "The Segment user traits to be forwarded to Screeb and set as attributes",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "User Attributes",
+                "description": "The Segment user traits to be forwarded to Screeb and set as attributes",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "track",
+      "name": "Track",
+      "description": "Track event to potentially filter user studies (microsurveys) later, or trigger a study now.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event != \"Signed Out\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event name",
+          "description": "The event name that will be shown on Screeb's dashboard",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event name",
+                "description": "The event name that will be shown on Screeb's dashboard",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Object containing the properties of the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "alias",
+      "name": "Alias",
+      "subscribe": "type = \"alias\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "group",
+      "name": "Group",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "groupType": {
+          "@path": "$.traits.group_type"
+        },
+        "properties": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identify",
+      "name": "Identify",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "properties": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "track",
+      "name": "Track",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
+++ b/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
@@ -10,16 +10,20 @@
         "description": "The window of time in milliseconds to throttle events.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 3000
+        "default": 3000,
+        "depends_on": null
       },
       "passThroughCount": {
         "label": "Number of events to pass through",
         "description": "Number of events to pass through while waiting for the throttle time to expire.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 1
+        "default": 1,
+        "depends_on": null
       }
     }
   },
@@ -33,7 +37,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "passThroughCount": {
           "label": "Number of events to pass through",
@@ -54,7 +58,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "throttleWindow": {
           "label": "Throttle time",
@@ -75,7 +81,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
+++ b/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
@@ -1,0 +1,112 @@
+{
+  "name": "Segment Utilities Web",
+  "basicOptions": ["throttleWindow", "passThroughCount"],
+  "options": {
+    "throttleWindow": {
+      "tags": [],
+      "default": 3000,
+      "description": "The window of time in milliseconds to throttle events.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Throttle time",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "passThroughCount": {
+      "tags": [],
+      "default": 1,
+      "description": "Number of events to pass through while waiting for the throttle time to expire.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Number of events to pass through",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "throttle",
+      "name": "Throttle by event name",
+      "description": "Throttle events sent to Segment. Throttling is on a per event name basis.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "passThroughCount",
+          "type": "integer",
+          "label": "Number of events to pass through",
+          "description": "Override the global pass through count.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "passThroughCount": {
+                "title": "Number of events to pass through",
+                "description": "Override the global pass through count.",
+                "type": ["integer", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "throttleWindow",
+          "type": "number",
+          "label": "Throttle time",
+          "description": "Override the global throttle time.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": true,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "throttleWindow": {
+                "title": "Throttle time",
+                "description": "Override the global throttle time.",
+                "type": ["number", "null"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": []
+}

--- a/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
+++ b/packages/browser-destinations/destinations/segment-utilities-web/metadata.json
@@ -1,112 +1,84 @@
 {
+  "slug": "actions-segment-utilities-web",
   "name": "Segment Utilities Web",
-  "basicOptions": ["throttleWindow", "passThroughCount"],
-  "options": {
-    "throttleWindow": {
-      "tags": [],
-      "default": 3000,
-      "description": "The window of time in milliseconds to throttle events.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Throttle time",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "passThroughCount": {
-      "tags": [],
-      "default": 1,
-      "description": "Number of events to pass through while waiting for the throttle time to expire.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Number of events to pass through",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "throttleWindow": {
+        "label": "Throttle time",
+        "description": "The window of time in milliseconds to throttle events.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 3000
+      },
+      "passThroughCount": {
+        "label": "Number of events to pass through",
+        "description": "Number of events to pass through while waiting for the throttle time to expire.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 1
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "throttle",
-      "name": "Throttle by event name",
+  "audienceConfig": null,
+  "actions": {
+    "throttle": {
+      "title": "Throttle by event name",
       "description": "Throttle events sent to Segment. Throttling is on a per event name basis.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "passThroughCount",
-          "type": "integer",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "passThroughCount": {
           "label": "Number of events to pass through",
           "description": "Override the global pass through count.",
+          "type": "integer",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "passThroughCount": {
-                "title": "Number of events to pass through",
-                "description": "Override the global pass through count.",
-                "type": ["integer", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "throttleWindow",
-          "type": "number",
+        "throttleWindow": {
           "label": "Throttle time",
           "description": "Override the global throttle time.",
+          "type": "number",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": true,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "throttleWindow": {
-                "title": "Throttle time",
-                "description": "Override the global throttle time.",
-                "type": ["number", "null"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": []
 }

--- a/packages/browser-destinations/destinations/sprig-web/metadata.json
+++ b/packages/browser-destinations/destinations/sprig-web/metadata.json
@@ -10,16 +10,20 @@
         "description": "Your environment ID (production or development).",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "debugMode": {
         "label": "Debug mode",
         "description": "Enable debug mode for testing purposes.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -33,7 +37,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -56,7 +60,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -79,7 +85,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "User Attributes",
@@ -102,7 +110,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -114,7 +124,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {}
     },
     "trackEvent": {
@@ -125,7 +135,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event name",
@@ -148,7 +158,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "userId": {
           "label": "User ID",
@@ -171,7 +183,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -194,7 +208,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -217,7 +233,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -229,7 +247,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -252,7 +270,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "anonymousId": {
           "label": "Anonymous ID",
@@ -275,7 +295,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/sprig-web/metadata.json
+++ b/packages/browser-destinations/destinations/sprig-web/metadata.json
@@ -1,0 +1,416 @@
+{
+  "name": "Sprig (Actions)",
+  "basicOptions": ["envId", "debugMode"],
+  "options": {
+    "envId": {
+      "tags": [],
+      "default": "",
+      "description": "Your environment ID (production or development).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Environment ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The envId property is required."]],
+      "uIMetadata": null
+    },
+    "debugMode": {
+      "tags": [],
+      "default": false,
+      "description": "Enable debug mode for testing purposes.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Debug mode",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Set user ID and/or attributes.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "User Attributes",
+          "description": "The Segment user traits to be forwarded to Sprig and set as attributes",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "User Attributes",
+                "description": "The Segment user traits to be forwarded to Sprig and set as attributes",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "signoutUser",
+      "name": "Sign Out User",
+      "description": "Clear stored user ID so that future events and traits are not associated with this user.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Signed Out\"",
+      "fields": []
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track event to potentially filter user studies (microsurveys) later, or trigger a study now.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event != \"Signed Out\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event name",
+          "description": "The event name that will be shown on Sprig's dashboard",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event name",
+                "description": "The event name that will be shown on Sprig's dashboard",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "Unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "Unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "Anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "Anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Object containing the properties of the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "updateUserId",
+      "name": "Update User ID",
+      "description": "Set updated user ID.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"alias\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "New unique identifier for the user",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "New unique identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "anonymousId",
+          "type": "string",
+          "label": "Anonymous ID",
+          "description": "New anonymous identifier for the user",
+          "defaultValue": {
+            "@path": "$.anonymousId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "anonymousId": {
+                "title": "Anonymous ID",
+                "description": "New anonymous identifier for the user",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "signoutUser",
+      "name": "Sign Out User",
+      "subscribe": "type = \"track\" and event = \"Signed Out\"",
+      "mapping": {},
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\" and event != \"Signed Out\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "updateUserId",
+      "name": "Update User ID",
+      "subscribe": "type = \"alias\"",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/sprig-web/metadata.json
+++ b/packages/browser-destinations/destinations/sprig-web/metadata.json
@@ -1,362 +1,290 @@
 {
+  "slug": "sprig-web",
   "name": "Sprig (Actions)",
-  "basicOptions": ["envId", "debugMode"],
-  "options": {
-    "envId": {
-      "tags": [],
-      "default": "",
-      "description": "Your environment ID (production or development).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Environment ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The envId property is required."]],
-      "uIMetadata": null
-    },
-    "debugMode": {
-      "tags": [],
-      "default": false,
-      "description": "Enable debug mode for testing purposes.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Debug mode",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "envId": {
+        "label": "Environment ID",
+        "description": "Your environment ID (production or development).",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "debugMode": {
+        "label": "Debug mode",
+        "description": "Enable debug mode for testing purposes.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Set user ID and/or attributes.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "Unique identifier for the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "Anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "traits",
-          "type": "object",
+        "traits": {
           "label": "User Attributes",
           "description": "The Segment user traits to be forwarded to Sprig and set as attributes",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "User Attributes",
-                "description": "The Segment user traits to be forwarded to Sprig and set as attributes",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "signoutUser",
-      "name": "Sign Out User",
+    "signoutUser": {
+      "title": "Sign Out User",
       "description": "Clear stored user ID so that future events and traits are not associated with this user.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Signed Out\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Signed Out\"",
-      "fields": []
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {}
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Track event to potentially filter user studies (microsurveys) later, or trigger a study now.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event != \"Signed Out\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event != \"Signed Out\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event name",
           "description": "The event name that will be shown on Sprig's dashboard",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event name",
-                "description": "The event name that will be shown on Sprig's dashboard",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "userId",
-          "type": "string",
+        "userId": {
           "label": "User ID",
           "description": "Unique identifier for the user",
-          "defaultValue": {
-            "@path": "$.userId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "Unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "Anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "Anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Object containing the properties of the event",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Object containing the properties of the event",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "updateUserId",
-      "name": "Update User ID",
+    "updateUserId": {
+      "title": "Update User ID",
       "description": "Set updated user ID.",
       "platform": "web",
+      "defaultSubscription": "type = \"alias\"",
       "hidden": false,
-      "defaultTrigger": "type = \"alias\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "New unique identifier for the user",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "New unique identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "anonymousId",
-          "type": "string",
+        "anonymousId": {
           "label": "Anonymous ID",
           "description": "New anonymous identifier for the user",
-          "defaultValue": {
-            "@path": "$.anonymousId"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "anonymousId": {
-                "title": "Anonymous ID",
-                "description": "New anonymous identifier for the user",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -369,18 +297,20 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "signoutUser",
       "name": "Sign Out User",
+      "type": "automatic",
+      "partnerAction": "signoutUser",
       "subscribe": "type = \"track\" and event = \"Signed Out\"",
       "mapping": {},
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\" and event != \"Signed Out\"",
       "mapping": {
         "name": {
@@ -396,11 +326,12 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "updateUserId",
       "name": "Update User ID",
+      "type": "automatic",
+      "partnerAction": "updateUserId",
       "subscribe": "type = \"alias\"",
       "mapping": {
         "userId": {
@@ -410,7 +341,7 @@
           "@path": "$.anonymousId"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/stackadapt/metadata.json
+++ b/packages/browser-destinations/destinations/stackadapt/metadata.json
@@ -1,0 +1,169 @@
+{
+  "name": "StackAdapt Pixel",
+  "basicOptions": ["universalPixelId"],
+  "options": {
+    "universalPixelId": {
+      "tags": [],
+      "default": "",
+      "description": "The universal pixel id for StackAdapt.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Universal Pixel Id",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The universalPixelId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Track events",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Name",
+          "description": "The name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Name",
+                "description": "The name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["eventName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "eventProperties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Hash of properties for this event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventProperties": {
+                "title": "Event Properties",
+                "description": "Hash of properties for this event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPage",
+      "name": "Track Page",
+      "description": "Record when a user visits a page.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Page Properties",
+          "description": "Hash of properties for this page view.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Page Properties",
+                "description": "Hash of properties for this page view.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        },
+        "eventProperties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPage",
+      "name": "Track Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/stackadapt/metadata.json
+++ b/packages/browser-destinations/destinations/stackadapt/metadata.json
@@ -10,8 +10,10 @@
         "description": "The universal pixel id for StackAdapt.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventName": {
           "label": "Name",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "eventProperties": {
           "label": "Event Properties",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -83,7 +89,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "properties": {
           "label": "Page Properties",
@@ -106,7 +112,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/stackadapt/metadata.json
+++ b/packages/browser-destinations/destinations/stackadapt/metadata.json
@@ -1,148 +1,121 @@
 {
+  "slug": "actions-stackadapt",
   "name": "StackAdapt Pixel",
-  "basicOptions": ["universalPixelId"],
-  "options": {
-    "universalPixelId": {
-      "tags": [],
-      "default": "",
-      "description": "The universal pixel id for StackAdapt.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Universal Pixel Id",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The universalPixelId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "universalPixelId": {
+        "label": "Universal Pixel Id",
+        "description": "The universal pixel id for StackAdapt.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Track events",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "eventName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventName": {
           "label": "Name",
           "description": "The name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Name",
-                "description": "The name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["eventName"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "eventProperties",
-          "type": "object",
+        "eventProperties": {
           "label": "Event Properties",
           "description": "Hash of properties for this event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventProperties": {
-                "title": "Event Properties",
-                "description": "Hash of properties for this event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackPage",
-      "name": "Track Page",
+    "trackPage": {
+      "title": "Track Page",
       "description": "Record when a user visits a page.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "properties",
-          "type": "object",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "properties": {
           "label": "Page Properties",
           "description": "Hash of properties for this page view.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Page Properties",
-                "description": "Hash of properties for this page view.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "eventName": {
@@ -152,18 +125,19 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackPage",
       "name": "Track Page",
+      "type": "automatic",
+      "partnerAction": "trackPage",
       "subscribe": "type = \"page\"",
       "mapping": {
         "properties": {
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/survicate/metadata.json
+++ b/packages/browser-destinations/destinations/survicate/metadata.json
@@ -1,0 +1,254 @@
+{
+  "name": "Survicate (Actions)",
+  "description": "Send user traits to Survicate and trigger surveys with Segment events",
+  "basicOptions": ["workspaceKey"],
+  "options": {
+    "workspaceKey": {
+      "tags": [],
+      "default": "",
+      "description": "The workspace key for your Survicate account.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Workspace Key",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The workspaceKey property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyGroup",
+      "name": "Identify Group",
+      "description": "Send group traits to Survicate",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Group ID",
+          "description": "The Segment groupId to be forwarded to Survicate",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Group ID",
+                "description": "The Segment groupId to be forwarded to Survicate",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Survicate",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to Survicate",
+                "type": "object"
+              }
+            },
+            "required": ["traits"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Set visitor traits with Segment Identify event",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Survicate",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "The Segment traits to be forwarded to Survicate",
+                "type": "object"
+              }
+            },
+            "required": ["traits"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Invoke survey with Segment Track event",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Event name",
+          "description": "The event name",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Event name",
+                "description": "The event name",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Event Properties",
+          "description": "Object containing the properties of the event",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Event Properties",
+                "description": "Object containing the properties of the event",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyGroup",
+      "name": "Identify Group",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/survicate/metadata.json
+++ b/packages/browser-destinations/destinations/survicate/metadata.json
@@ -1,244 +1,180 @@
 {
+  "slug": "actions-survicate",
   "name": "Survicate (Actions)",
+  "mode": "device",
   "description": "Send user traits to Survicate and trigger surveys with Segment events",
-  "basicOptions": ["workspaceKey"],
-  "options": {
-    "workspaceKey": {
-      "tags": [],
-      "default": "",
-      "description": "The workspace key for your Survicate account.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Workspace Key",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The workspaceKey property is required."]],
-      "uIMetadata": null
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "workspaceKey": {
+        "label": "Workspace Key",
+        "description": "The workspace key for your Survicate account.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyGroup",
-      "name": "Identify Group",
-      "description": "Send group traits to Survicate",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
-          "label": "Group ID",
-          "description": "The Segment groupId to be forwarded to Survicate",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Group ID",
-                "description": "The Segment groupId to be forwarded to Survicate",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "The Segment traits to be forwarded to Survicate",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to Survicate",
-                "type": "object"
-              }
-            },
-            "required": ["traits"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Set visitor traits with Segment Identify event",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "The Segment traits to be forwarded to Survicate",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "The Segment traits to be forwarded to Survicate",
-                "type": "object"
-              }
-            },
-            "required": ["traits"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Invoke survey with Segment Track event",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
           "label": "Event name",
           "description": "The event name",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Event name",
-                "description": "The event name",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Event Properties",
           "description": "Object containing the properties of the event",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Event Properties",
-                "description": "Object containing the properties of the event",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyGroup",
-      "name": "Identify Group",
-      "subscribe": "type = \"group\"",
-      "mapping": {
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Set visitor traits with Segment Identify event",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "traits": {
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Survicate",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "identifyGroup": {
+      "title": "Identify Group",
+      "description": "Send group traits to Survicate",
+      "platform": "web",
+      "defaultSubscription": "type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
         "groupId": {
-          "@path": "$.groupId"
+          "label": "Group ID",
+          "description": "The Segment groupId to be forwarded to Survicate",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "Traits",
+          "description": "The Segment traits to be forwarded to Survicate",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
-    },
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "traits": {
-          "@path": "$.traits"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -248,7 +184,34 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Identify Group",
+      "type": "automatic",
+      "partnerAction": "identifyGroup",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/survicate/metadata.json
+++ b/packages/browser-destinations/destinations/survicate/metadata.json
@@ -11,8 +11,10 @@
         "description": "The workspace key for your Survicate account.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -26,7 +28,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Event name",
@@ -49,7 +51,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Event Properties",
@@ -72,7 +76,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -84,7 +90,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "traits": {
           "label": "Traits",
@@ -107,7 +113,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -119,7 +127,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Group ID",
@@ -142,7 +150,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -165,7 +175,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
@@ -1,0 +1,6013 @@
+{
+  "name": "TikTok Pixel",
+  "basicOptions": ["pixelCode", "ldu", "autoPageView", "useExistingPixel"],
+  "options": {
+    "pixelCode": {
+      "tags": [],
+      "default": "",
+      "description": "Your TikTok Pixel ID. Please see TikTok's [Pixel documentation](https://ads.tiktok.com/marketing_api/docs?id=1739583652957185) for information on how to find this value.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Pixel Code",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The pixelCode property is required."]],
+      "uIMetadata": null
+    },
+    "ldu": {
+      "tags": [],
+      "default": false,
+      "description": "In order to help facilitate advertiser's compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use (\"LDU\") feature. For more information, please refer to TikTok's [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Limited Data Use",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "autoPageView": {
+      "tags": [],
+      "default": true,
+      "description": "If true, TikTok Pixel will fire a \"Pageview\" event whenevent the pixel is loaded on the page.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Fire TikTok Pixel Pageview event on page load.",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "useExistingPixel": {
+      "tags": [],
+      "default": false,
+      "description": "Deprecated. Please do not provide any value.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "[Deprecated] Use Existing Pixel",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identify",
+      "name": "Identify",
+      "description": "Use a Segment identify() call to sent PII data to TikTok Pixel. Note that the PII information will be sent with the next track() call.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "phone_number",
+          "type": "string",
+          "label": "Phone Number",
+          "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@path": "$.traits.phone"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "phone_number": {
+                "title": "Phone Number",
+                "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@path": "$.traits.email"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "first_name",
+          "type": "string",
+          "label": "First Name",
+          "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "defaultValue": {
+            "@path": "$.traits.first_name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "first_name": {
+                "title": "First Name",
+                "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "last_name",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "defaultValue": {
+            "@path": "$.traits.last_name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "last_name": {
+                "title": "Last Name",
+                "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "address",
+          "type": "object",
+          "label": "Address",
+          "description": "The address of the customer.",
+          "defaultValue": {
+            "city": {
+              "@path": "$.traits.address.city"
+            },
+            "country": {
+              "@path": "$.traits.address.country"
+            },
+            "zip_code": {
+              "@path": "$.traits.address.postal_code"
+            },
+            "state": {
+              "@path": "$.traits.address.state"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "title": "Address",
+                "description": "The address of the customer.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "city": {
+                    "title": "City",
+                    "description": "The customer's city.",
+                    "type": "string"
+                  },
+                  "country": {
+                    "title": "Country",
+                    "description": "The customer's country.",
+                    "type": "string"
+                  },
+                  "zip_code": {
+                    "title": "Zip Code",
+                    "description": "The customer's Zip Code.",
+                    "type": "string"
+                  },
+                  "state": {
+                    "title": "State",
+                    "description": "The customer's State.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "external_id",
+          "type": "string",
+          "label": "External ID",
+          "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "external_id": {
+                "title": "External ID",
+                "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "reportWebEvent",
+      "name": "Report Web Event",
+      "description": "Report events directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "event_spec_type",
+          "type": "string",
+          "label": "Additional Fields",
+          "description": "Include fields for travel or vehicle events.",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "value": "travel_fields",
+              "label": "Travel Fields"
+            },
+            {
+              "value": "vehicle_fields",
+              "label": "Vehicle Fields"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_spec_type": {
+                "title": "Additional Fields",
+                "description": "Include fields for travel or vehicle events.",
+                "type": "string",
+                "enum": ["travel_fields", "vehicle_fields"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event",
+          "type": "string",
+          "label": "Event Name",
+          "description": "Conversion event name. Please refer to the \"Supported Web Events\" section on in TikTok’s [Pixel SDK documentation](https://business-api.tiktok.com/portal/docs?id=1739585696931842) for accepted event names.",
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event": {
+                "title": "Event Name",
+                "description": "Conversion event name. Please refer to the \"Supported Web Events\" section on in TikTok’s [Pixel SDK documentation](https://business-api.tiktok.com/portal/docs?id=1739585696931842) for accepted event names.",
+                "type": "string"
+              }
+            },
+            "required": ["event"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "event_id",
+          "type": "string",
+          "label": "Event ID",
+          "description": "Any hashed ID that can identify a unique user/session.",
+          "defaultValue": {
+            "@path": "$.messageId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "event_id": {
+                "title": "Event ID",
+                "description": "Any hashed ID that can identify a unique user/session.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "order_id",
+          "type": "string",
+          "label": "Order ID",
+          "description": "Order ID of the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.order_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "order_id": {
+                "title": "Order ID",
+                "description": "Order ID of the transaction.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "shop_id",
+          "type": "string",
+          "label": "Shop ID",
+          "description": "Shop ID of the transaction.",
+          "defaultValue": {
+            "@path": "$.properties.shop_id"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "shop_id": {
+                "title": "Shop ID",
+                "description": "Shop ID of the transaction.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "contents",
+          "type": "object",
+          "label": "Contents",
+          "description": "Related item details for the event.",
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "contents": {
+                "title": "Contents",
+                "description": "Related item details for the event.",
+                "type": "array",
+                "items": {
+                  "$schema": "http://json-schema.org/schema#",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "price": {
+                      "title": "Price",
+                      "description": "Price of the item.",
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "title": "Quantity",
+                      "description": "Number of items.",
+                      "type": "number"
+                    },
+                    "content_category": {
+                      "title": "Content Category",
+                      "description": "Category of the product item.",
+                      "type": "string"
+                    },
+                    "content_id": {
+                      "title": "Content ID",
+                      "description": "ID of the product item.",
+                      "type": "string"
+                    },
+                    "content_name": {
+                      "title": "Content Name",
+                      "description": "Name of the product item.",
+                      "type": "string"
+                    },
+                    "brand": {
+                      "title": "Brand",
+                      "description": "Brand name of the product item.",
+                      "type": "string"
+                    }
+                  },
+                  "required": []
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_ids",
+          "type": "string",
+          "label": "Content IDs",
+          "description": "Product IDs associated with the event, such as SKUs. Do not populate this field if the 'Contents' field is populated. This field accepts a single string value or an array of string values.",
+          "defaultValue": {
+            "@path": "$.properties.content_ids"
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_ids": {
+                "title": "Content IDs",
+                "description": "Product IDs associated with the event, such as SKUs. Do not populate this field if the 'Contents' field is populated. This field accepts a single string value or an array of string values.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "num_items",
+          "type": "number",
+          "label": "Number of Items",
+          "description": "Number of items when checkout was initiated. Used with the InitiateCheckout event.",
+          "defaultValue": {
+            "@path": "$.properties.num_items"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "num_items": {
+                "title": "Number of Items",
+                "description": "Number of items when checkout was initiated. Used with the InitiateCheckout event.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "content_type",
+          "type": "string",
+          "label": "Content Type",
+          "description": "Type of the product item. When the `content_id` in the `Contents` field is specified as a `sku_id`, set this field to `product`. When the `content_id` in the `Contents` field is specified as an `item_group_id`, set this field to `product_group`.",
+          "defaultValue": "product",
+          "required": false,
+          "multiple": false,
+          "choices": [
+            {
+              "label": "product",
+              "value": "product"
+            },
+            {
+              "label": "product_group",
+              "value": "product_group"
+            }
+          ],
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "content_type": {
+                "title": "Content Type",
+                "description": "Type of the product item. When the `content_id` in the `Contents` field is specified as a `sku_id`, set this field to `product`. When the `content_id` in the `Contents` field is specified as an `item_group_id`, set this field to `product_group`.",
+                "type": "string",
+                "enum": ["product", "product_group"]
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "currency",
+          "type": "string",
+          "label": "Currency",
+          "description": "Currency for the value specified as ISO 4217 code.",
+          "defaultValue": {
+            "@path": "$.properties.currency"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "currency": {
+                "title": "Currency",
+                "description": "Currency for the value specified as ISO 4217 code.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "value",
+          "type": "number",
+          "label": "Value",
+          "description": "Value of the order or items sold.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.value"
+              },
+              "then": {
+                "@path": "$.properties.value"
+              },
+              "else": {
+                "@path": "$.properties.revenue"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "description": "Value of the order or items sold.",
+                "type": "number"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "description",
+          "type": "string",
+          "label": "Description",
+          "description": "A string description of the web event.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "title": "Description",
+                "description": "A string description of the web event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "query",
+          "type": "string",
+          "label": "Query",
+          "description": "The text string that was searched for.",
+          "defaultValue": {
+            "@path": "$.properties.query"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "query": {
+                "title": "Query",
+                "description": "The text string that was searched for.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "search_string",
+          "type": "string",
+          "label": "Search String",
+          "description": "The text string entered by the user for the search. Optionally used with the Search event.",
+          "defaultValue": {
+            "@path": "$.properties.search_string"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "search_string": {
+                "title": "Search String",
+                "description": "The text string entered by the user for the search. Optionally used with the Search event.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "conditions": [
+              {
+                "fieldKey": "event",
+                "operator": "is",
+                "value": "Search"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "phone_number",
+          "type": "string",
+          "label": "Phone Number",
+          "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.phone"
+              },
+              "then": {
+                "@path": "$.properties.phone"
+              },
+              "else": {
+                "@path": "$.context.traits.phone"
+              }
+            }
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "phone_number": {
+                "title": "Phone Number",
+                "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "email",
+          "type": "string",
+          "label": "Email",
+          "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.email"
+              },
+              "then": {
+                "@path": "$.properties.email"
+              },
+              "else": {
+                "@path": "$.context.traits.email"
+              }
+            }
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "title": "Email",
+                "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "first_name",
+          "type": "string",
+          "label": "First Name",
+          "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.first_name"
+              },
+              "then": {
+                "@path": "$.properties.first_name"
+              },
+              "else": {
+                "@path": "$.context.traits.first_name"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "first_name": {
+                "title": "First Name",
+                "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "last_name",
+          "type": "string",
+          "label": "Last Name",
+          "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.last_name"
+              },
+              "then": {
+                "@path": "$.properties.last_name"
+              },
+              "else": {
+                "@path": "$.context.traits.last_name"
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "last_name": {
+                "title": "Last Name",
+                "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "address",
+          "type": "object",
+          "label": "Address",
+          "description": "The address of the customer.",
+          "defaultValue": {
+            "city": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.address.city"
+                },
+                "then": {
+                  "@path": "$.properties.address.city"
+                },
+                "else": {
+                  "@path": "$.context.traits.address.city"
+                }
+              }
+            },
+            "country": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.address.country"
+                },
+                "then": {
+                  "@path": "$.properties.address.country"
+                },
+                "else": {
+                  "@path": "$.context.traits.address.country"
+                }
+              }
+            },
+            "zip_code": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.address.postal_code"
+                },
+                "then": {
+                  "@path": "$.properties.address.postal_code"
+                },
+                "else": {
+                  "@path": "$.context.traits.address.postal_code"
+                }
+              }
+            },
+            "state": {
+              "@if": {
+                "exists": {
+                  "@path": "$.properties.address.state"
+                },
+                "then": {
+                  "@path": "$.properties.address.state"
+                },
+                "else": {
+                  "@path": "$.context.traits.address.state"
+                }
+              }
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "title": "Address",
+                "description": "The address of the customer.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "city": {
+                    "title": "City",
+                    "description": "The customer's city.",
+                    "type": "string"
+                  },
+                  "country": {
+                    "title": "Country",
+                    "description": "The customer's country.",
+                    "type": "string"
+                  },
+                  "zip_code": {
+                    "title": "Zip Code",
+                    "description": "The customer's Zip Code.",
+                    "type": "string"
+                  },
+                  "state": {
+                    "title": "State",
+                    "description": "The customer's State.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "external_id",
+          "type": "string",
+          "label": "External ID",
+          "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": false,
+          "multiple": true,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "external_id": {
+                "title": "External ID",
+                "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "vehicle_fields",
+          "type": "object",
+          "label": "Vehicle Fields",
+          "description": "Fields related to vehicle events.",
+          "defaultValue": {
+            "postal_code": {
+              "@path": "$.properties.postal_code"
+            },
+            "make": {
+              "@path": "$.properties.make"
+            },
+            "model": {
+              "@path": "$.properties.model"
+            },
+            "year": {
+              "@path": "$.properties.year"
+            },
+            "state_of_vehicle": {
+              "@path": "$.properties.state_of_vehicle"
+            },
+            "mileage_value": {
+              "@path": "$.properties.mileage_value"
+            },
+            "mileage_unit": {
+              "@path": "$.properties.mileage_unit"
+            },
+            "exterior_color": {
+              "@path": "$.properties.exterior_color"
+            },
+            "transmission": {
+              "@path": "$.properties.transmission"
+            },
+            "body_style": {
+              "@path": "$.properties.body_style"
+            },
+            "fuel_type": {
+              "@path": "$.properties.fuel_type"
+            },
+            "drivetrain": {
+              "@path": "$.properties.drive_train"
+            },
+            "preferred_price_range_min": {
+              "@path": "$.properties.preferred_price_range_min"
+            },
+            "preferred_price_range_max": {
+              "@path": "$.properties.preferred_price_range_max"
+            },
+            "trim": {
+              "@path": "$.properties.trim"
+            },
+            "vin": {
+              "@path": "$.properties.vin"
+            },
+            "interior_color": {
+              "@path": "$.properties.interior_color"
+            },
+            "condition_of_vehicle": {
+              "@path": "$.properties.condition_of_vehicle"
+            },
+            "viewcontent_type": {
+              "@path": "$.properties.viewcontent_type"
+            },
+            "search_type": {
+              "@path": "$.properties.search_type"
+            },
+            "registration_type": {
+              "@path": "$.properties.registration_type"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "vehicle_fields": {
+                "title": "Vehicle Fields",
+                "description": "Fields related to vehicle events.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "postal_code": {
+                    "title": "Postal Code",
+                    "description": "Postal code for the vehicle location.",
+                    "type": "string"
+                  },
+                  "make": {
+                    "title": "Make of the Vehicle",
+                    "description": "Vehicle make/brand/manufacturer.",
+                    "type": "string"
+                  },
+                  "model": {
+                    "title": "Model of the Vehicle",
+                    "description": "Vehicle model.",
+                    "type": "string"
+                  },
+                  "year": {
+                    "title": "Year of the Vehicle",
+                    "description": "Year the vehicle was laucned in yyyy format.",
+                    "type": "number"
+                  },
+                  "state_of_vehicle": {
+                    "title": "State of the Vehicle",
+                    "description": "Vehicle status.",
+                    "type": "string",
+                    "enum": ["New", "Used", "CPO"]
+                  },
+                  "mileage_value": {
+                    "title": "Mileage Value",
+                    "description": "Vehicle mileage (in km or miles). Zero (0) for new vehicle.",
+                    "type": "number"
+                  },
+                  "mileage_unit": {
+                    "title": "Mileage Unit",
+                    "description": "Mileage unites in miles (MI) or kilometers (KM).",
+                    "type": "string",
+                    "enum": ["MI", "KM"]
+                  },
+                  "exterior_color": {
+                    "title": "Exterior Color of the Vehicle",
+                    "description": "Vehicle exterior color.",
+                    "type": "string"
+                  },
+                  "transmission": {
+                    "title": "Transmission Type of the Vehicle",
+                    "description": "Vehicle transmission type.",
+                    "type": "string",
+                    "enum": ["Automatic", "Manual", "Other"]
+                  },
+                  "body_style": {
+                    "title": "Body Type of the Vehicle",
+                    "description": "Vehicle body type.",
+                    "type": "string",
+                    "enum": [
+                      "Convertible",
+                      "Coupe",
+                      "Hatchback",
+                      "Minivan",
+                      "Truck",
+                      "SUV",
+                      "Sedan",
+                      "Van",
+                      "Wagon",
+                      "Crossover",
+                      "Other"
+                    ]
+                  },
+                  "fuel_type": {
+                    "title": "Fuel Type of the Vehicle",
+                    "description": "Vehicle fuel type.",
+                    "type": "string",
+                    "enum": ["Diesel", "Electric", "Flex", "Gasoline", "Hybrid", "Other"]
+                  },
+                  "drivetrain": {
+                    "title": "Drivetrain of the Vehicle",
+                    "description": "Vehicle drivetrain.",
+                    "type": "string",
+                    "enum": ["AWD", "FOUR_WD", "FWD", "RWD", "TWO_WD", "Other"]
+                  },
+                  "preferred_price_range_min": {
+                    "title": "Minimum Preferred Price",
+                    "description": "Minimum preferred price of the vehicle.",
+                    "type": "number"
+                  },
+                  "preferred_price_range_max": {
+                    "title": "Maximum Preferred Price",
+                    "description": "Maximum preferred price of the vehicle.",
+                    "type": "number"
+                  },
+                  "trim": {
+                    "title": "Trim of the Vehicle",
+                    "description": "Vehicle trim.",
+                    "type": "string"
+                  },
+                  "vin": {
+                    "title": "VIN of the Vehicle",
+                    "description": "Vehicle identification number. Maximum characters: 17.",
+                    "type": "string"
+                  },
+                  "interior_color": {
+                    "title": "Interior Color of the Vehicle",
+                    "description": "Vehicle interior color.",
+                    "type": "string"
+                  },
+                  "condition_of_vehicle": {
+                    "title": "Condition of the Vehicle",
+                    "description": "Vehicle drivetrain.",
+                    "type": "string",
+                    "enum": ["Excellent", "Good", "Fair", "Poor", "Other"]
+                  },
+                  "viewcontent_type": {
+                    "title": "Soft Lead Landing Page",
+                    "description": "Optional for ViewContent. Use viewcontent_type to differentiate between soft lead landing pages.",
+                    "type": "string"
+                  },
+                  "search_type": {
+                    "title": "Other Search Page",
+                    "description": "Optional for Search. Use search_type to differentiate other user searches (such as dealer lookup) from inventory search.",
+                    "type": "string"
+                  },
+                  "registration_type": {
+                    "title": "Other Registration Page",
+                    "description": "Optional for CompleteRegistration. Use registration_type to differentiate between different types of customer registration on websites.",
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "conditions": [
+              {
+                "fieldKey": "event_spec_type",
+                "operator": "is",
+                "value": "vehicle_fields"
+              }
+            ]
+          },
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "travel_fields",
+          "type": "object",
+          "label": "Travel Fields",
+          "description": "Fields related to travel events.",
+          "defaultValue": {
+            "city": {
+              "@path": "$.properties.city"
+            },
+            "region": {
+              "@path": "$.properties.region"
+            },
+            "country": {
+              "@path": "$.properties.country"
+            },
+            "checkin_date": {
+              "@path": "$.properties.checkin_date"
+            },
+            "checkout_date": {
+              "@path": "$.properties.checkout_date"
+            },
+            "num_adults": {
+              "@path": "$.properties.num_adults"
+            },
+            "num_children": {
+              "@path": "$.properties.num_children"
+            },
+            "num_infants": {
+              "@path": "$.properties.num_infants"
+            },
+            "suggested_hotels": {
+              "@path": "$.properties.suggested_hotels"
+            },
+            "departing_departure_date": {
+              "@path": "$.properties.departing_departure_date"
+            },
+            "returning_departure_date": {
+              "@path": "$.properties.returning_departure_date"
+            },
+            "origin_airport": {
+              "@path": "$.properties.origin_airport"
+            },
+            "destination_airport": {
+              "@path": "$.properties.destination_airport"
+            },
+            "destination_ids": {
+              "@path": "$.properties.destination_ids"
+            },
+            "departing_arrival_date": {
+              "@path": "$.properties.departing_arrival_date"
+            },
+            "returning_arrival_date": {
+              "@path": "$.properties.returning_arrival_date"
+            },
+            "travel_class": {
+              "@path": "$.properties.travel_class"
+            },
+            "user_score": {
+              "@path": "$.properties.user_score"
+            },
+            "preferred_num_stops": {
+              "@path": "$.properties.preferred_num_stops"
+            },
+            "travel_start": {
+              "@path": "$.properties.travel_start"
+            },
+            "travel_end": {
+              "@path": "$.properties.travel_end"
+            },
+            "suggested_destinations": {
+              "@path": "$.properties.suggested_destinations"
+            }
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "defaultObjectUI": "keyvalue",
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "travel_fields": {
+                "title": "Travel Fields",
+                "description": "Fields related to travel events.",
+                "type": "object",
+                "$schema": "http://json-schema.org/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "city": {
+                    "title": "Hotel City Location",
+                    "description": "Hotel city location.",
+                    "type": "string"
+                  },
+                  "region": {
+                    "title": "Hotel Region",
+                    "description": "Hotel region location.",
+                    "type": "string"
+                  },
+                  "country": {
+                    "title": "Hotel Country",
+                    "description": "Hotel country location.",
+                    "type": "string"
+                  },
+                  "checkin_date": {
+                    "title": "Hotel Check-in Date",
+                    "description": "Hotel check-in date.",
+                    "type": "string"
+                  },
+                  "checkout_date": {
+                    "title": "Hotel Check-out Date",
+                    "description": "Hotel check-out date.",
+                    "type": "string"
+                  },
+                  "num_adults": {
+                    "title": "Number of Adults",
+                    "description": "Number of adults.",
+                    "type": "number"
+                  },
+                  "num_children": {
+                    "title": "Number of Children",
+                    "description": "Number of children.",
+                    "type": "number"
+                  },
+                  "num_infants": {
+                    "title": "Number of Infants",
+                    "description": "Number of infants flying.",
+                    "type": "number"
+                  },
+                  "suggested_hotels": {
+                    "title": "Suggested Hotels",
+                    "description": "Suggested hotels. This can be a single string value or an array of string values.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "departing_departure_date": {
+                    "title": "Departure Date",
+                    "description": "Date of flight departure. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+                    "type": "string"
+                  },
+                  "returning_departure_date": {
+                    "title": "Arrival Date",
+                    "description": "Date of return flight. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+                    "type": "string"
+                  },
+                  "origin_airport": {
+                    "title": "Origin Airport",
+                    "description": "Origin airport.",
+                    "type": "string"
+                  },
+                  "destination_airport": {
+                    "title": "Destination Airport",
+                    "description": "Destination airport.",
+                    "type": "string"
+                  },
+                  "destination_ids": {
+                    "title": "Destination IDs",
+                    "description": "If a client has a destination catalog, the client can associate one or more destinations in the catalog with a specific flight event. For instance, link a particular route to a nearby museum and a nearby beach, both of which are destinations in the catalog. This field accepts a single string value or an array of string values.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "departing_arrival_date": {
+                    "title": "Departing Arrival Date",
+                    "description": "The date and time for arrival at the destination of the outbound journey. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+                    "type": "string"
+                  },
+                  "returning_arrival_date": {
+                    "title": "Returning Arrival Date",
+                    "description": "The date and time when the return journey is completed. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+                    "type": "string"
+                  },
+                  "travel_class": {
+                    "title": "Flight Ticket Class",
+                    "description": "Class of the flight ticket, must be: \"eco\", \"prem\", \"bus\", \"first\".",
+                    "type": "string",
+                    "enum": ["eco", "prem", "bus", "first"]
+                  },
+                  "user_score": {
+                    "title": "User Score",
+                    "description": "Represents the relative value of this potential customer to advertiser.",
+                    "type": "number"
+                  },
+                  "preferred_num_stops": {
+                    "title": "Preferred Number of Stops",
+                    "description": "The preferred number of stops the user is looking for. 0 for direct flight.",
+                    "type": "integer"
+                  },
+                  "travel_start": {
+                    "title": "Start Date of the Trip",
+                    "description": "The start date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
+                    "type": "string"
+                  },
+                  "travel_end": {
+                    "title": "End Date of the Trip",
+                    "description": "The end date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
+                    "type": "string"
+                  },
+                  "suggested_destinations": {
+                    "title": "Suggested Destination IDs",
+                    "description": "A list of IDs representing destination suggestions for this user. This parameter is not applicable for the Search event. This field accepts a single string value or an array of string values.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": []
+              }
+            },
+            "required": []
+          },
+          "dependsOn": {
+            "conditions": [
+              {
+                "fieldKey": "event_spec_type",
+                "operator": "is",
+                "value": "travel_fields"
+              }
+            ]
+          },
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Add Payment Info",
+      "subscribe": "event = \"Payment Info Entered\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddPaymentInfo"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Add to Cart",
+      "subscribe": "event = \"Product Added\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddToCart"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Add to Wishlist",
+      "subscribe": "event = \"Product Added to Wishlist\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddToWishlist"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Click Button",
+      "subscribe": "event = \"Product Clicked\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "ClickButton"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Complete Payment",
+      "subscribe": "event = \"Order Completed\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "CompletePayment"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Complete Registration",
+      "subscribe": "event = \"Signed Up\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "CompleteRegistration"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Contact",
+      "subscribe": "event = \"Callback Started\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "Contact"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Download",
+      "subscribe": "event = \"Download Link Clicked\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "Download"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Initiate Checkout",
+      "subscribe": "event = \"Checkout Started\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "InitiateCheckout"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Page View",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "event": "Pageview"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Place an Order",
+      "subscribe": "event = \"Order Placed\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "PlaceAnOrder"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Search",
+      "subscribe": "event = \"Products Searched\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "Search"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Submit Form",
+      "subscribe": "event = \"Form Submitted\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "SubmitForm"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "Subscribe",
+      "subscribe": "event = \"Subscription Created\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "Subscribe"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "reportWebEvent",
+      "name": "View Content",
+      "subscribe": "event = \"Product Viewed\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "ViewContent"
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
@@ -10,32 +10,40 @@
         "description": "Your TikTok Pixel ID. Please see TikTok's [Pixel documentation](https://ads.tiktok.com/marketing_api/docs?id=1739583652957185) for information on how to find this value.",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "ldu": {
         "label": "Limited Data Use",
         "description": "In order to help facilitate advertiser's compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use (\"LDU\") feature. For more information, please refer to TikTok's [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "autoPageView": {
         "label": "Fire TikTok Pixel Pageview event on page load.",
         "description": "If true, TikTok Pixel will fire a \"Pageview\" event whenevent the pixel is loaded on the page.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       },
       "useExistingPixel": {
         "label": "[Deprecated] Use Existing Pixel",
         "description": "Deprecated. Please do not provide any value.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       }
     }
   },
@@ -49,7 +57,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "event_spec_type": {
           "label": "Additional Fields",
@@ -79,7 +87,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event": {
           "label": "Event Name",
@@ -100,7 +110,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "event_id": {
           "label": "Event ID",
@@ -123,7 +135,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "order_id": {
           "label": "Order ID",
@@ -146,7 +160,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "shop_id": {
           "label": "Shop ID",
@@ -169,7 +185,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "contents": {
           "label": "Contents",
@@ -202,7 +220,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "quantity": {
               "label": "Quantity",
@@ -223,7 +243,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "content_category": {
               "label": "Content Category",
@@ -244,7 +266,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "content_id": {
               "label": "Content ID",
@@ -265,7 +289,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "content_name": {
               "label": "Content Name",
@@ -286,7 +312,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "brand": {
               "label": "Brand",
@@ -307,7 +335,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -317,7 +347,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_ids": {
           "label": "Content IDs",
@@ -340,7 +372,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "num_items": {
           "label": "Number of Items",
@@ -363,7 +397,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "content_type": {
           "label": "Content Type",
@@ -393,7 +429,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "currency": {
           "label": "Currency",
@@ -416,7 +454,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "value": {
           "label": "Value",
@@ -449,7 +489,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "description": {
           "label": "Description",
@@ -470,7 +512,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "query": {
           "label": "Query",
@@ -493,7 +537,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "search_string": {
           "label": "Search String",
@@ -524,7 +570,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "phone_number": {
           "label": "Phone Number",
@@ -557,7 +605,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -590,7 +640,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "first_name": {
           "label": "First Name",
@@ -623,7 +675,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "last_name": {
           "label": "Last Name",
@@ -656,7 +710,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "address": {
           "label": "Address",
@@ -742,7 +798,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "country": {
               "label": "Country",
@@ -763,7 +821,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "zip_code": {
               "label": "Zip Code",
@@ -784,7 +844,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "state": {
               "label": "State",
@@ -805,7 +867,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -815,7 +879,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "external_id": {
           "label": "External ID",
@@ -848,7 +914,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "vehicle_fields": {
           "label": "Vehicle Fields",
@@ -945,7 +1013,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "make": {
               "label": "Make of the Vehicle",
@@ -966,7 +1036,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "model": {
               "label": "Model of the Vehicle",
@@ -987,7 +1059,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "year": {
               "label": "Year of the Vehicle",
@@ -1008,7 +1082,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "state_of_vehicle": {
               "label": "State of the Vehicle",
@@ -1042,7 +1118,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "mileage_value": {
               "label": "Mileage Value",
@@ -1063,7 +1141,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "mileage_unit": {
               "label": "Mileage Unit",
@@ -1093,7 +1173,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "exterior_color": {
               "label": "Exterior Color of the Vehicle",
@@ -1114,7 +1196,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "transmission": {
               "label": "Transmission Type of the Vehicle",
@@ -1148,7 +1232,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "body_style": {
               "label": "Body Type of the Vehicle",
@@ -1214,7 +1300,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "fuel_type": {
               "label": "Fuel Type of the Vehicle",
@@ -1260,7 +1348,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "drivetrain": {
               "label": "Drivetrain of the Vehicle",
@@ -1306,7 +1396,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "preferred_price_range_min": {
               "label": "Minimum Preferred Price",
@@ -1327,7 +1419,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "preferred_price_range_max": {
               "label": "Maximum Preferred Price",
@@ -1348,7 +1442,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "trim": {
               "label": "Trim of the Vehicle",
@@ -1369,7 +1465,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "vin": {
               "label": "VIN of the Vehicle",
@@ -1390,7 +1488,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "interior_color": {
               "label": "Interior Color of the Vehicle",
@@ -1411,7 +1511,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "condition_of_vehicle": {
               "label": "Condition of the Vehicle",
@@ -1453,7 +1555,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "viewcontent_type": {
               "label": "Soft Lead Landing Page",
@@ -1483,7 +1587,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "search_type": {
               "label": "Other Search Page",
@@ -1513,7 +1619,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "registration_type": {
               "label": "Other Registration Page",
@@ -1543,7 +1651,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -1561,7 +1671,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "travel_fields": {
           "label": "Travel Fields",
@@ -1661,7 +1773,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "region": {
               "label": "Hotel Region",
@@ -1682,7 +1796,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "country": {
               "label": "Hotel Country",
@@ -1703,7 +1819,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "checkin_date": {
               "label": "Hotel Check-in Date",
@@ -1724,7 +1842,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "checkout_date": {
               "label": "Hotel Check-out Date",
@@ -1745,7 +1865,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "num_adults": {
               "label": "Number of Adults",
@@ -1766,7 +1888,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "num_children": {
               "label": "Number of Children",
@@ -1787,7 +1911,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "num_infants": {
               "label": "Number of Infants",
@@ -1808,7 +1934,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "suggested_hotels": {
               "label": "Suggested Hotels",
@@ -1829,7 +1957,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "departing_departure_date": {
               "label": "Departure Date",
@@ -1850,7 +1980,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "returning_departure_date": {
               "label": "Arrival Date",
@@ -1871,7 +2003,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "origin_airport": {
               "label": "Origin Airport",
@@ -1892,7 +2026,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "destination_airport": {
               "label": "Destination Airport",
@@ -1913,7 +2049,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "destination_ids": {
               "label": "Destination IDs",
@@ -1934,7 +2072,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "departing_arrival_date": {
               "label": "Departing Arrival Date",
@@ -1955,7 +2095,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "returning_arrival_date": {
               "label": "Returning Arrival Date",
@@ -1976,7 +2118,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "travel_class": {
               "label": "Flight Ticket Class",
@@ -2014,7 +2158,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "user_score": {
               "label": "User Score",
@@ -2035,7 +2181,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "preferred_num_stops": {
               "label": "Preferred Number of Stops",
@@ -2056,7 +2204,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "travel_start": {
               "label": "Start Date of the Trip",
@@ -2077,7 +2227,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "travel_end": {
               "label": "End Date of the Trip",
@@ -2098,7 +2250,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "suggested_destinations": {
               "label": "Suggested Destination IDs",
@@ -2119,7 +2273,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2137,7 +2293,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": "keyvalue",
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -2149,7 +2307,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "phone_number": {
           "label": "Phone Number",
@@ -2172,7 +2330,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "email": {
           "label": "Email",
@@ -2195,7 +2355,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "first_name": {
           "label": "First Name",
@@ -2218,7 +2380,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "last_name": {
           "label": "Last Name",
@@ -2241,7 +2405,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "address": {
           "label": "Address",
@@ -2287,7 +2453,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "country": {
               "label": "Country",
@@ -2308,7 +2476,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "zip_code": {
               "label": "Zip Code",
@@ -2329,7 +2499,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             },
             "state": {
               "label": "State",
@@ -2350,7 +2522,9 @@
               "minimum": null,
               "maximum": null,
               "defaultObjectUI": null,
-              "disabledInputMethods": null
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "additionalProperties": false
             }
           },
           "category": null,
@@ -2360,7 +2534,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "external_id": {
           "label": "External ID",
@@ -2393,7 +2569,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
+++ b/packages/browser-destinations/destinations/tiktok-pixel/metadata.json
@@ -1,338 +1,65 @@
 {
+  "slug": "actions-tiktok-pixel",
   "name": "TikTok Pixel",
-  "basicOptions": ["pixelCode", "ldu", "autoPageView", "useExistingPixel"],
-  "options": {
-    "pixelCode": {
-      "tags": [],
-      "default": "",
-      "description": "Your TikTok Pixel ID. Please see TikTok's [Pixel documentation](https://ads.tiktok.com/marketing_api/docs?id=1739583652957185) for information on how to find this value.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Pixel Code",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The pixelCode property is required."]],
-      "uIMetadata": null
-    },
-    "ldu": {
-      "tags": [],
-      "default": false,
-      "description": "In order to help facilitate advertiser's compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use (\"LDU\") feature. For more information, please refer to TikTok's [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Limited Data Use",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "autoPageView": {
-      "tags": [],
-      "default": true,
-      "description": "If true, TikTok Pixel will fire a \"Pageview\" event whenevent the pixel is loaded on the page.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Fire TikTok Pixel Pageview event on page load.",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "useExistingPixel": {
-      "tags": [],
-      "default": false,
-      "description": "Deprecated. Please do not provide any value.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "[Deprecated] Use Existing Pixel",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "pixelCode": {
+        "label": "Pixel Code",
+        "description": "Your TikTok Pixel ID. Please see TikTok's [Pixel documentation](https://ads.tiktok.com/marketing_api/docs?id=1739583652957185) for information on how to find this value.",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "ldu": {
+        "label": "Limited Data Use",
+        "description": "In order to help facilitate advertiser's compliance with the right to opt-out of sale and sharing of personal data under certain U.S. state privacy laws, TikTok offers a Limited Data Use (\"LDU\") feature. For more information, please refer to TikTok's [documentation page](https://business-api.tiktok.com/portal/docs?id=1770092377990145).",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "autoPageView": {
+        "label": "Fire TikTok Pixel Pageview event on page load.",
+        "description": "If true, TikTok Pixel will fire a \"Pageview\" event whenevent the pixel is loaded on the page.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      },
+      "useExistingPixel": {
+        "label": "[Deprecated] Use Existing Pixel",
+        "description": "Deprecated. Please do not provide any value.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identify",
-      "name": "Identify",
-      "description": "Use a Segment identify() call to sent PII data to TikTok Pixel. Note that the PII information will be sent with the next track() call.",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "phone_number",
-          "type": "string",
-          "label": "Phone Number",
-          "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
-          "defaultValue": {
-            "@path": "$.traits.phone"
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "phone_number": {
-                "title": "Phone Number",
-                "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "email",
-          "type": "string",
-          "label": "Email",
-          "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
-          "defaultValue": {
-            "@path": "$.traits.email"
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "first_name",
-          "type": "string",
-          "label": "First Name",
-          "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-          "defaultValue": {
-            "@path": "$.traits.first_name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "first_name": {
-                "title": "First Name",
-                "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "last_name",
-          "type": "string",
-          "label": "Last Name",
-          "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-          "defaultValue": {
-            "@path": "$.traits.last_name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "last_name": {
-                "title": "Last Name",
-                "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "address",
-          "type": "object",
-          "label": "Address",
-          "description": "The address of the customer.",
-          "defaultValue": {
-            "city": {
-              "@path": "$.traits.address.city"
-            },
-            "country": {
-              "@path": "$.traits.address.country"
-            },
-            "zip_code": {
-              "@path": "$.traits.address.postal_code"
-            },
-            "state": {
-              "@path": "$.traits.address.state"
-            }
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "address": {
-                "title": "Address",
-                "description": "The address of the customer.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "city": {
-                    "title": "City",
-                    "description": "The customer's city.",
-                    "type": "string"
-                  },
-                  "country": {
-                    "title": "Country",
-                    "description": "The customer's country.",
-                    "type": "string"
-                  },
-                  "zip_code": {
-                    "title": "Zip Code",
-                    "description": "The customer's Zip Code.",
-                    "type": "string"
-                  },
-                  "state": {
-                    "title": "State",
-                    "description": "The customer's State.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "external_id",
-          "type": "string",
-          "label": "External ID",
-          "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
-          "defaultValue": {
-            "@if": {
-              "exists": {
-                "@path": "$.userId"
-              },
-              "then": {
-                "@path": "$.userId"
-              },
-              "else": {
-                "@path": "$.anonymousId"
-              }
-            }
-          },
-          "required": false,
-          "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "external_id": {
-                "title": "External ID",
-                "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "reportWebEvent",
-      "name": "Report Web Event",
+  "audienceConfig": null,
+  "actions": {
+    "reportWebEvent": {
+      "title": "Report Web Event",
       "description": "Report events directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "event_spec_type",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "event_spec_type": {
           "label": "Additional Fields",
           "description": "Include fields for travel or vehicle events.",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
           "choices": [
             {
               "value": "travel_fields",
@@ -343,279 +70,310 @@
               "label": "Vehicle Fields"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_spec_type": {
-                "title": "Additional Fields",
-                "description": "Include fields for travel or vehicle events.",
-                "type": "string",
-                "enum": ["travel_fields", "vehicle_fields"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event",
-          "type": "string",
+        "event": {
           "label": "Event Name",
           "description": "Conversion event name. Please refer to the \"Supported Web Events\" section on in TikTok’s [Pixel SDK documentation](https://business-api.tiktok.com/portal/docs?id=1739585696931842) for accepted event names.",
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event": {
-                "title": "Event Name",
-                "description": "Conversion event name. Please refer to the \"Supported Web Events\" section on in TikTok’s [Pixel SDK documentation](https://business-api.tiktok.com/portal/docs?id=1739585696931842) for accepted event names.",
-                "type": "string"
-              }
-            },
-            "required": ["event"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "event_id",
-          "type": "string",
+        "event_id": {
           "label": "Event ID",
           "description": "Any hashed ID that can identify a unique user/session.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.messageId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "event_id": {
-                "title": "Event ID",
-                "description": "Any hashed ID that can identify a unique user/session.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "order_id",
-          "type": "string",
+        "order_id": {
           "label": "Order ID",
           "description": "Order ID of the transaction.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.order_id"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "order_id": {
-                "title": "Order ID",
-                "description": "Order ID of the transaction.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "shop_id",
-          "type": "string",
+        "shop_id": {
           "label": "Shop ID",
           "description": "Shop ID of the transaction.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.shop_id"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "shop_id": {
-                "title": "Shop ID",
-                "description": "Shop ID of the transaction.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "contents",
-          "type": "object",
+        "contents": {
           "label": "Contents",
           "description": "Related item details for the event.",
+          "type": "object",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "contents": {
-                "title": "Contents",
-                "description": "Related item details for the event.",
-                "type": "array",
-                "items": {
-                  "$schema": "http://json-schema.org/schema#",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "price": {
-                      "title": "Price",
-                      "description": "Price of the item.",
-                      "type": "number"
-                    },
-                    "quantity": {
-                      "title": "Quantity",
-                      "description": "Number of items.",
-                      "type": "number"
-                    },
-                    "content_category": {
-                      "title": "Content Category",
-                      "description": "Category of the product item.",
-                      "type": "string"
-                    },
-                    "content_id": {
-                      "title": "Content ID",
-                      "description": "ID of the product item.",
-                      "type": "string"
-                    },
-                    "content_name": {
-                      "title": "Content Name",
-                      "description": "Name of the product item.",
-                      "type": "string"
-                    },
-                    "brand": {
-                      "title": "Brand",
-                      "description": "Brand name of the product item.",
-                      "type": "string"
-                    }
-                  },
-                  "required": []
-                }
-              }
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "price": {
+              "label": "Price",
+              "description": "Price of the item.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "quantity": {
+              "label": "Quantity",
+              "description": "Number of items.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "content_category": {
+              "label": "Content Category",
+              "description": "Category of the product item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "content_id": {
+              "label": "Content ID",
+              "description": "ID of the product item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "content_name": {
+              "label": "Content Name",
+              "description": "Name of the product item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "brand": {
+              "label": "Brand",
+              "description": "Brand name of the product item.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_ids",
-          "type": "string",
+        "content_ids": {
           "label": "Content IDs",
           "description": "Product IDs associated with the event, such as SKUs. Do not populate this field if the 'Contents' field is populated. This field accepts a single string value or an array of string values.",
-          "defaultValue": {
-            "@path": "$.properties.content_ids"
-          },
+          "type": "string",
           "required": false,
           "multiple": true,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_ids": {
-                "title": "Content IDs",
-                "description": "Product IDs associated with the event, such as SKUs. Do not populate this field if the 'Contents' field is populated. This field accepts a single string value or an array of string values.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.content_ids"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "num_items",
-          "type": "number",
+        "num_items": {
           "label": "Number of Items",
           "description": "Number of items when checkout was initiated. Used with the InitiateCheckout event.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.num_items"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "num_items": {
-                "title": "Number of Items",
-                "description": "Number of items when checkout was initiated. Used with the InitiateCheckout event.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "content_type",
-          "type": "string",
+        "content_type": {
           "label": "Content Type",
           "description": "Type of the product item. When the `content_id` in the `Contents` field is specified as a `sku_id`, set this field to `product`. When the `content_id` in the `Contents` field is specified as an `item_group_id`, set this field to `product_group`.",
-          "defaultValue": "product",
+          "type": "string",
           "required": false,
           "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "product",
           "choices": [
             {
               "label": "product",
@@ -626,62 +384,49 @@
               "value": "product_group"
             }
           ],
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "content_type": {
-                "title": "Content Type",
-                "description": "Type of the product item. When the `content_id` in the `Contents` field is specified as a `sku_id`, set this field to `product`. When the `content_id` in the `Contents` field is specified as an `item_group_id`, set this field to `product_group`.",
-                "type": "string",
-                "enum": ["product", "product_group"]
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "currency",
-          "type": "string",
+        "currency": {
           "label": "Currency",
           "description": "Currency for the value specified as ISO 4217 code.",
-          "defaultValue": {
-            "@path": "$.properties.currency"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "currency": {
-                "title": "Currency",
-                "description": "Currency for the value specified as ISO 4217 code.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.currency"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "value",
-          "type": "number",
+        "value": {
           "label": "Value",
           "description": "Value of the order or items sold.",
-          "defaultValue": {
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.value"
@@ -694,113 +439,78 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "value": {
-                "title": "Value",
-                "description": "Value of the order or items sold.",
-                "type": "number"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "description",
-          "type": "string",
+        "description": {
           "label": "Description",
           "description": "A string description of the web event.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "description": {
-                "title": "Description",
-                "description": "A string description of the web event.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "query",
-          "type": "string",
+        "query": {
           "label": "Query",
           "description": "The text string that was searched for.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.properties.query"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "query": {
-                "title": "Query",
-                "description": "The text string that was searched for.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "search_string",
-          "type": "string",
+        "search_string": {
           "label": "Search String",
           "description": "The text string entered by the user for the search. Optionally used with the Search event.",
-          "defaultValue": {
-            "@path": "$.properties.search_string"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "search_string": {
-                "title": "Search String",
-                "description": "The text string entered by the user for the search. Optionally used with the Search event.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.search_string"
           },
-          "dependsOn": {
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": {
             "conditions": [
               {
                 "fieldKey": "event",
@@ -809,14 +519,22 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "phone_number",
-          "type": "string",
+        "phone_number": {
           "label": "Phone Number",
           "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.phone"
@@ -829,37 +547,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "phone_number": {
-                "title": "Phone Number",
-                "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "email",
-          "type": "string",
+        "email": {
           "label": "Email",
           "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.email"
@@ -872,37 +580,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "email": {
-                "title": "Email",
-                "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "first_name",
-          "type": "string",
+        "first_name": {
           "label": "First Name",
           "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.first_name"
@@ -915,34 +613,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "first_name": {
-                "title": "First Name",
-                "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "last_name",
-          "type": "string",
+        "last_name": {
           "label": "Last Name",
           "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.properties.last_name"
@@ -955,34 +646,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "last_name": {
-                "title": "Last Name",
-                "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "address",
-          "type": "object",
+        "address": {
           "label": "Address",
           "description": "The address of the customer.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "city": {
               "@if": {
                 "exists": {
@@ -1036,59 +720,112 @@
               }
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "address": {
-                "title": "Address",
-                "description": "The address of the customer.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "city": {
-                    "title": "City",
-                    "description": "The customer's city.",
-                    "type": "string"
-                  },
-                  "country": {
-                    "title": "Country",
-                    "description": "The customer's country.",
-                    "type": "string"
-                  },
-                  "zip_code": {
-                    "title": "Zip Code",
-                    "description": "The customer's Zip Code.",
-                    "type": "string"
-                  },
-                  "state": {
-                    "title": "State",
-                    "description": "The customer's State.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "city": {
+              "label": "City",
+              "description": "The customer's city.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "country": {
+              "label": "Country",
+              "description": "The customer's country.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "zip_code": {
+              "label": "Zip Code",
+              "description": "The customer's Zip Code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "state": {
+              "label": "State",
+              "description": "The customer's State.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "external_id",
-          "type": "string",
+        "external_id": {
           "label": "External ID",
           "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.userId"
@@ -1101,37 +838,27 @@
               }
             }
           },
-          "required": false,
-          "multiple": true,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "external_id": {
-                "title": "External ID",
-                "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "vehicle_fields",
-          "type": "object",
+        "vehicle_fields": {
           "label": "Vehicle Fields",
           "description": "Fields related to vehicle events.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "postal_code": {
               "@path": "$.properties.postal_code"
             },
@@ -1196,156 +923,631 @@
               "@path": "$.properties.registration_type"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "vehicle_fields": {
-                "title": "Vehicle Fields",
-                "description": "Fields related to vehicle events.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "postal_code": {
-                    "title": "Postal Code",
-                    "description": "Postal code for the vehicle location.",
-                    "type": "string"
-                  },
-                  "make": {
-                    "title": "Make of the Vehicle",
-                    "description": "Vehicle make/brand/manufacturer.",
-                    "type": "string"
-                  },
-                  "model": {
-                    "title": "Model of the Vehicle",
-                    "description": "Vehicle model.",
-                    "type": "string"
-                  },
-                  "year": {
-                    "title": "Year of the Vehicle",
-                    "description": "Year the vehicle was laucned in yyyy format.",
-                    "type": "number"
-                  },
-                  "state_of_vehicle": {
-                    "title": "State of the Vehicle",
-                    "description": "Vehicle status.",
-                    "type": "string",
-                    "enum": ["New", "Used", "CPO"]
-                  },
-                  "mileage_value": {
-                    "title": "Mileage Value",
-                    "description": "Vehicle mileage (in km or miles). Zero (0) for new vehicle.",
-                    "type": "number"
-                  },
-                  "mileage_unit": {
-                    "title": "Mileage Unit",
-                    "description": "Mileage unites in miles (MI) or kilometers (KM).",
-                    "type": "string",
-                    "enum": ["MI", "KM"]
-                  },
-                  "exterior_color": {
-                    "title": "Exterior Color of the Vehicle",
-                    "description": "Vehicle exterior color.",
-                    "type": "string"
-                  },
-                  "transmission": {
-                    "title": "Transmission Type of the Vehicle",
-                    "description": "Vehicle transmission type.",
-                    "type": "string",
-                    "enum": ["Automatic", "Manual", "Other"]
-                  },
-                  "body_style": {
-                    "title": "Body Type of the Vehicle",
-                    "description": "Vehicle body type.",
-                    "type": "string",
-                    "enum": [
-                      "Convertible",
-                      "Coupe",
-                      "Hatchback",
-                      "Minivan",
-                      "Truck",
-                      "SUV",
-                      "Sedan",
-                      "Van",
-                      "Wagon",
-                      "Crossover",
-                      "Other"
-                    ]
-                  },
-                  "fuel_type": {
-                    "title": "Fuel Type of the Vehicle",
-                    "description": "Vehicle fuel type.",
-                    "type": "string",
-                    "enum": ["Diesel", "Electric", "Flex", "Gasoline", "Hybrid", "Other"]
-                  },
-                  "drivetrain": {
-                    "title": "Drivetrain of the Vehicle",
-                    "description": "Vehicle drivetrain.",
-                    "type": "string",
-                    "enum": ["AWD", "FOUR_WD", "FWD", "RWD", "TWO_WD", "Other"]
-                  },
-                  "preferred_price_range_min": {
-                    "title": "Minimum Preferred Price",
-                    "description": "Minimum preferred price of the vehicle.",
-                    "type": "number"
-                  },
-                  "preferred_price_range_max": {
-                    "title": "Maximum Preferred Price",
-                    "description": "Maximum preferred price of the vehicle.",
-                    "type": "number"
-                  },
-                  "trim": {
-                    "title": "Trim of the Vehicle",
-                    "description": "Vehicle trim.",
-                    "type": "string"
-                  },
-                  "vin": {
-                    "title": "VIN of the Vehicle",
-                    "description": "Vehicle identification number. Maximum characters: 17.",
-                    "type": "string"
-                  },
-                  "interior_color": {
-                    "title": "Interior Color of the Vehicle",
-                    "description": "Vehicle interior color.",
-                    "type": "string"
-                  },
-                  "condition_of_vehicle": {
-                    "title": "Condition of the Vehicle",
-                    "description": "Vehicle drivetrain.",
-                    "type": "string",
-                    "enum": ["Excellent", "Good", "Fair", "Poor", "Other"]
-                  },
-                  "viewcontent_type": {
-                    "title": "Soft Lead Landing Page",
-                    "description": "Optional for ViewContent. Use viewcontent_type to differentiate between soft lead landing pages.",
-                    "type": "string"
-                  },
-                  "search_type": {
-                    "title": "Other Search Page",
-                    "description": "Optional for Search. Use search_type to differentiate other user searches (such as dealer lookup) from inventory search.",
-                    "type": "string"
-                  },
-                  "registration_type": {
-                    "title": "Other Registration Page",
-                    "description": "Optional for CompleteRegistration. Use registration_type to differentiate between different types of customer registration on websites.",
-                    "type": "string"
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "postal_code": {
+              "label": "Postal Code",
+              "description": "Postal code for the vehicle location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "make": {
+              "label": "Make of the Vehicle",
+              "description": "Vehicle make/brand/manufacturer.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "model": {
+              "label": "Model of the Vehicle",
+              "description": "Vehicle model.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "year": {
+              "label": "Year of the Vehicle",
+              "description": "Year the vehicle was laucned in yyyy format.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "state_of_vehicle": {
+              "label": "State of the Vehicle",
+              "description": "Vehicle status.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "New",
+                  "label": "New"
+                },
+                {
+                  "value": "Used",
+                  "label": "Used"
+                },
+                {
+                  "value": "CPO",
+                  "label": "CPO"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "mileage_value": {
+              "label": "Mileage Value",
+              "description": "Vehicle mileage (in km or miles). Zero (0) for new vehicle.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "mileage_unit": {
+              "label": "Mileage Unit",
+              "description": "Mileage unites in miles (MI) or kilometers (KM).",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "MI",
+                  "label": "Miles"
+                },
+                {
+                  "value": "KM",
+                  "label": "Kilometers"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "exterior_color": {
+              "label": "Exterior Color of the Vehicle",
+              "description": "Vehicle exterior color.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "transmission": {
+              "label": "Transmission Type of the Vehicle",
+              "description": "Vehicle transmission type.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "Automatic",
+                  "label": "Automatic"
+                },
+                {
+                  "value": "Manual",
+                  "label": "Manual"
+                },
+                {
+                  "value": "Other",
+                  "label": "Other"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "body_style": {
+              "label": "Body Type of the Vehicle",
+              "description": "Vehicle body type.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "Convertible",
+                  "label": "Convertible"
+                },
+                {
+                  "value": "Coupe",
+                  "label": "Coupe"
+                },
+                {
+                  "value": "Hatchback",
+                  "label": "Hatchback"
+                },
+                {
+                  "value": "Minivan",
+                  "label": "Minivan"
+                },
+                {
+                  "value": "Truck",
+                  "label": "Truck"
+                },
+                {
+                  "value": "SUV",
+                  "label": "SUV"
+                },
+                {
+                  "value": "Sedan",
+                  "label": "Sedan"
+                },
+                {
+                  "value": "Van",
+                  "label": "Van"
+                },
+                {
+                  "value": "Wagon",
+                  "label": "Wagon"
+                },
+                {
+                  "value": "Crossover",
+                  "label": "Crossover"
+                },
+                {
+                  "value": "Other",
+                  "label": "Other"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "fuel_type": {
+              "label": "Fuel Type of the Vehicle",
+              "description": "Vehicle fuel type.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "Diesel",
+                  "label": "Diesel"
+                },
+                {
+                  "value": "Electric",
+                  "label": "Electric"
+                },
+                {
+                  "value": "Flex",
+                  "label": "Flex"
+                },
+                {
+                  "value": "Gasoline",
+                  "label": "Gasoline"
+                },
+                {
+                  "value": "Hybrid",
+                  "label": "Hybrid"
+                },
+                {
+                  "value": "Other",
+                  "label": "Other"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "drivetrain": {
+              "label": "Drivetrain of the Vehicle",
+              "description": "Vehicle drivetrain.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "AWD",
+                  "label": "AWD"
+                },
+                {
+                  "value": "FOUR_WD",
+                  "label": "Four WD"
+                },
+                {
+                  "value": "FWD",
+                  "label": "FWD"
+                },
+                {
+                  "value": "RWD",
+                  "label": "RWD"
+                },
+                {
+                  "value": "TWO_WD",
+                  "label": "Two WD"
+                },
+                {
+                  "value": "Other",
+                  "label": "Other"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "preferred_price_range_min": {
+              "label": "Minimum Preferred Price",
+              "description": "Minimum preferred price of the vehicle.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "preferred_price_range_max": {
+              "label": "Maximum Preferred Price",
+              "description": "Maximum preferred price of the vehicle.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "trim": {
+              "label": "Trim of the Vehicle",
+              "description": "Vehicle trim.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "vin": {
+              "label": "VIN of the Vehicle",
+              "description": "Vehicle identification number. Maximum characters: 17.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "interior_color": {
+              "label": "Interior Color of the Vehicle",
+              "description": "Vehicle interior color.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "condition_of_vehicle": {
+              "label": "Condition of the Vehicle",
+              "description": "Vehicle drivetrain.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "Excellent",
+                  "label": "Excellent"
+                },
+                {
+                  "value": "Good",
+                  "label": "Good"
+                },
+                {
+                  "value": "Fair",
+                  "label": "Fair"
+                },
+                {
+                  "value": "Poor",
+                  "label": "Poor"
+                },
+                {
+                  "value": "Other",
+                  "label": "Other"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "viewcontent_type": {
+              "label": "Soft Lead Landing Page",
+              "description": "Optional for ViewContent. Use viewcontent_type to differentiate between soft lead landing pages.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": {
+                "match": "any",
+                "conditions": [
+                  {
+                    "fieldKey": "event",
+                    "operator": "is",
+                    "value": "ViewContent"
+                  }
+                ]
+              },
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "search_type": {
+              "label": "Other Search Page",
+              "description": "Optional for Search. Use search_type to differentiate other user searches (such as dealer lookup) from inventory search.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": {
+                "match": "any",
+                "conditions": [
+                  {
+                    "fieldKey": "event",
+                    "operator": "is",
+                    "value": "Search"
+                  }
+                ]
+              },
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "registration_type": {
+              "label": "Other Registration Page",
+              "description": "Optional for CompleteRegistration. Use registration_type to differentiate between different types of customer registration on websites.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": {
+                "match": "any",
+                "conditions": [
+                  {
+                    "fieldKey": "event",
+                    "operator": "is",
+                    "value": "CompleteRegistration"
+                  }
+                ]
+              },
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": {
+          "category": null,
+          "depends_on": {
             "conditions": [
               {
                 "fieldKey": "event_spec_type",
@@ -1354,14 +1556,22 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "travel_fields",
-          "type": "object",
+        "travel_fields": {
           "label": "Travel Fields",
           "description": "Fields related to travel events.",
-          "defaultValue": {
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "city": {
               "@path": "$.properties.city"
             },
@@ -1429,152 +1639,491 @@
               "@path": "$.properties.suggested_destinations"
             }
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "defaultObjectUI": "keyvalue",
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "travel_fields": {
-                "title": "Travel Fields",
-                "description": "Fields related to travel events.",
-                "type": "object",
-                "$schema": "http://json-schema.org/schema#",
-                "additionalProperties": false,
-                "properties": {
-                  "city": {
-                    "title": "Hotel City Location",
-                    "description": "Hotel city location.",
-                    "type": "string"
-                  },
-                  "region": {
-                    "title": "Hotel Region",
-                    "description": "Hotel region location.",
-                    "type": "string"
-                  },
-                  "country": {
-                    "title": "Hotel Country",
-                    "description": "Hotel country location.",
-                    "type": "string"
-                  },
-                  "checkin_date": {
-                    "title": "Hotel Check-in Date",
-                    "description": "Hotel check-in date.",
-                    "type": "string"
-                  },
-                  "checkout_date": {
-                    "title": "Hotel Check-out Date",
-                    "description": "Hotel check-out date.",
-                    "type": "string"
-                  },
-                  "num_adults": {
-                    "title": "Number of Adults",
-                    "description": "Number of adults.",
-                    "type": "number"
-                  },
-                  "num_children": {
-                    "title": "Number of Children",
-                    "description": "Number of children.",
-                    "type": "number"
-                  },
-                  "num_infants": {
-                    "title": "Number of Infants",
-                    "description": "Number of infants flying.",
-                    "type": "number"
-                  },
-                  "suggested_hotels": {
-                    "title": "Suggested Hotels",
-                    "description": "Suggested hotels. This can be a single string value or an array of string values.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "departing_departure_date": {
-                    "title": "Departure Date",
-                    "description": "Date of flight departure. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
-                    "type": "string"
-                  },
-                  "returning_departure_date": {
-                    "title": "Arrival Date",
-                    "description": "Date of return flight. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
-                    "type": "string"
-                  },
-                  "origin_airport": {
-                    "title": "Origin Airport",
-                    "description": "Origin airport.",
-                    "type": "string"
-                  },
-                  "destination_airport": {
-                    "title": "Destination Airport",
-                    "description": "Destination airport.",
-                    "type": "string"
-                  },
-                  "destination_ids": {
-                    "title": "Destination IDs",
-                    "description": "If a client has a destination catalog, the client can associate one or more destinations in the catalog with a specific flight event. For instance, link a particular route to a nearby museum and a nearby beach, both of which are destinations in the catalog. This field accepts a single string value or an array of string values.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "departing_arrival_date": {
-                    "title": "Departing Arrival Date",
-                    "description": "The date and time for arrival at the destination of the outbound journey. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
-                    "type": "string"
-                  },
-                  "returning_arrival_date": {
-                    "title": "Returning Arrival Date",
-                    "description": "The date and time when the return journey is completed. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
-                    "type": "string"
-                  },
-                  "travel_class": {
-                    "title": "Flight Ticket Class",
-                    "description": "Class of the flight ticket, must be: \"eco\", \"prem\", \"bus\", \"first\".",
-                    "type": "string",
-                    "enum": ["eco", "prem", "bus", "first"]
-                  },
-                  "user_score": {
-                    "title": "User Score",
-                    "description": "Represents the relative value of this potential customer to advertiser.",
-                    "type": "number"
-                  },
-                  "preferred_num_stops": {
-                    "title": "Preferred Number of Stops",
-                    "description": "The preferred number of stops the user is looking for. 0 for direct flight.",
-                    "type": "integer"
-                  },
-                  "travel_start": {
-                    "title": "Start Date of the Trip",
-                    "description": "The start date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
-                    "type": "string"
-                  },
-                  "travel_end": {
-                    "title": "End Date of the Trip",
-                    "description": "The end date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
-                    "type": "string"
-                  },
-                  "suggested_destinations": {
-                    "title": "Suggested Destination IDs",
-                    "description": "A list of IDs representing destination suggestions for this user. This parameter is not applicable for the Search event. This field accepts a single string value or an array of string values.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "required": []
-              }
+          "placeholder": null,
+          "properties": {
+            "city": {
+              "label": "Hotel City Location",
+              "description": "Hotel city location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
             },
-            "required": []
+            "region": {
+              "label": "Hotel Region",
+              "description": "Hotel region location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "country": {
+              "label": "Hotel Country",
+              "description": "Hotel country location.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "checkin_date": {
+              "label": "Hotel Check-in Date",
+              "description": "Hotel check-in date.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "checkout_date": {
+              "label": "Hotel Check-out Date",
+              "description": "Hotel check-out date.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "num_adults": {
+              "label": "Number of Adults",
+              "description": "Number of adults.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "num_children": {
+              "label": "Number of Children",
+              "description": "Number of children.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "num_infants": {
+              "label": "Number of Infants",
+              "description": "Number of infants flying.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "suggested_hotels": {
+              "label": "Suggested Hotels",
+              "description": "Suggested hotels. This can be a single string value or an array of string values.",
+              "type": "string",
+              "required": false,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "departing_departure_date": {
+              "label": "Departure Date",
+              "description": "Date of flight departure. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "returning_departure_date": {
+              "label": "Arrival Date",
+              "description": "Date of return flight. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "origin_airport": {
+              "label": "Origin Airport",
+              "description": "Origin airport.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "destination_airport": {
+              "label": "Destination Airport",
+              "description": "Destination airport.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "destination_ids": {
+              "label": "Destination IDs",
+              "description": "If a client has a destination catalog, the client can associate one or more destinations in the catalog with a specific flight event. For instance, link a particular route to a nearby museum and a nearby beach, both of which are destinations in the catalog. This field accepts a single string value or an array of string values.",
+              "type": "string",
+              "required": false,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "departing_arrival_date": {
+              "label": "Departing Arrival Date",
+              "description": "The date and time for arrival at the destination of the outbound journey. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "returning_arrival_date": {
+              "label": "Returning Arrival Date",
+              "description": "The date and time when the return journey is completed. Accepted date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "travel_class": {
+              "label": "Flight Ticket Class",
+              "description": "Class of the flight ticket, must be: \"eco\", \"prem\", \"bus\", \"first\".",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "value": "eco",
+                  "label": "Economy"
+                },
+                {
+                  "value": "prem",
+                  "label": "Premium"
+                },
+                {
+                  "value": "bus",
+                  "label": "Bus"
+                },
+                {
+                  "value": "first",
+                  "label": "First"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "user_score": {
+              "label": "User Score",
+              "description": "Represents the relative value of this potential customer to advertiser.",
+              "type": "number",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "preferred_num_stops": {
+              "label": "Preferred Number of Stops",
+              "description": "The preferred number of stops the user is looking for. 0 for direct flight.",
+              "type": "integer",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "travel_start": {
+              "label": "Start Date of the Trip",
+              "description": "The start date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "travel_end": {
+              "label": "End Date of the Trip",
+              "description": "The end date of user's trip. Accept date formats: YYYYMMDD, YYYY-MM-DD, YYYY-MM-DDThh:mmTZD, and YYYY-MM-DDThh:mm:ssTZD.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "suggested_destinations": {
+              "label": "Suggested Destination IDs",
+              "description": "A list of IDs representing destination suggestions for this user. This parameter is not applicable for the Search event. This field accepts a single string value or an array of string values.",
+              "type": "string",
+              "required": false,
+              "multiple": true,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
           },
-          "dependsOn": {
+          "category": null,
+          "depends_on": {
             "conditions": [
               {
                 "fieldKey": "event_spec_type",
@@ -1583,1311 +2132,287 @@
               }
             ]
           },
-          "displayMetadata": null
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identify": {
+      "title": "Identify",
+      "description": "Use a Segment identify() call to sent PII data to TikTok Pixel. Note that the PII information will be sent with the next track() call.",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "phone_number": {
+          "label": "Phone Number",
+          "description": "A single phone number in E.164 standard format. TikTok Pixel will hash this value before sending to TikTok. e.g. +14150000000. Segment will hash this value before sending to TikTok.",
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.phone"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "email": {
+          "label": "Email",
+          "description": "A single email address. TikTok Pixel will be hash this value before sending to TikTok.",
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.email"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "first_name": {
+          "label": "First Name",
+          "description": "The first name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.first_name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "last_name": {
+          "label": "Last Name",
+          "description": "The last name of the customer. The name should be in lowercase without any punctuation. Special characters are allowed.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.last_name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "address": {
+          "label": "Address",
+          "description": "The address of the customer.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "city": {
+              "@path": "$.traits.address.city"
+            },
+            "country": {
+              "@path": "$.traits.address.country"
+            },
+            "zip_code": {
+              "@path": "$.traits.address.postal_code"
+            },
+            "state": {
+              "@path": "$.traits.address.state"
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "city": {
+              "label": "City",
+              "description": "The customer's city.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "country": {
+              "label": "Country",
+              "description": "The customer's country.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "zip_code": {
+              "label": "Zip Code",
+              "description": "The customer's Zip Code.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            },
+            "state": {
+              "label": "State",
+              "description": "The customer's State.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": false,
+              "hidden": false,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null
+            }
+          },
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "external_id": {
+          "label": "External ID",
+          "description": "Uniquely identifies the user who triggered the conversion event. TikTok Pixel will hash this value before sending to TikTok.",
+          "type": "string",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
+      "name": "Page View",
+      "type": "automatic",
       "partnerAction": "reportWebEvent",
-      "name": "Add Payment Info",
-      "subscribe": "event = \"Payment Info Entered\"",
+      "subscribe": "type = \"page\"",
       "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "AddPaymentInfo"
+        "event": "Pageview"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "reportWebEvent",
-      "name": "Add to Cart",
-      "subscribe": "event = \"Product Added\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "AddToCart"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Add to Wishlist",
-      "subscribe": "event = \"Product Added to Wishlist\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "AddToWishlist"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Click Button",
-      "subscribe": "event = \"Product Clicked\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "ClickButton"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
       "name": "Complete Payment",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "event = \"Order Completed\"",
       "mapping": {
         "event_id": {
@@ -3207,310 +2732,12 @@
         },
         "event": "CompletePayment"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "reportWebEvent",
-      "name": "Complete Registration",
-      "subscribe": "event = \"Signed Up\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "event": "CompleteRegistration"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
       "name": "Contact",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "event = \"Callback Started\"",
       "mapping": {
         "event_id": {
@@ -3805,1590 +3032,12 @@
         },
         "event": "Contact"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "reportWebEvent",
-      "name": "Download",
-      "subscribe": "event = \"Download Link Clicked\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "event": "Download"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Initiate Checkout",
-      "subscribe": "event = \"Checkout Started\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "InitiateCheckout"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Page View",
-      "subscribe": "type = \"page\"",
-      "mapping": {
-        "event": "Pageview"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Place an Order",
-      "subscribe": "event = \"Order Placed\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties.products",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "PlaceAnOrder"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Search",
-      "subscribe": "event = \"Products Searched\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "contents": {
-          "@arrayPath": [
-            "$.properties",
-            {
-              "price": {
-                "@path": "$.price"
-              },
-              "quantity": {
-                "@path": "$.quantity"
-              },
-              "content_category": {
-                "@path": "$.category"
-              },
-              "content_id": {
-                "@path": "$.product_id"
-              },
-              "content_name": {
-                "@path": "$.name"
-              },
-              "brand": {
-                "@path": "$.brand"
-              }
-            }
-          ]
-        },
-        "event": "Search"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
-      "name": "Submit Form",
-      "subscribe": "event = \"Form Submitted\"",
-      "mapping": {
-        "event_id": {
-          "@path": "$.messageId"
-        },
-        "order_id": {
-          "@path": "$.properties.order_id"
-        },
-        "shop_id": {
-          "@path": "$.properties.shop_id"
-        },
-        "content_ids": {
-          "@path": "$.properties.content_ids"
-        },
-        "num_items": {
-          "@path": "$.properties.num_items"
-        },
-        "content_type": "product",
-        "currency": {
-          "@path": "$.properties.currency"
-        },
-        "value": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.value"
-            },
-            "then": {
-              "@path": "$.properties.value"
-            },
-            "else": {
-              "@path": "$.properties.revenue"
-            }
-          }
-        },
-        "query": {
-          "@path": "$.properties.query"
-        },
-        "search_string": {
-          "@path": "$.properties.search_string"
-        },
-        "phone_number": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.phone"
-            },
-            "then": {
-              "@path": "$.properties.phone"
-            },
-            "else": {
-              "@path": "$.context.traits.phone"
-            }
-          }
-        },
-        "email": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.email"
-            },
-            "then": {
-              "@path": "$.properties.email"
-            },
-            "else": {
-              "@path": "$.context.traits.email"
-            }
-          }
-        },
-        "first_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.first_name"
-            },
-            "then": {
-              "@path": "$.properties.first_name"
-            },
-            "else": {
-              "@path": "$.context.traits.first_name"
-            }
-          }
-        },
-        "last_name": {
-          "@if": {
-            "exists": {
-              "@path": "$.properties.last_name"
-            },
-            "then": {
-              "@path": "$.properties.last_name"
-            },
-            "else": {
-              "@path": "$.context.traits.last_name"
-            }
-          }
-        },
-        "address": {
-          "city": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.city"
-              },
-              "then": {
-                "@path": "$.properties.address.city"
-              },
-              "else": {
-                "@path": "$.context.traits.address.city"
-              }
-            }
-          },
-          "country": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.country"
-              },
-              "then": {
-                "@path": "$.properties.address.country"
-              },
-              "else": {
-                "@path": "$.context.traits.address.country"
-              }
-            }
-          },
-          "zip_code": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "then": {
-                "@path": "$.properties.address.postal_code"
-              },
-              "else": {
-                "@path": "$.context.traits.address.postal_code"
-              }
-            }
-          },
-          "state": {
-            "@if": {
-              "exists": {
-                "@path": "$.properties.address.state"
-              },
-              "then": {
-                "@path": "$.properties.address.state"
-              },
-              "else": {
-                "@path": "$.context.traits.address.state"
-              }
-            }
-          }
-        },
-        "external_id": {
-          "@if": {
-            "exists": {
-              "@path": "$.userId"
-            },
-            "then": {
-              "@path": "$.userId"
-            },
-            "else": {
-              "@path": "$.anonymousId"
-            }
-          }
-        },
-        "vehicle_fields": {
-          "postal_code": {
-            "@path": "$.properties.postal_code"
-          },
-          "make": {
-            "@path": "$.properties.make"
-          },
-          "model": {
-            "@path": "$.properties.model"
-          },
-          "year": {
-            "@path": "$.properties.year"
-          },
-          "state_of_vehicle": {
-            "@path": "$.properties.state_of_vehicle"
-          },
-          "mileage_value": {
-            "@path": "$.properties.mileage_value"
-          },
-          "mileage_unit": {
-            "@path": "$.properties.mileage_unit"
-          },
-          "exterior_color": {
-            "@path": "$.properties.exterior_color"
-          },
-          "transmission": {
-            "@path": "$.properties.transmission"
-          },
-          "body_style": {
-            "@path": "$.properties.body_style"
-          },
-          "fuel_type": {
-            "@path": "$.properties.fuel_type"
-          },
-          "drivetrain": {
-            "@path": "$.properties.drive_train"
-          },
-          "preferred_price_range_min": {
-            "@path": "$.properties.preferred_price_range_min"
-          },
-          "preferred_price_range_max": {
-            "@path": "$.properties.preferred_price_range_max"
-          },
-          "trim": {
-            "@path": "$.properties.trim"
-          },
-          "vin": {
-            "@path": "$.properties.vin"
-          },
-          "interior_color": {
-            "@path": "$.properties.interior_color"
-          },
-          "condition_of_vehicle": {
-            "@path": "$.properties.condition_of_vehicle"
-          },
-          "viewcontent_type": {
-            "@path": "$.properties.viewcontent_type"
-          },
-          "search_type": {
-            "@path": "$.properties.search_type"
-          },
-          "registration_type": {
-            "@path": "$.properties.registration_type"
-          }
-        },
-        "travel_fields": {
-          "city": {
-            "@path": "$.properties.city"
-          },
-          "region": {
-            "@path": "$.properties.region"
-          },
-          "country": {
-            "@path": "$.properties.country"
-          },
-          "checkin_date": {
-            "@path": "$.properties.checkin_date"
-          },
-          "checkout_date": {
-            "@path": "$.properties.checkout_date"
-          },
-          "num_adults": {
-            "@path": "$.properties.num_adults"
-          },
-          "num_children": {
-            "@path": "$.properties.num_children"
-          },
-          "num_infants": {
-            "@path": "$.properties.num_infants"
-          },
-          "suggested_hotels": {
-            "@path": "$.properties.suggested_hotels"
-          },
-          "departing_departure_date": {
-            "@path": "$.properties.departing_departure_date"
-          },
-          "returning_departure_date": {
-            "@path": "$.properties.returning_departure_date"
-          },
-          "origin_airport": {
-            "@path": "$.properties.origin_airport"
-          },
-          "destination_airport": {
-            "@path": "$.properties.destination_airport"
-          },
-          "destination_ids": {
-            "@path": "$.properties.destination_ids"
-          },
-          "departing_arrival_date": {
-            "@path": "$.properties.departing_arrival_date"
-          },
-          "returning_arrival_date": {
-            "@path": "$.properties.returning_arrival_date"
-          },
-          "travel_class": {
-            "@path": "$.properties.travel_class"
-          },
-          "user_score": {
-            "@path": "$.properties.user_score"
-          },
-          "preferred_num_stops": {
-            "@path": "$.properties.preferred_num_stops"
-          },
-          "travel_start": {
-            "@path": "$.properties.travel_start"
-          },
-          "travel_end": {
-            "@path": "$.properties.travel_end"
-          },
-          "suggested_destinations": {
-            "@path": "$.properties.suggested_destinations"
-          }
-        },
-        "event": "SubmitForm"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "reportWebEvent",
       "name": "Subscribe",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "event = \"Subscription Created\"",
       "mapping": {
         "event_id": {
@@ -5683,11 +3332,312 @@
         },
         "event": "Subscribe"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
+      "name": "Submit Form",
+      "type": "automatic",
       "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Form Submitted\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "SubmitForm"
+      },
+      "eventSlug": null
+    },
+    {
       "name": "View Content",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
       "subscribe": "event = \"Product Viewed\"",
       "mapping": {
         "event_id": {
@@ -6007,7 +3957,2882 @@
         },
         "event": "ViewContent"
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Click Button",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Product Clicked\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "ClickButton"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Search",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Products Searched\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "Search"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Add to Wishlist",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Product Added to Wishlist\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddToWishlist"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Add to Cart",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Product Added\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddToCart"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Initiate Checkout",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Checkout Started\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "InitiateCheckout"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Add Payment Info",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Payment Info Entered\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "AddPaymentInfo"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Place an Order",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Order Placed\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "contents": {
+          "@arrayPath": [
+            "$.properties.products",
+            {
+              "price": {
+                "@path": "$.price"
+              },
+              "quantity": {
+                "@path": "$.quantity"
+              },
+              "content_category": {
+                "@path": "$.category"
+              },
+              "content_id": {
+                "@path": "$.product_id"
+              },
+              "content_name": {
+                "@path": "$.name"
+              },
+              "brand": {
+                "@path": "$.brand"
+              }
+            }
+          ]
+        },
+        "event": "PlaceAnOrder"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Download",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Download Link Clicked\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "Download"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Complete Registration",
+      "type": "automatic",
+      "partnerAction": "reportWebEvent",
+      "subscribe": "event = \"Signed Up\"",
+      "mapping": {
+        "event_id": {
+          "@path": "$.messageId"
+        },
+        "order_id": {
+          "@path": "$.properties.order_id"
+        },
+        "shop_id": {
+          "@path": "$.properties.shop_id"
+        },
+        "content_ids": {
+          "@path": "$.properties.content_ids"
+        },
+        "num_items": {
+          "@path": "$.properties.num_items"
+        },
+        "content_type": "product",
+        "currency": {
+          "@path": "$.properties.currency"
+        },
+        "value": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.value"
+            },
+            "then": {
+              "@path": "$.properties.value"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "query": {
+          "@path": "$.properties.query"
+        },
+        "search_string": {
+          "@path": "$.properties.search_string"
+        },
+        "phone_number": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.phone"
+            },
+            "then": {
+              "@path": "$.properties.phone"
+            },
+            "else": {
+              "@path": "$.context.traits.phone"
+            }
+          }
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@path": "$.context.traits.email"
+            }
+          }
+        },
+        "first_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.first_name"
+            },
+            "then": {
+              "@path": "$.properties.first_name"
+            },
+            "else": {
+              "@path": "$.context.traits.first_name"
+            }
+          }
+        },
+        "last_name": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.last_name"
+            },
+            "then": {
+              "@path": "$.properties.last_name"
+            },
+            "else": {
+              "@path": "$.context.traits.last_name"
+            }
+          }
+        },
+        "address": {
+          "city": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.city"
+              },
+              "then": {
+                "@path": "$.properties.address.city"
+              },
+              "else": {
+                "@path": "$.context.traits.address.city"
+              }
+            }
+          },
+          "country": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.country"
+              },
+              "then": {
+                "@path": "$.properties.address.country"
+              },
+              "else": {
+                "@path": "$.context.traits.address.country"
+              }
+            }
+          },
+          "zip_code": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "then": {
+                "@path": "$.properties.address.postal_code"
+              },
+              "else": {
+                "@path": "$.context.traits.address.postal_code"
+              }
+            }
+          },
+          "state": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.address.state"
+              },
+              "then": {
+                "@path": "$.properties.address.state"
+              },
+              "else": {
+                "@path": "$.context.traits.address.state"
+              }
+            }
+          }
+        },
+        "external_id": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "vehicle_fields": {
+          "postal_code": {
+            "@path": "$.properties.postal_code"
+          },
+          "make": {
+            "@path": "$.properties.make"
+          },
+          "model": {
+            "@path": "$.properties.model"
+          },
+          "year": {
+            "@path": "$.properties.year"
+          },
+          "state_of_vehicle": {
+            "@path": "$.properties.state_of_vehicle"
+          },
+          "mileage_value": {
+            "@path": "$.properties.mileage_value"
+          },
+          "mileage_unit": {
+            "@path": "$.properties.mileage_unit"
+          },
+          "exterior_color": {
+            "@path": "$.properties.exterior_color"
+          },
+          "transmission": {
+            "@path": "$.properties.transmission"
+          },
+          "body_style": {
+            "@path": "$.properties.body_style"
+          },
+          "fuel_type": {
+            "@path": "$.properties.fuel_type"
+          },
+          "drivetrain": {
+            "@path": "$.properties.drive_train"
+          },
+          "preferred_price_range_min": {
+            "@path": "$.properties.preferred_price_range_min"
+          },
+          "preferred_price_range_max": {
+            "@path": "$.properties.preferred_price_range_max"
+          },
+          "trim": {
+            "@path": "$.properties.trim"
+          },
+          "vin": {
+            "@path": "$.properties.vin"
+          },
+          "interior_color": {
+            "@path": "$.properties.interior_color"
+          },
+          "condition_of_vehicle": {
+            "@path": "$.properties.condition_of_vehicle"
+          },
+          "viewcontent_type": {
+            "@path": "$.properties.viewcontent_type"
+          },
+          "search_type": {
+            "@path": "$.properties.search_type"
+          },
+          "registration_type": {
+            "@path": "$.properties.registration_type"
+          }
+        },
+        "travel_fields": {
+          "city": {
+            "@path": "$.properties.city"
+          },
+          "region": {
+            "@path": "$.properties.region"
+          },
+          "country": {
+            "@path": "$.properties.country"
+          },
+          "checkin_date": {
+            "@path": "$.properties.checkin_date"
+          },
+          "checkout_date": {
+            "@path": "$.properties.checkout_date"
+          },
+          "num_adults": {
+            "@path": "$.properties.num_adults"
+          },
+          "num_children": {
+            "@path": "$.properties.num_children"
+          },
+          "num_infants": {
+            "@path": "$.properties.num_infants"
+          },
+          "suggested_hotels": {
+            "@path": "$.properties.suggested_hotels"
+          },
+          "departing_departure_date": {
+            "@path": "$.properties.departing_departure_date"
+          },
+          "returning_departure_date": {
+            "@path": "$.properties.returning_departure_date"
+          },
+          "origin_airport": {
+            "@path": "$.properties.origin_airport"
+          },
+          "destination_airport": {
+            "@path": "$.properties.destination_airport"
+          },
+          "destination_ids": {
+            "@path": "$.properties.destination_ids"
+          },
+          "departing_arrival_date": {
+            "@path": "$.properties.departing_arrival_date"
+          },
+          "returning_arrival_date": {
+            "@path": "$.properties.returning_arrival_date"
+          },
+          "travel_class": {
+            "@path": "$.properties.travel_class"
+          },
+          "user_score": {
+            "@path": "$.properties.user_score"
+          },
+          "preferred_num_stops": {
+            "@path": "$.properties.preferred_num_stops"
+          },
+          "travel_start": {
+            "@path": "$.properties.travel_start"
+          },
+          "travel_end": {
+            "@path": "$.properties.travel_end"
+          },
+          "suggested_destinations": {
+            "@path": "$.properties.suggested_destinations"
+          }
+        },
+        "event": "CompleteRegistration"
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/userpilot/metadata.json
+++ b/packages/browser-destinations/destinations/userpilot/metadata.json
@@ -1,147 +1,57 @@
 {
+  "slug": "actions-userpilot-web",
   "name": "Userpilot Web (Actions)",
-  "basicOptions": ["token", "endpoint", "shouldSegmentLoadSDK"],
-  "options": {
-    "token": {
-      "tags": [],
-      "default": "",
-      "description": "Your Userpilot app token, you can find it in the [Userpilot installation](https://run.userpilot.io/installation) dashboard.",
-      "encrypt": true,
-      "hidden": false,
-      "label": "App Token",
-      "private": false,
-      "scope": "event_destination",
-      "type": "password",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The token property is required."]],
-      "uIMetadata": null
-    },
-    "endpoint": {
-      "tags": [],
-      "default": "",
-      "description": "By default, Userpilot would use a service discovery mechanism to determine the API endpoint to connect to. If you are using a proxy or a firewall, you can specify the API endpoint here.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "The API endpoint the SDK would connect to",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "shouldSegmentLoadSDK": {
-      "tags": [],
-      "default": true,
-      "description": "By default, Segment will load the Userpilot JS snippet onto the page. If you are already loading the Userpilot JS onto the page then disable this setting and Segment will detect the Userpilot JS on the page",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Segment Loads Userpilot JS",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The shouldSegmentLoadSDK property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "token": {
+        "label": "App Token",
+        "description": "Your Userpilot app token, you can find it in the [Userpilot installation](https://run.userpilot.io/installation) dashboard.",
+        "type": "password",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "endpoint": {
+        "label": "The API endpoint the SDK would connect to",
+        "description": "By default, Userpilot would use a service discovery mechanism to determine the API endpoint to connect to. If you are using a proxy or a firewall, you can specify the API endpoint here.",
+        "type": "string",
+        "required": false,
+        "choices": null,
+        "default": null
+      },
+      "shouldSegmentLoadSDK": {
+        "label": "Segment Loads Userpilot JS",
+        "description": "By default, Segment will load the Userpilot JS snippet onto the page. If you are already loading the Userpilot JS onto the page then disable this setting and Segment will detect the Userpilot JS on the page",
+        "type": "boolean",
+        "required": true,
+        "choices": null,
+        "default": true
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyCompany",
-      "name": "Identify Company",
-      "description": "Create or update a company entity in Userpilot",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"group\"",
-      "fields": [
-        {
-          "fieldKey": "groupId",
-          "type": "string",
-          "label": "Company ID",
-          "description": "The ID of the company.",
-          "defaultValue": {
-            "@path": "$.groupId"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "groupId": {
-                "title": "Company ID",
-                "description": "The ID of the company.",
-                "type": "string"
-              }
-            },
-            "required": ["groupId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "Company traits",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "Company traits",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
+  "audienceConfig": null,
+  "actions": {
+    "identifyUser": {
+      "title": "Identify User",
       "description": "Create or update a user entity in Userpilot. It's mandatory to identify a user by calling identify() prior to invoking other methods such as track(), page(), or group(). You can learn more by visiting the [Userpilot documentation](https://docs.userpilot.com/article/23-identify-users-track-custom-events).",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "userId",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "userId": {
           "label": "User ID",
           "description": "The ID of the logged-in user.",
-          "defaultValue": {
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@if": {
               "exists": {
                 "@path": "$.userId"
@@ -154,250 +64,246 @@
               }
             }
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "userId": {
-                "title": "User ID",
-                "description": "The ID of the logged-in user.",
-                "type": "string"
-              }
-            },
-            "required": ["userId"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "createdAt",
-          "type": "datetime",
+        "createdAt": {
           "label": "User Created At Date",
           "description": "The date the user profile was created at",
-          "defaultValue": {
+          "type": "datetime",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits.createdAt"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "createdAt": {
-                "title": "User Created At Date",
-                "description": "The date the user profile was created at",
-                "type": ["string", "number"],
-                "format": "date-like"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "traits",
-          "type": "object",
-          "label": "Traits",
-          "description": "User traits.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Traits",
-                "description": "User traits.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "pageView",
-      "name": "Page View",
-      "description": "Update the content queue designed to trigger on a specific page. It's mandatory to identify a user by calling identify() prior to invoking other methods such as page()",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Page Name",
-          "description": "The name of the page that was viewed.",
-          "defaultValue": {
-            "@path": "$.name"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Page Name",
-                "description": "The name of the page that was viewed.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Properties",
-          "description": "The properties of the page that was viewed.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "The properties of the page that was viewed.",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
-      "description": "Send an event to Userpilot. It's mandatory to identify a user by calling identify() prior to invoking other methods such as track(). You can learn more by visiting the [Userpilot documentation](https://docs.userpilot.com/article/23-identify-users-track-custom-events).",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "name",
-          "type": "string",
-          "label": "Name",
-          "description": "Event name",
-          "defaultValue": {
-            "@path": "$.event"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "title": "Name",
-                "description": "Event name",
-                "type": "string"
-              }
-            },
-            "required": ["name"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        },
-        {
-          "fieldKey": "properties",
-          "type": "object",
-          "label": "Properties",
-          "description": "Event properties",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
-          "required": false,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "Event properties",
-                "type": "object"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    }
-  ],
-  "presets": [
-    {
-      "partnerAction": "identifyCompany",
-      "name": "Identify Company",
-      "subscribe": "type = \"group\"",
-      "mapping": {
-        "groupId": {
-          "@path": "$.groupId"
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
         "traits": {
-          "@path": "$.traits"
+          "label": "Traits",
+          "description": "User traits.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      },
-      "type": "automatic"
+      }
     },
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Send an event to Userpilot. It's mandatory to identify a user by calling identify() prior to invoking other methods such as track(). You can learn more by visiting the [Userpilot documentation](https://docs.userpilot.com/article/23-identify-users-track-custom-events).",
+      "platform": "web",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Name",
+          "description": "Event name",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Properties",
+          "description": "Event properties",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "pageView": {
+      "title": "Page View",
+      "description": "Update the content queue designed to trigger on a specific page. It's mandatory to identify a user by calling identify() prior to invoking other methods such as page()",
+      "platform": "web",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "name": {
+          "label": "Page Name",
+          "description": "The name of the page that was viewed.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "properties": {
+          "label": "Properties",
+          "description": "The properties of the page that was viewed.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    },
+    "identifyCompany": {
+      "title": "Identify Company",
+      "description": "Create or update a company entity in Userpilot",
+      "platform": "web",
+      "defaultSubscription": "type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "groupId": {
+          "label": "Company ID",
+          "description": "The ID of the company.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        },
+        "traits": {
+          "label": "Traits",
+          "description": "Company traits",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
+    }
+  },
+  "presets": [
     {
-      "partnerAction": "identifyUser",
       "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
       "subscribe": "type = \"identify\"",
       "mapping": {
         "userId": {
@@ -420,25 +326,27 @@
           "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "pageView",
-      "name": "Page View",
-      "subscribe": "type = \"page\"",
+      "name": "Identify Company",
+      "type": "automatic",
+      "partnerAction": "identifyCompany",
+      "subscribe": "type = \"group\"",
       "mapping": {
-        "name": {
-          "@path": "$.name"
+        "groupId": {
+          "@path": "$.groupId"
         },
-        "properties": {
-          "@path": "$.properties"
+        "traits": {
+          "@path": "$.traits"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "name": {
@@ -448,7 +356,22 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Page View",
+      "type": "automatic",
+      "partnerAction": "pageView",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "name": {
+          "@path": "$.name"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/userpilot/metadata.json
+++ b/packages/browser-destinations/destinations/userpilot/metadata.json
@@ -1,0 +1,454 @@
+{
+  "name": "Userpilot Web (Actions)",
+  "basicOptions": ["token", "endpoint", "shouldSegmentLoadSDK"],
+  "options": {
+    "token": {
+      "tags": [],
+      "default": "",
+      "description": "Your Userpilot app token, you can find it in the [Userpilot installation](https://run.userpilot.io/installation) dashboard.",
+      "encrypt": true,
+      "hidden": false,
+      "label": "App Token",
+      "private": false,
+      "scope": "event_destination",
+      "type": "password",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The token property is required."]],
+      "uIMetadata": null
+    },
+    "endpoint": {
+      "tags": [],
+      "default": "",
+      "description": "By default, Userpilot would use a service discovery mechanism to determine the API endpoint to connect to. If you are using a proxy or a firewall, you can specify the API endpoint here.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "The API endpoint the SDK would connect to",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "shouldSegmentLoadSDK": {
+      "tags": [],
+      "default": true,
+      "description": "By default, Segment will load the Userpilot JS snippet onto the page. If you are already loading the Userpilot JS onto the page then disable this setting and Segment will detect the Userpilot JS on the page",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Segment Loads Userpilot JS",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The shouldSegmentLoadSDK property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyCompany",
+      "name": "Identify Company",
+      "description": "Create or update a company entity in Userpilot",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"group\"",
+      "fields": [
+        {
+          "fieldKey": "groupId",
+          "type": "string",
+          "label": "Company ID",
+          "description": "The ID of the company.",
+          "defaultValue": {
+            "@path": "$.groupId"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "groupId": {
+                "title": "Company ID",
+                "description": "The ID of the company.",
+                "type": "string"
+              }
+            },
+            "required": ["groupId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "Company traits",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "Company traits",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Create or update a user entity in Userpilot. It's mandatory to identify a user by calling identify() prior to invoking other methods such as track(), page(), or group(). You can learn more by visiting the [Userpilot documentation](https://docs.userpilot.com/article/23-identify-users-track-custom-events).",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "userId",
+          "type": "string",
+          "label": "User ID",
+          "description": "The ID of the logged-in user.",
+          "defaultValue": {
+            "@if": {
+              "exists": {
+                "@path": "$.userId"
+              },
+              "then": {
+                "@path": "$.userId"
+              },
+              "else": {
+                "@path": "$.anonymousId"
+              }
+            }
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "userId": {
+                "title": "User ID",
+                "description": "The ID of the logged-in user.",
+                "type": "string"
+              }
+            },
+            "required": ["userId"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "createdAt",
+          "type": "datetime",
+          "label": "User Created At Date",
+          "description": "The date the user profile was created at",
+          "defaultValue": {
+            "@path": "$.traits.createdAt"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "createdAt": {
+                "title": "User Created At Date",
+                "description": "The date the user profile was created at",
+                "type": ["string", "number"],
+                "format": "date-like"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Traits",
+          "description": "User traits.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Traits",
+                "description": "User traits.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "pageView",
+      "name": "Page View",
+      "description": "Update the content queue designed to trigger on a specific page. It's mandatory to identify a user by calling identify() prior to invoking other methods such as page()",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Page Name",
+          "description": "The name of the page that was viewed.",
+          "defaultValue": {
+            "@path": "$.name"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Page Name",
+                "description": "The name of the page that was viewed.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "The properties of the page that was viewed.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "The properties of the page that was viewed.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send an event to Userpilot. It's mandatory to identify a user by calling identify() prior to invoking other methods such as track(). You can learn more by visiting the [Userpilot documentation](https://docs.userpilot.com/article/23-identify-users-track-custom-events).",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "name",
+          "type": "string",
+          "label": "Name",
+          "description": "Event name",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "Event name",
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "Event properties",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "Event properties",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyCompany",
+      "name": "Identify Company",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "userId": {
+          "@if": {
+            "exists": {
+              "@path": "$.userId"
+            },
+            "then": {
+              "@path": "$.userId"
+            },
+            "else": {
+              "@path": "$.anonymousId"
+            }
+          }
+        },
+        "createdAt": {
+          "@path": "$.traits.createdAt"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "pageView",
+      "name": "Page View",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "name": {
+          "@path": "$.name"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "name": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/userpilot/metadata.json
+++ b/packages/browser-destinations/destinations/userpilot/metadata.json
@@ -10,24 +10,30 @@
         "description": "Your Userpilot app token, you can find it in the [Userpilot installation](https://run.userpilot.io/installation) dashboard.",
         "type": "password",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "endpoint": {
         "label": "The API endpoint the SDK would connect to",
         "description": "By default, Userpilot would use a service discovery mechanism to determine the API endpoint to connect to. If you are using a proxy or a firewall, you can specify the API endpoint here.",
         "type": "string",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "shouldSegmentLoadSDK": {
         "label": "Segment Loads Userpilot JS",
         "description": "By default, Segment will load the Userpilot JS snippet onto the page. If you are already loading the Userpilot JS onto the page then disable this setting and Segment will detect the Userpilot JS on the page",
         "type": "boolean",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       }
     }
   },
@@ -41,7 +47,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "userId": {
           "label": "User ID",
@@ -74,7 +80,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "createdAt": {
           "label": "User Created At Date",
@@ -97,7 +105,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -120,7 +130,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -132,7 +144,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Name",
@@ -155,7 +167,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -178,7 +192,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -190,7 +206,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "name": {
           "label": "Page Name",
@@ -213,7 +229,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -236,7 +254,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -248,7 +268,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "groupId": {
           "label": "Company ID",
@@ -271,7 +291,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "traits": {
           "label": "Traits",
@@ -294,7 +316,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/vwo/metadata.json
+++ b/packages/browser-destinations/destinations/vwo/metadata.json
@@ -1,219 +1,153 @@
 {
+  "slug": "actions-vwo-web",
   "name": "VWO Web Mode (Actions)",
-  "basicOptions": ["vwoAccountId", "settingsTolerance", "libraryTolerance", "useExistingJquery", "addSmartcode"],
-  "options": {
-    "vwoAccountId": {
-      "tags": [],
-      "default": 0,
-      "description": "Your VWO account ID, used for fetching your VWO async smart code.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "VWO Account ID",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The vwoAccountId property is required."]],
-      "uIMetadata": null
-    },
-    "settingsTolerance": {
-      "tags": [],
-      "default": 2000,
-      "description": "The maximum amount of time (in milliseconds) to wait for test settings before VWO will simply display your original page.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Settings Tolerance",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "libraryTolerance": {
-      "tags": [],
-      "default": 2500,
-      "description": "The maximum amount of time (in milliseconds) to wait for VWO’s full library to be downloaded before simply displaying your original page.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Library Tolerance",
-      "private": false,
-      "scope": "event_destination",
-      "type": "number",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "useExistingJquery": {
-      "tags": [],
-      "default": false,
-      "description": "If your page already includes JQuery, you can set this to “true”. Otherwise, VWO will include JQuery onto the page for you. VWO needs JQuery on the page to function correctly. ",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Use Existing JQuery",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
-    },
-    "addSmartcode": {
-      "tags": [],
-      "default": true,
-      "description": "When enabled, Segment will load the VWO SmartCode onto the webpage. When disabled, you will have to manually add SmartCode to your webpage. The setting is enabled by default, however we recommended manually adding SmartCode to the webpage to avoid flicker issues.",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Add Asynchronous SmartCode",
-      "private": false,
-      "scope": "event_destination",
-      "type": "boolean",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "vwoAccountId": {
+        "label": "VWO Account ID",
+        "description": "Your VWO account ID, used for fetching your VWO async smart code.",
+        "type": "number",
+        "required": true,
+        "choices": null,
+        "default": null
+      },
+      "settingsTolerance": {
+        "label": "Settings Tolerance",
+        "description": "The maximum amount of time (in milliseconds) to wait for test settings before VWO will simply display your original page.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 2000
+      },
+      "libraryTolerance": {
+        "label": "Library Tolerance",
+        "description": "The maximum amount of time (in milliseconds) to wait for VWO’s full library to be downloaded before simply displaying your original page.",
+        "type": "number",
+        "required": false,
+        "choices": null,
+        "default": 2500
+      },
+      "useExistingJquery": {
+        "label": "Use Existing JQuery",
+        "description": "If your page already includes JQuery, you can set this to “true”. Otherwise, VWO will include JQuery onto the page for you. VWO needs JQuery on the page to function correctly. ",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": false
+      },
+      "addSmartcode": {
+        "label": "Add Asynchronous SmartCode",
+        "description": "When enabled, Segment will load the VWO SmartCode onto the webpage. When disabled, you will have to manually add SmartCode to your webpage. The setting is enabled by default, however we recommended manually adding SmartCode to the webpage to avoid flicker issues.",
+        "type": "boolean",
+        "required": false,
+        "choices": null,
+        "default": true
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "identifyUser",
-      "name": "Identify User",
-      "description": "Sends Segment's user traits to VWO",
-      "platform": "web",
-      "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "attributes",
-          "type": "object",
-          "label": "Attributes",
-          "description": "JSON object containing additional attributes that will be associated with the user.",
-          "defaultValue": {
-            "@path": "$.traits"
-          },
-          "required": true,
-          "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "attributes": {
-                "title": "Attributes",
-                "description": "JSON object containing additional attributes that will be associated with the user.",
-                "type": "object"
-              }
-            },
-            "required": ["attributes"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
-        }
-      ]
-    },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Sends Segment's track event to VWO",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "eventName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventName": {
           "label": "Name",
           "description": "Name of the event.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Name",
-                "description": "Name of the event.",
-                "type": "string"
-              }
-            },
-            "required": ["eventName"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "properties",
-          "type": "object",
+        "properties": {
           "label": "Properties",
           "description": "JSON object containing additional properties that will be associated with the event.",
-          "defaultValue": {
-            "@path": "$.properties"
-          },
+          "type": "object",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "properties": {
-                "title": "Properties",
-                "description": "JSON object containing additional properties that will be associated with the event.",
-                "type": "object"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Sends Segment's user traits to VWO",
+      "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "attributes": {
+          "label": "Attributes",
+          "description": "JSON object containing additional attributes that will be associated with the user.",
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
+        }
+      }
     }
-  ],
+  },
   "presets": [
     {
-      "partnerAction": "identifyUser",
-      "name": "Identify User",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "attributes": {
-          "@path": "$.traits"
-        }
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "eventName": {
@@ -223,7 +157,19 @@
           "@path": "$.properties"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
+    },
+    {
+      "name": "Identify User",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "attributes": {
+          "@path": "$.traits"
+        }
+      },
+      "eventSlug": null
     }
   ]
 }

--- a/packages/browser-destinations/destinations/vwo/metadata.json
+++ b/packages/browser-destinations/destinations/vwo/metadata.json
@@ -1,0 +1,229 @@
+{
+  "name": "VWO Web Mode (Actions)",
+  "basicOptions": ["vwoAccountId", "settingsTolerance", "libraryTolerance", "useExistingJquery", "addSmartcode"],
+  "options": {
+    "vwoAccountId": {
+      "tags": [],
+      "default": 0,
+      "description": "Your VWO account ID, used for fetching your VWO async smart code.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "VWO Account ID",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The vwoAccountId property is required."]],
+      "uIMetadata": null
+    },
+    "settingsTolerance": {
+      "tags": [],
+      "default": 2000,
+      "description": "The maximum amount of time (in milliseconds) to wait for test settings before VWO will simply display your original page.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Settings Tolerance",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "libraryTolerance": {
+      "tags": [],
+      "default": 2500,
+      "description": "The maximum amount of time (in milliseconds) to wait for VWO’s full library to be downloaded before simply displaying your original page.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Library Tolerance",
+      "private": false,
+      "scope": "event_destination",
+      "type": "number",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "useExistingJquery": {
+      "tags": [],
+      "default": false,
+      "description": "If your page already includes JQuery, you can set this to “true”. Otherwise, VWO will include JQuery onto the page for you. VWO needs JQuery on the page to function correctly. ",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Use Existing JQuery",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    },
+    "addSmartcode": {
+      "tags": [],
+      "default": true,
+      "description": "When enabled, Segment will load the VWO SmartCode onto the webpage. When disabled, you will have to manually add SmartCode to your webpage. The setting is enabled by default, however we recommended manually adding SmartCode to the webpage to avoid flicker issues.",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Add Asynchronous SmartCode",
+      "private": false,
+      "scope": "event_destination",
+      "type": "boolean",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "identifyUser",
+      "name": "Identify User",
+      "description": "Sends Segment's user traits to VWO",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "attributes",
+          "type": "object",
+          "label": "Attributes",
+          "description": "JSON object containing additional attributes that will be associated with the user.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attributes": {
+                "title": "Attributes",
+                "description": "JSON object containing additional attributes that will be associated with the user.",
+                "type": "object"
+              }
+            },
+            "required": ["attributes"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Sends Segment's track event to VWO",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Name",
+          "description": "Name of the event.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Name",
+                "description": "Name of the event.",
+                "type": "string"
+              }
+            },
+            "required": ["eventName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "properties",
+          "type": "object",
+          "label": "Properties",
+          "description": "JSON object containing additional properties that will be associated with the event.",
+          "defaultValue": {
+            "@path": "$.properties"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "properties": {
+                "title": "Properties",
+                "description": "JSON object containing additional properties that will be associated with the event.",
+                "type": "object"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "identifyUser",
+      "name": "Identify User",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "attributes": {
+          "@path": "$.traits"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        },
+        "properties": {
+          "@path": "$.properties"
+        }
+      },
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/vwo/metadata.json
+++ b/packages/browser-destinations/destinations/vwo/metadata.json
@@ -10,40 +10,50 @@
         "description": "Your VWO account ID, used for fetching your VWO async smart code.",
         "type": "number",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       },
       "settingsTolerance": {
         "label": "Settings Tolerance",
         "description": "The maximum amount of time (in milliseconds) to wait for test settings before VWO will simply display your original page.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 2000
+        "default": 2000,
+        "depends_on": null
       },
       "libraryTolerance": {
         "label": "Library Tolerance",
         "description": "The maximum amount of time (in milliseconds) to wait for VWO’s full library to be downloaded before simply displaying your original page.",
         "type": "number",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": 2500
+        "default": 2500,
+        "depends_on": null
       },
       "useExistingJquery": {
         "label": "Use Existing JQuery",
         "description": "If your page already includes JQuery, you can set this to “true”. Otherwise, VWO will include JQuery onto the page for you. VWO needs JQuery on the page to function correctly. ",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": false
+        "default": false,
+        "depends_on": null
       },
       "addSmartcode": {
         "label": "Add Asynchronous SmartCode",
         "description": "When enabled, Segment will load the VWO SmartCode onto the webpage. When disabled, you will have to manually add SmartCode to your webpage. The setting is enabled by default, however we recommended manually adding SmartCode to the webpage to avoid flicker issues.",
         "type": "boolean",
         "required": false,
+        "multiple": false,
         "choices": null,
-        "default": true
+        "default": true,
+        "depends_on": null
       }
     }
   },
@@ -57,7 +67,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventName": {
           "label": "Name",
@@ -80,7 +90,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "properties": {
           "label": "Properties",
@@ -103,7 +115,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -115,7 +129,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "attributes": {
           "label": "Attributes",
@@ -138,7 +152,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/browser-destinations/destinations/wisepops/metadata.json
+++ b/packages/browser-destinations/destinations/wisepops/metadata.json
@@ -1,0 +1,324 @@
+{
+  "name": "Wisepops",
+  "basicOptions": ["websiteId"],
+  "options": {
+    "websiteId": {
+      "tags": [],
+      "default": "",
+      "description": "The identifier of your Wisepops' website. You can find it in [your setup code on Wisepops](https://id.wisepops.com/r/id/workspaces/_workspaceId_/settings/setup-code).",
+      "encrypt": false,
+      "hidden": false,
+      "label": "Website Identifier",
+      "private": false,
+      "scope": "event_destination",
+      "type": "string",
+      "readOnly": false,
+      "dependsOn": null,
+      "validators": [["required", "The websiteId property is required."]],
+      "uIMetadata": null
+    }
+  },
+  "platforms": {
+    "browser": true,
+    "server": false,
+    "mobile": false,
+    "warehouse": false,
+    "cloudAppObject": false
+  },
+  "supportedRegions": ["us-west-2", "eu-west-1"],
+  "supportsAudiences": false,
+  "actions": [
+    {
+      "slug": "setCustomProperties",
+      "name": "Set Custom Properties",
+      "description": "Define [custom properties](https://support.wisepops.com/article/yrdyv1tfih-set-up-custom-properties) to let Wisepops target them in your scenarios.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"identify\"",
+      "fields": [
+        {
+          "fieldKey": "traits",
+          "type": "object",
+          "label": "Custom Properties",
+          "description": "The custom properties to send to Wisepops.",
+          "defaultValue": {
+            "@path": "$.traits"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "traits": {
+                "title": "Custom Properties",
+                "description": "The custom properties to send to Wisepops.",
+                "type": "object"
+              }
+            },
+            "required": ["traits"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "id",
+          "type": "string",
+          "label": "Entity ID",
+          "description": "A unique identifier. Typically, a user ID or group ID.",
+          "defaultValue": {
+            "@path": "$.userId"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "title": "Entity ID",
+                "description": "A unique identifier. Typically, a user ID or group ID.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "idProperty",
+          "type": "string",
+          "label": "Property name for the entity ID",
+          "description": "How to name the entity ID among the other custom properties?",
+          "defaultValue": "userId",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "idProperty": {
+                "title": "Property name for the entity ID",
+                "description": "How to name the entity ID among the other custom properties?",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "prefix",
+          "type": "string",
+          "label": "Prefix",
+          "description": "This lets you define the properties as a nested object. If you set the property `\"name\"` with the prefix `\"group\"`, you'll access it in Wisepops as `\"group.name\"`.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "prefix": {
+                "title": "Prefix",
+                "description": "This lets you define the properties as a nested object. If you set the property `\"name\"` with the prefix `\"group\"`, you'll access it in Wisepops as `\"group.name\"`.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackEvent",
+      "name": "Track Event",
+      "description": "Send a [custom event](https://support.wisepops.com/article/zbpq1z0exk-set-up-custom-events-to-trigger-popups) to Wisepops. Keep in mind that events are counted as page views in your Wisepops' monthly quota.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\"",
+      "fields": [
+        {
+          "fieldKey": "eventName",
+          "type": "string",
+          "label": "Event Name",
+          "description": "The name of the event to send to Wisepops.",
+          "defaultValue": {
+            "@path": "$.event"
+          },
+          "required": true,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "title": "Event Name",
+                "description": "The name of the event to send to Wisepops.",
+                "type": "string"
+              }
+            },
+            "required": ["eventName"]
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackGoal",
+      "name": "Track Goal",
+      "description": "[Track goals and revenue](https://support.wisepops.com/article/mx3z8na6yb-set-up-goal-tracking) to know which campaigns are generating the most value.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
+      "fields": [
+        {
+          "fieldKey": "goalName",
+          "type": "string",
+          "label": "Goal Identifier",
+          "description": "This is a 32-character identifier, visible when you create the JS goal in Wisepops.",
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "goalName": {
+                "title": "Goal Identifier",
+                "description": "This is a 32-character identifier, visible when you create the JS goal in Wisepops.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        },
+        {
+          "fieldKey": "goalRevenue",
+          "type": "string",
+          "label": "Goal Revenue",
+          "description": "The revenue associated with the goal.",
+          "defaultValue": {
+            "@path": "$.properties.revenue"
+          },
+          "required": false,
+          "multiple": false,
+          "choices": null,
+          "dynamic": false,
+          "placeholder": "",
+          "allowNull": false,
+          "fieldSchema": {
+            "$schema": "http://json-schema.org/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "goalRevenue": {
+                "title": "Goal Revenue",
+                "description": "The revenue associated with the goal.",
+                "type": "string"
+              }
+            },
+            "required": []
+          },
+          "dependsOn": null,
+          "displayMetadata": null
+        }
+      ]
+    },
+    {
+      "slug": "trackPage",
+      "name": "Track Page",
+      "description": "Let Wisepops know when the visitor goes to a new page. This allows Wisepops to display campaigns at page change.",
+      "platform": "web",
+      "hidden": false,
+      "defaultTrigger": "type = \"page\"",
+      "fields": []
+    }
+  ],
+  "presets": [
+    {
+      "partnerAction": "setCustomProperties",
+      "name": "Set Group Traits as Custom Properties",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        },
+        "id": {
+          "@path": "$.groupId"
+        },
+        "idProperty": "groupId",
+        "prefix": "group"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "setCustomProperties",
+      "name": "Set User Traits as Custom Properties",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        },
+        "id": {
+          "@path": "$.userId"
+        },
+        "idProperty": "userId"
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackEvent",
+      "name": "Track Event",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "eventName": {
+          "@path": "$.event"
+        }
+      },
+      "type": "automatic"
+    },
+    {
+      "partnerAction": "trackPage",
+      "name": "Track Page",
+      "subscribe": "type = \"page\"",
+      "mapping": {},
+      "type": "automatic"
+    }
+  ]
+}

--- a/packages/browser-destinations/destinations/wisepops/metadata.json
+++ b/packages/browser-destinations/destinations/wisepops/metadata.json
@@ -10,8 +10,10 @@
         "description": "The identifier of your Wisepops' website. You can find it in [your setup code on Wisepops](https://id.wisepops.com/r/id/workspaces/_workspaceId_/settings/setup-code).",
         "type": "string",
         "required": true,
+        "multiple": false,
         "choices": null,
-        "default": null
+        "default": null,
+        "depends_on": null
       }
     }
   },
@@ -25,7 +27,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "traits": {
           "label": "Custom Properties",
@@ -48,7 +50,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "id": {
           "label": "Entity ID",
@@ -71,7 +75,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "idProperty": {
           "label": "Property name for the entity ID",
@@ -92,7 +98,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "prefix": {
           "label": "Prefix",
@@ -113,7 +121,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -125,7 +135,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "eventName": {
           "label": "Event Name",
@@ -148,7 +158,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -160,7 +172,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {
         "goalName": {
           "label": "Goal Identifier",
@@ -181,7 +193,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         },
         "goalRevenue": {
           "label": "Goal Revenue",
@@ -204,7 +218,9 @@
           "minimum": null,
           "maximum": null,
           "defaultObjectUI": null,
-          "disabledInputMethods": null
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "additionalProperties": false
         }
       }
     },
@@ -216,7 +232,7 @@
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
-      "hooks": [],
+      "hooks": null,
       "fields": {}
     }
   },

--- a/packages/browser-destinations/destinations/wisepops/metadata.json
+++ b/packages/browser-destinations/destinations/wisepops/metadata.json
@@ -1,279 +1,246 @@
 {
+  "slug": "actions-wisepops",
   "name": "Wisepops",
-  "basicOptions": ["websiteId"],
-  "options": {
-    "websiteId": {
-      "tags": [],
-      "default": "",
-      "description": "The identifier of your Wisepops' website. You can find it in [your setup code on Wisepops](https://id.wisepops.com/r/id/workspaces/_workspaceId_/settings/setup-code).",
-      "encrypt": false,
-      "hidden": false,
-      "label": "Website Identifier",
-      "private": false,
-      "scope": "event_destination",
-      "type": "string",
-      "readOnly": false,
-      "dependsOn": null,
-      "validators": [["required", "The websiteId property is required."]],
-      "uIMetadata": null
+  "mode": "device",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "websiteId": {
+        "label": "Website Identifier",
+        "description": "The identifier of your Wisepops' website. You can find it in [your setup code on Wisepops](https://id.wisepops.com/r/id/workspaces/_workspaceId_/settings/setup-code).",
+        "type": "string",
+        "required": true,
+        "choices": null,
+        "default": null
+      }
     }
   },
-  "platforms": {
-    "browser": true,
-    "server": false,
-    "mobile": false,
-    "warehouse": false,
-    "cloudAppObject": false
-  },
-  "supportedRegions": ["us-west-2", "eu-west-1"],
-  "supportsAudiences": false,
-  "actions": [
-    {
-      "slug": "setCustomProperties",
-      "name": "Set Custom Properties",
+  "audienceConfig": null,
+  "actions": {
+    "setCustomProperties": {
+      "title": "Set Custom Properties",
       "description": "Define [custom properties](https://support.wisepops.com/article/yrdyv1tfih-set-up-custom-properties) to let Wisepops target them in your scenarios.",
       "platform": "web",
+      "defaultSubscription": "type = \"identify\"",
       "hidden": false,
-      "defaultTrigger": "type = \"identify\"",
-      "fields": [
-        {
-          "fieldKey": "traits",
-          "type": "object",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "traits": {
           "label": "Custom Properties",
           "description": "The custom properties to send to Wisepops.",
-          "defaultValue": {
+          "type": "object",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.traits"
           },
-          "required": true,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "traits": {
-                "title": "Custom Properties",
-                "description": "The custom properties to send to Wisepops.",
-                "type": "object"
-              }
-            },
-            "required": ["traits"]
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "id",
-          "type": "string",
+        "id": {
           "label": "Entity ID",
           "description": "A unique identifier. Typically, a user ID or group ID.",
-          "defaultValue": {
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
             "@path": "$.userId"
           },
-          "required": false,
-          "multiple": false,
           "choices": null,
-          "dynamic": false,
-          "placeholder": "",
-          "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "id": {
-                "title": "Entity ID",
-                "description": "A unique identifier. Typically, a user ID or group ID.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "idProperty",
-          "type": "string",
+        "idProperty": {
           "label": "Property name for the entity ID",
           "description": "How to name the entity ID among the other custom properties?",
-          "defaultValue": "userId",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "idProperty": {
-                "title": "Property name for the entity ID",
-                "description": "How to name the entity ID among the other custom properties?",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": "userId",
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "prefix",
-          "type": "string",
+        "prefix": {
           "label": "Prefix",
           "description": "This lets you define the properties as a nested object. If you set the property `\"name\"` with the prefix `\"group\"`, you'll access it in Wisepops as `\"group.name\"`.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "prefix": {
-                "title": "Prefix",
-                "description": "This lets you define the properties as a nested object. If you set the property `\"name\"` with the prefix `\"group\"`, you'll access it in Wisepops as `\"group.name\"`.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackEvent",
-      "name": "Track Event",
+    "trackEvent": {
+      "title": "Track Event",
       "description": "Send a [custom event](https://support.wisepops.com/article/zbpq1z0exk-set-up-custom-events-to-trigger-popups) to Wisepops. Keep in mind that events are counted as page views in your Wisepops' monthly quota.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\"",
-      "fields": [
-        {
-          "fieldKey": "eventName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "eventName": {
           "label": "Event Name",
           "description": "The name of the event to send to Wisepops.",
-          "defaultValue": {
-            "@path": "$.event"
-          },
+          "type": "string",
           "required": true,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "eventName": {
-                "title": "Event Name",
-                "description": "The name of the event to send to Wisepops.",
-                "type": "string"
-              }
-            },
-            "required": ["eventName"]
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackGoal",
-      "name": "Track Goal",
+    "trackGoal": {
+      "title": "Track Goal",
       "description": "[Track goals and revenue](https://support.wisepops.com/article/mx3z8na6yb-set-up-goal-tracking) to know which campaigns are generating the most value.",
       "platform": "web",
+      "defaultSubscription": "type = \"track\" and event = \"Order Completed\"",
       "hidden": false,
-      "defaultTrigger": "type = \"track\" and event = \"Order Completed\"",
-      "fields": [
-        {
-          "fieldKey": "goalName",
-          "type": "string",
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {
+        "goalName": {
           "label": "Goal Identifier",
           "description": "This is a 32-character identifier, visible when you create the JS goal in Wisepops.",
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "goalName": {
-                "title": "Goal Identifier",
-                "description": "This is a 32-character identifier, visible when you create the JS goal in Wisepops.",
-                "type": "string"
-              }
-            },
-            "required": []
-          },
-          "dependsOn": null,
-          "displayMetadata": null
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         },
-        {
-          "fieldKey": "goalRevenue",
-          "type": "string",
+        "goalRevenue": {
           "label": "Goal Revenue",
           "description": "The revenue associated with the goal.",
-          "defaultValue": {
-            "@path": "$.properties.revenue"
-          },
+          "type": "string",
           "required": false,
           "multiple": false,
-          "choices": null,
-          "dynamic": false,
-          "placeholder": "",
           "allowNull": false,
-          "fieldSchema": {
-            "$schema": "http://json-schema.org/schema#",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "goalRevenue": {
-                "title": "Goal Revenue",
-                "description": "The revenue associated with the goal.",
-                "type": "string"
-              }
-            },
-            "required": []
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.revenue"
           },
-          "dependsOn": null,
-          "displayMetadata": null
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null
         }
-      ]
+      }
     },
-    {
-      "slug": "trackPage",
-      "name": "Track Page",
+    "trackPage": {
+      "title": "Track Page",
       "description": "Let Wisepops know when the visitor goes to a new page. This allows Wisepops to display campaigns at page change.",
       "platform": "web",
+      "defaultSubscription": "type = \"page\"",
       "hidden": false,
-      "defaultTrigger": "type = \"page\"",
-      "fields": []
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": [],
+      "fields": {}
     }
-  ],
+  },
   "presets": [
     {
+      "name": "Set User Traits as Custom Properties",
+      "type": "automatic",
       "partnerAction": "setCustomProperties",
+      "subscribe": "type = \"identify\"",
+      "mapping": {
+        "traits": {
+          "@path": "$.traits"
+        },
+        "id": {
+          "@path": "$.userId"
+        },
+        "idProperty": "userId"
+      },
+      "eventSlug": null
+    },
+    {
       "name": "Set Group Traits as Custom Properties",
+      "type": "automatic",
+      "partnerAction": "setCustomProperties",
       "subscribe": "type = \"group\"",
       "mapping": {
         "traits": {
@@ -285,40 +252,27 @@
         "idProperty": "groupId",
         "prefix": "group"
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "setCustomProperties",
-      "name": "Set User Traits as Custom Properties",
-      "subscribe": "type = \"identify\"",
-      "mapping": {
-        "traits": {
-          "@path": "$.traits"
-        },
-        "id": {
-          "@path": "$.userId"
-        },
-        "idProperty": "userId"
-      },
-      "type": "automatic"
-    },
-    {
-      "partnerAction": "trackEvent",
       "name": "Track Event",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
       "subscribe": "type = \"track\"",
       "mapping": {
         "eventName": {
           "@path": "$.event"
         }
       },
-      "type": "automatic"
+      "eventSlug": null
     },
     {
-      "partnerAction": "trackPage",
       "name": "Track Page",
+      "type": "automatic",
+      "partnerAction": "trackPage",
       "subscribe": "type = \"page\"",
       "mapping": {},
-      "type": "automatic"
+      "eventSlug": null
     }
   ]
 }


### PR DESCRIPTION
Generated `metadata.json` files for all 40 browser destinations. This is PR 2 of 4.

## What

Adds co-located `metadata.json` to each browser destination under `packages/browser-destinations/destinations/*/`.

Files are generated by `yarn generate:metadata-payload` (added in PR 1).

## Series

- PR 1: CLI command + scripts + workflows (merge first)
- **PR 2 (this)**: browser destination `metadata.json` files — draft
- PR 3: cloud destination `metadata.json` files — draft
- PR 4: CI assert step in `ci.yml` — draft