### PR TITLE
feat: assert metadata.json files are up-to-date in CI validate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Assert generated types are up-to-date
         run: bash scripts/assert-types-updated.sh
 
+      - name: Assert metadata payloads are up-to-date
+        run: bash scripts/assert-metadata-payload.sh
+
   browser-destination-bundle-qa:
     name: Browser Destination Bundle QA
     # env: # Disable saucelabs - we blew through our quota.


### PR DESCRIPTION
Adds the `assert-metadata-payload.sh` check to the CI validate job. This is PR 4 of 4 — merge last, after PRs 2 and 3.

## What

Adds a step to `.github/workflows/ci.yml` that runs `bash scripts/assert-metadata-payload.sh` in the validate job, ensuring `metadata.json` files are always committed and up-to-date.

## Series

- PR 1: CLI command + scripts + workflows (merge first)
- PR 2: browser destination `metadata.json` files
- PR 3: cloud destination `metadata.json` files
- **PR 4 (this)**: CI assert step — merge last