### PR TITLE
[Cleanup] [linkedin-conversions] Promote 202603 as default API version

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/versioning-info.ts
@@ -1,13 +1,12 @@
 /** LINKEDIN_CONVERSIONS_API_VERSION
  * LinkedIn Conversions API version (stable/production).
- * API reference: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api?view=li-lms-2025-05&tabs=curl
+ * API reference: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api?view=li-lms-2026-03&tabs=curl
  * Changelog: https://learn.microsoft.com/en-us/linkedin/marketing/changelog
  */
-export const LINKEDIN_CONVERSIONS_API_VERSION = '202505'
+export const LINKEDIN_CONVERSIONS_API_VERSION = '202603'
 
 /** LINKEDIN_CONVERSIONS_CANARY_API_VERSION
  * LinkedIn Conversions API version (canary/feature-flagged).
- * Testing new version 202603 behind feature flag.
- * Version 202505 sunsets May 15, 2026.
+ * Changelog: https://learn.microsoft.com/en-us/linkedin/marketing/changelog
  */
 export const LINKEDIN_CONVERSIONS_CANARY_API_VERSION = '202603'


### PR DESCRIPTION
## Summary
- Promotes `202603` as the new stable default API version for LinkedIn Conversions (was `202505`)
- Resets the canary version to `202603` as well, so both point to the same version until the next canary cycle
- Feature flag infrastructure (`FLAGON_NAME`, `getApiVersion`, `LINKEDIN_CANARY_API_VERSION`) is preserved for future version upgrades

## Test plan
- [x] Existing unit tests pass (`yarn cloud jest --testPathPattern="linkedin-conversions"`)
- [x] Verify `LinkedIn-Version` header is `202603` in requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)