### PR TITLE
CUSTINT-24021: Migrate Emarsys Segment.io connector to use OIDC (v3 API)

### DIFF
--- a/packages/destination-actions/src/destinations/emarsys/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -67,13 +67,23 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for actions-emarsys destination: upsertContact action - required fields 1`] = `
-Object {
-  "contacts": Array [
-    Object {
-      "ADOas@%XS83LqVu9": "ADOas@%XS83LqVu9",
-    },
-  ],
-  "key_id": "ADOas@%XS83LqVu9",
+exports[`Testing snapshot for actions-emarsys destination: upsertContact action - required fields 1`] = `"grant_type=client_credentials"`;
+
+exports[`Testing snapshot for actions-emarsys destination: upsertContact action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "Content-Type": Array [
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    ],
+    "accept": Array [
+      "application/json",
+    ],
+    "authorization": Array [
+      "Basic dGVzdGNsaWVudDpzdXBlcnNlY3JldA==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/emarsys/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/__tests__/index.test.ts
@@ -1,33 +1,22 @@
 import nock from 'nock'
 import { createTestIntegration } from '@segment/actions-core'
-import { API_HOST, API_PATH } from '../emarsys-helper'
 import Definition from '../index'
 
 const testDestination = createTestIntegration(Definition)
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+
 describe('Emarsys', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
-      nock(`${API_HOST}`)
-        .get(`${API_PATH}settings`)
-        .reply(200, {
-          replyCode: 0,
-          replyText: 'OK',
-          data: {
-            id: 123456,
-            environment: 'suitex.emarys.net',
-            timezone: 'Europe/Vienna',
-            name: 'segment_test_account',
-            password_history_queue_size: 3,
-            country: '',
-            totalContacts: '1319053'
-          }
-        })
+      nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
 
-      // This should match your authentication.fields
       const authData = {
-        api_user: 'test001',
-        api_password: 'test_secret'
+        apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+        apiBaseUrl: 'https://api.example.com/api/',
+        apiClientId: 'testclient',
+        apiClientSecret: 'supersecret'
       }
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()

--- a/packages/destination-actions/src/destinations/emarsys/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/__tests__/snapshot.test.ts
@@ -6,23 +6,37 @@ import nock from 'nock'
 const testDestination = createTestIntegration(destination)
 const destinationSlug = 'actions-emarsys'
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
+const settingsData = {
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
+}
+
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
     it(`${actionSlug} action - required fields`, async () => {
       const seedName = `${destinationSlug}#${actionSlug}`
       const action = destination.actions[actionSlug]
-      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+      const [eventData] = generateTestData(seedName, destination, action, true)
 
+      nock(AUTH_HOST)
+        .persist()
+        .post(AUTH_PATH)
+        .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
       nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
       nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
       nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-      const event = createTestEvent({
-        properties: eventData
-      })
+      const event = createTestEvent({ properties: eventData })
 
       const responses = await testDestination.testAction(actionSlug, {
-        event: event,
+        event,
         mapping: event.properties,
         settings: settingsData,
         auth: undefined
@@ -45,18 +59,20 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
     it(`${actionSlug} action - all fields`, async () => {
       const seedName = `${destinationSlug}#${actionSlug}`
       const action = destination.actions[actionSlug]
-      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+      const [eventData] = generateTestData(seedName, destination, action, false)
 
+      nock(AUTH_HOST)
+        .persist()
+        .post(AUTH_PATH)
+        .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
       nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
       nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
       nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-      const event = createTestEvent({
-        properties: eventData
-      })
+      const event = createTestEvent({ properties: eventData })
 
       const responses = await testDestination.testAction(actionSlug, {
-        event: event,
+        event,
         mapping: event.properties,
         settings: settingsData,
         auth: undefined

--- a/packages/destination-actions/src/destinations/emarsys/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/__tests__/snapshot.test.ts
@@ -2,6 +2,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../lib/test-data'
 import destination from '../index'
 import nock from 'nock'
+import { tokenCache } from '../emarsys-helper'
 
 const testDestination = createTestIntegration(destination)
 const destinationSlug = 'actions-emarsys'
@@ -18,6 +19,11 @@ const settingsData = {
   apiClientSecret: 'supersecret'
 }
 
+beforeEach(() => {
+  nock.cleanAll()
+  tokenCache.clear()
+})
+
 describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
   for (const actionSlug in destination.actions) {
     it(`${actionSlug} action - required fields`, async () => {
@@ -25,13 +31,10 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData] = generateTestData(seedName, destination, action, true)
 
-      nock(AUTH_HOST)
-        .persist()
-        .post(AUTH_PATH)
-        .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-      nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-      nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-      nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+      nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+      nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+      nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+      nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
       const event = createTestEvent({ properties: eventData })
 
@@ -42,8 +45,9 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         auth: undefined
       })
 
-      const request = responses[0].request
-      const rawBody = await request.text()
+      const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+      if (!apiResponse) throw new Error('No Emarsys API response found')
+      const rawBody = await apiResponse.request.text()
 
       try {
         const json = JSON.parse(rawBody)
@@ -53,7 +57,7 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         expect(rawBody).toMatchSnapshot()
       }
 
-      expect(request.headers).toMatchSnapshot()
+      expect(Object.fromEntries(apiResponse.request.headers)).toMatchSnapshot()
     })
 
     it(`${actionSlug} action - all fields`, async () => {
@@ -61,13 +65,10 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
       const action = destination.actions[actionSlug]
       const [eventData] = generateTestData(seedName, destination, action, false)
 
-      nock(AUTH_HOST)
-        .persist()
-        .post(AUTH_PATH)
-        .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-      nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-      nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-      nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+      nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+      nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+      nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+      nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
       const event = createTestEvent({ properties: eventData })
 
@@ -78,8 +79,9 @@ describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
         auth: undefined
       })
 
-      const request = responses[0].request
-      const rawBody = await request.text()
+      const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+      if (!apiResponse) throw new Error('No Emarsys API response found')
+      const rawBody = await apiResponse.request.text()
 
       try {
         const json = JSON.parse(rawBody)

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -9,11 +9,23 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for Emarsys's addToContactList destination action: required fields 1`] = `
-Object {
-  "external_ids": Array [
-    "RIiSIeEZflwbfBVGmj@^",
-  ],
-  "key_id": "RIiSIeEZflwbfBVGmj@^",
+exports[`Testing snapshot for Emarsys's addToContactList destination action: required fields 1`] = `"grant_type=client_credentials"`;
+
+exports[`Testing snapshot for Emarsys's addToContactList destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "Content-Type": Array [
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    ],
+    "accept": Array [
+      "application/json",
+    ],
+    "authorization": Array [
+      "Basic dGVzdGNsaWVudDpzdXBlcnNlY3JldA==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/index.test.ts
@@ -1,25 +1,32 @@
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration, RetryableError } from '@segment/actions-core'
 import Destination from '../../index'
-import { API_HOST, API_PATH } from '../../emarsys-helper'
-import { RetryableError } from '@segment/actions-core'
-// import { IntegrationError } from '@segment/actions-core'
-// import { RetryableError } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(Destination)
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
 const SETTINGS = {
-  api_user: 'testuser001',
-  api_password: 'supersecret'
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
 }
 
 const TESTPAYLOAD = {
   contactlistid: 1234567890,
-  key_field: 3,
+  key_field: '3',
   key_value: 'tester@emarsys.com'
 }
 
-const regex = new RegExp(`${API_PATH}contactlist/-*\\d+/add$`, 'g')
+const regex = new RegExp(`${API_BASE_PATH}contactlist/\\d+/add$`, 'g')
+
+function mockAuth() {
+  nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+}
 
 beforeEach(() => {
   nock.cleanAll()
@@ -27,6 +34,7 @@ beforeEach(() => {
 
 describe('Emarsys.addToContactList', () => {
   it('should throw an error if the key_value is empty', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(
@@ -55,6 +63,7 @@ describe('Emarsys.addToContactList', () => {
   })
 
   it('should throw an RetryableError if the API responds with a server error', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(500, 'Internal server error')
     await expect(
       testDestination.testAction('addToContactList', {
@@ -65,6 +74,7 @@ describe('Emarsys.addToContactList', () => {
   })
 
   it('should throw an RetryableError if the rate limit was reached', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(429, 'Too many requests')
     await expect(
       testDestination.testAction('addToContactList', {
@@ -75,6 +85,7 @@ describe('Emarsys.addToContactList', () => {
   })
 
   it('should get a replyCode=0', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/snapshot.test.ts
@@ -8,11 +8,27 @@ const actionSlug = 'addToContactList'
 const destinationSlug = 'Emarsys'
 const seedName = `${destinationSlug}#${actionSlug}`
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    const [eventData] = generateTestData(seedName, destination, action, true)
 
+    const settingsData = {
+      apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+      apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+      apiClientId: 'testclient',
+      apiClientSecret: 'supersecret'
+    }
+
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
@@ -44,8 +60,19 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    const [eventData] = generateTestData(seedName, destination, action, false)
 
+    const settingsData = {
+      apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+      apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+      apiClientId: 'testclient',
+      apiClientSecret: 'supersecret'
+    }
+
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/__tests__/snapshot.test.ts
@@ -2,6 +2,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
 import nock from 'nock'
+import { tokenCache } from '../../emarsys-helper'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'addToContactList'
@@ -13,39 +14,40 @@ const AUTH_PATH = '/oauth/token'
 const API_HOST = 'https://api.example.com'
 const API_BASE_PATH = '/api/'
 
+const settingsData = {
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
+}
+
+beforeEach(() => {
+  nock.cleanAll()
+  tokenCache.clear()
+})
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, true)
 
-    const settingsData = {
-      apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
-      apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
-      apiClientId: 'testclient',
-      apiClientSecret: 'supersecret'
-    }
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
-
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)
@@ -55,41 +57,30 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       expect(rawBody).toMatchSnapshot()
     }
 
-    expect(request.headers).toMatchSnapshot()
+    expect(Object.fromEntries(apiResponse.request.headers)).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, false)
 
-    const settingsData = {
-      apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
-      apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
-      apiClientId: 'testclient',
-      apiClientSecret: 'supersecret'
-    }
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
-
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import {
   getContactLists,
   getFields,
-  API_BASE,
+  getAuthHeader,
   ContactListApiPayload,
   BufferBatchContactList,
   BufferBatchContactListItem
@@ -37,24 +37,26 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   dynamicFields: {
-    contactlistid: async (request) => {
-      return getContactLists(request)
+    contactlistid: async (request, data) => {
+      return getContactLists(request, data.settings)
     },
-    key_field: async (request) => {
-      return getFields(request)
+    key_field: async (request, data) => {
+      return getFields(request, data.settings)
     }
   },
   perform: async (request, data) => {
     data.payload.contactlistid = parseInt(data.payload.contactlistid.toString().replace(/[^0-9]/g, ''))
 
     if (data.payload.contactlistid > 0) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const payload: ContactListApiPayload = {
         key_id: data.payload.key_field,
         external_ids: [data.payload.key_value]
       }
-      const response = await request(`${API_BASE}contactlist/${data.payload.contactlistid}/add`, {
+      const response = await request(`${data.settings.apiBaseUrl}contactlist/${data.payload.contactlistid}/add`, {
         method: 'post',
         json: payload,
+        headers: authHeader,
         throwHttpErrors: false
       })
 
@@ -84,6 +86,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, data) => {
     if (data && data.payload && Array.isArray(data.payload)) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const batches: BufferBatchContactList = {}
       data.payload.forEach((payload: Payload) => {
         if (!batches[`${payload.contactlistid}-${payload.key_field}`]) {
@@ -105,9 +108,10 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           external_ids: batch.external_ids
         }
-        const response = request(`${API_BASE}contactlist/${batch.contactlistid}/add`, {
+        const response = request(`${data.settings.apiBaseUrl}contactlist/${batch.contactlistid}/add`, {
           method: 'post',
           json: payload,
+          headers: authHeader,
           throwHttpErrors: true
         })
         requests.push(response)

--- a/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/addToContactList/index.ts
@@ -5,6 +5,7 @@ import {
   getContactLists,
   getFields,
   getAuthHeader,
+  getApiBaseUrl,
   ContactListApiPayload,
   BufferBatchContactList,
   BufferBatchContactListItem
@@ -53,7 +54,7 @@ const action: ActionDefinition<Settings, Payload> = {
         key_id: data.payload.key_field,
         external_ids: [data.payload.key_value]
       }
-      const response = await request(`${data.settings.apiBaseUrl}contactlist/${data.payload.contactlistid}/add`, {
+      const response = await request(`${getApiBaseUrl(data.settings)}contactlist/${data.payload.contactlistid}/add`, {
         method: 'post',
         json: payload,
         headers: authHeader,
@@ -108,7 +109,7 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           external_ids: batch.external_ids
         }
-        const response = request(`${data.settings.apiBaseUrl}contactlist/${batch.contactlistid}/add`, {
+        const response = request(`${getApiBaseUrl(data.settings)}contactlist/${batch.contactlistid}/add`, {
           method: 'post',
           json: payload,
           headers: authHeader,

--- a/packages/destination-actions/src/destinations/emarsys/auth.ts
+++ b/packages/destination-actions/src/destinations/emarsys/auth.ts
@@ -1,0 +1,39 @@
+import { RequestClient } from '@segment/actions-core'
+
+export interface AccessTokenResponse {
+  token_type: string
+  access_token: string
+  expires_in: number
+}
+
+export interface AccessTokenResult {
+  accessToken: string
+  expiresIn: number
+}
+
+export default async function getAccessToken(
+  request: RequestClient,
+  apiAuthEndpoint: string,
+  apiClientId: string,
+  apiClientSecret: string
+): Promise<AccessTokenResult> {
+  const requestPayload = {
+    grant_type: 'client_credentials'
+  }
+
+  const requestHeaders = {
+    Authorization: `Basic ${Buffer.from(`${apiClientId}:${apiClientSecret}`).toString('base64')}`,
+    Accept: 'application/json'
+  }
+
+  const res = await request<AccessTokenResponse>(apiAuthEndpoint, {
+    method: 'POST',
+    body: new URLSearchParams(requestPayload),
+    headers: requestHeaders
+  })
+
+  return {
+    accessToken: res.data.access_token,
+    expiresIn: res.data.expires_in
+  }
+}

--- a/packages/destination-actions/src/destinations/emarsys/auth.ts
+++ b/packages/destination-actions/src/destinations/emarsys/auth.ts
@@ -1,9 +1,10 @@
 import { RequestClient } from '@segment/actions-core'
+import { IntegrationError } from '@segment/actions-core'
 
 export interface AccessTokenResponse {
   token_type: string
-  access_token: string
-  expires_in: number
+  access_token?: string
+  expires_in?: number
 }
 
 export interface AccessTokenResult {
@@ -32,8 +33,12 @@ export default async function getAccessToken(
     headers: requestHeaders
   })
 
+  if (!res.data.access_token) {
+    throw new IntegrationError('Authentication failed: no access token in response', 'INVALID_AUTH_RESPONSE', 401)
+  }
+
   return {
     accessToken: res.data.access_token,
-    expiresIn: res.data.expires_in
+    expiresIn: res.data.expires_in ?? 3600
   }
 }

--- a/packages/destination-actions/src/destinations/emarsys/constants.ts
+++ b/packages/destination-actions/src/destinations/emarsys/constants.ts
@@ -1,0 +1,1 @@
+export const USER_AGENT_HEADER = 'segment-destination/1.0'

--- a/packages/destination-actions/src/destinations/emarsys/constants.ts
+++ b/packages/destination-actions/src/destinations/emarsys/constants.ts
@@ -1,1 +1,1 @@
-export const USER_AGENT_HEADER = 'segment-destination/1.0'
+export const USER_AGENT_HEADER = 'segmentio-emarsys/1.5'

--- a/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
+++ b/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
@@ -1,12 +1,43 @@
 import type { Settings } from './generated-types'
 import type { RequestClient } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
-// eslint-disable-next-line no-restricted-syntax
-import { randomBytes, createHash } from 'crypto'
+import getAccessToken from './auth'
 
-export const API_HOST = 'https://api.emarsys.net'
-export const API_PATH = '/api/v2/'
-export const API_BASE = `${API_HOST}${API_PATH}`
+interface CachedToken {
+  accessToken: string
+  expiresAt: number // Unix timestamp in ms
+}
+
+const tokenCache = new Map<string, CachedToken>()
+const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000 // 60 seconds
+
+function getCacheKey(settings: Settings): string {
+  return `${settings.apiAuthEndpoint}::${settings.apiClientId}`
+}
+
+export const getAuthHeader = async (request: RequestClient, settings: Settings): Promise<{ Authorization: string }> => {
+  const cacheKey = getCacheKey(settings)
+  const cached = tokenCache.get(cacheKey)
+  const now = Date.now()
+
+  if (cached && cached.expiresAt - now > TOKEN_EXPIRY_BUFFER_MS) {
+    return { Authorization: `Bearer ${cached.accessToken}` }
+  }
+
+  const { accessToken, expiresIn } = await getAccessToken(
+    request,
+    settings.apiAuthEndpoint,
+    settings.apiClientId,
+    settings.apiClientSecret
+  )
+
+  tokenCache.set(cacheKey, {
+    accessToken,
+    expiresAt: now + expiresIn * 1000
+  })
+
+  return { Authorization: `Bearer ${accessToken}` }
+}
 
 /**
  * Types triggerEvent
@@ -82,40 +113,9 @@ export interface ContactsApiPayload {
   contacts: ContactData[]
 }
 
-export const createWsseHeader = (settings: Settings): string => {
-  const nonce = randomBytes(16).toString('hex')
-  const hash = createHash('sha1')
-  const ts = new Date().toISOString()
-  const secret = nonce + ts + settings.api_password
-  const secret_hash = Buffer.from(hash.update(secret).digest('hex')).toString('base64')
-  const auth_header = `UsernameToken Username="${settings.api_user}", PasswordDigest="${secret_hash}", Nonce="${nonce}", Created="${ts}"`
-  return auth_header
-}
-
-export const getEvents = async (request: RequestClient): Promise<DynamicFieldResponse> => {
-  const data = await request(`${API_BASE}event`)
-  const choices = []
-  if (data && data.content) {
-    const api_data = JSON.parse(data.content)
-    if (api_data && api_data.replyCode !== undefined && api_data.replyCode == 0) {
-      if (api_data.data && Array.isArray(api_data.data) && api_data.data.length > 0) {
-        for (let a = 0; a < api_data.data.length; a++) {
-          choices.push({
-            label: api_data.data[a].name,
-            value: api_data.data[a].id
-          })
-        }
-      }
-    }
-  }
-  const events = {
-    choices: choices
-  }
-  return events
-}
-
-export const getFields = async (request: RequestClient): Promise<DynamicFieldResponse> => {
-  const data = await request(`${API_BASE}field/translate/en`)
+export const getEvents = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
+  const authHeader = await getAuthHeader(request, settings)
+  const data = await request(`${settings.apiBaseUrl}event`, { headers: authHeader })
   const choices = []
   if (data && data.content) {
     const api_data = JSON.parse(data.content)
@@ -136,8 +136,14 @@ export const getFields = async (request: RequestClient): Promise<DynamicFieldRes
   return fields
 }
 
-export const getContactLists = async (request: RequestClient): Promise<DynamicFieldResponse> => {
-  const data = await request(`${API_BASE}contactlist`)
+export const getFields = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
+  const authHeader = await getAuthHeader(request, settings)
+  let data
+  try {
+    data = await request(`${settings.apiBaseUrl}field/translate/en`, { headers: authHeader })
+  } catch (err) {
+    return { choices: [] }
+  }
   const choices = []
   if (data && data.content) {
     const api_data = JSON.parse(data.content)
@@ -152,8 +158,31 @@ export const getContactLists = async (request: RequestClient): Promise<DynamicFi
       }
     }
   }
-  const lists = {
+  const fields = {
     choices: choices
   }
-  return lists
+  return fields
+}
+
+export const getContactLists = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
+  const authHeader = await getAuthHeader(request, settings)
+  const data = await request(`${settings.apiBaseUrl}contactlist`, { headers: authHeader })
+  const choices = []
+  if (data && data.content) {
+    const api_data = JSON.parse(data.content)
+    if (api_data && api_data.replyCode !== undefined && api_data.replyCode == 0) {
+      if (api_data.data && Array.isArray(api_data.data) && api_data.data.length > 0) {
+        for (let a = 0; a < api_data.data.length; a++) {
+          choices.push({
+            label: api_data.data[a].name,
+            value: api_data.data[a].id
+          })
+        }
+      }
+    }
+  }
+  const fields = {
+    choices: choices
+  }
+  return fields
 }

--- a/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
+++ b/packages/destination-actions/src/destinations/emarsys/emarsys-helper.ts
@@ -1,34 +1,77 @@
+import { IntegrationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import type { RequestClient } from '@segment/actions-core'
 import { DynamicFieldResponse } from '@segment/actions-core'
 import getAccessToken from './auth'
+import { randomBytes } from 'crypto'
+import { processHashing } from '../../lib/hashing-utils'
+
+export const LEGACY_API_BASE = 'https://api.emarsys.net/api/v2/'
 
 interface CachedToken {
   accessToken: string
   expiresAt: number // Unix timestamp in ms
 }
 
-const tokenCache = new Map<string, CachedToken>()
+export const tokenCache = new Map<string, CachedToken>()
 const TOKEN_EXPIRY_BUFFER_MS = 60 * 1000 // 60 seconds
 
 function getCacheKey(settings: Settings): string {
   return `${settings.apiAuthEndpoint}::${settings.apiClientId}`
 }
 
-export const getAuthHeader = async (request: RequestClient, settings: Settings): Promise<{ Authorization: string }> => {
+export const isLegacyAuth = (settings: Settings): boolean => {
+  return Boolean(settings.api_user && settings.api_password)
+}
+
+export const getApiBaseUrl = (settings: Settings): string => {
+  if (isLegacyAuth(settings)) return LEGACY_API_BASE
+  if (!settings.apiBaseUrl) {
+    throw new IntegrationError('API base URL is required', 'MISSING_API_BASE_URL', 400)
+  }
+  return settings.apiBaseUrl.endsWith('/') ? settings.apiBaseUrl : `${settings.apiBaseUrl}/`
+}
+
+export const createWsseHeader = (settings: Settings): string => {
+  if (!settings.api_user || !settings.api_password) {
+    throw new IntegrationError('Username and password must be specified.', 'MISSING_CREDENTIALS', 400)
+  }
+  const nonce = randomBytes(16).toString('hex')
+  const ts = new Date().toISOString()
+  const secret = nonce + ts + settings.api_password
+  const secretHex = processHashing(secret, 'sha1', 'hex')
+  const secret_hash = Buffer.from(secretHex, 'utf8').toString('base64')
+  return `UsernameToken Username="${settings.api_user}", PasswordDigest="${secret_hash}", Nonce="${nonce}", Created="${ts}"`
+}
+
+export const getAuthHeader = async (
+  request: RequestClient,
+  settings: Settings
+): Promise<{ Authorization: string } | { 'X-WSSE': string }> => {
+  if (isLegacyAuth(settings)) {
+    return { 'X-WSSE': createWsseHeader(settings) }
+  }
+
   const cacheKey = getCacheKey(settings)
   const cached = tokenCache.get(cacheKey)
   const now = Date.now()
 
-  if (cached && cached.expiresAt - now > TOKEN_EXPIRY_BUFFER_MS) {
-    return { Authorization: `Bearer ${cached.accessToken}` }
+  if (cached) {
+    if (cached.expiresAt - now > TOKEN_EXPIRY_BUFFER_MS) {
+      return { Authorization: `Bearer ${cached.accessToken}` }
+    }
+    tokenCache.delete(cacheKey)
+  }
+
+  if (!settings.apiAuthEndpoint) {
+    throw new IntegrationError('Auth endpoint is required', 'MISSING_AUTH_ENDPOINT', 400)
   }
 
   const { accessToken, expiresIn } = await getAccessToken(
     request,
-    settings.apiAuthEndpoint,
-    settings.apiClientId,
-    settings.apiClientSecret
+    settings.apiAuthEndpoint.replace(/\/$/, ''),
+    settings.apiClientId as string,
+    settings.apiClientSecret as string
   )
 
   tokenCache.set(cacheKey, {
@@ -115,7 +158,7 @@ export interface ContactsApiPayload {
 
 export const getEvents = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
   const authHeader = await getAuthHeader(request, settings)
-  const data = await request(`${settings.apiBaseUrl}event`, { headers: authHeader })
+  const data = await request(`${getApiBaseUrl(settings)}event`, { headers: authHeader })
   const choices = []
   if (data && data.content) {
     const api_data = JSON.parse(data.content)
@@ -140,7 +183,7 @@ export const getFields = async (request: RequestClient, settings: Settings): Pro
   const authHeader = await getAuthHeader(request, settings)
   let data
   try {
-    data = await request(`${settings.apiBaseUrl}field/translate/en`, { headers: authHeader })
+    data = await request(`${getApiBaseUrl(settings)}field/translate/en`, { headers: authHeader })
   } catch (err) {
     return { choices: [] }
   }
@@ -166,7 +209,7 @@ export const getFields = async (request: RequestClient, settings: Settings): Pro
 
 export const getContactLists = async (request: RequestClient, settings: Settings): Promise<DynamicFieldResponse> => {
   const authHeader = await getAuthHeader(request, settings)
-  const data = await request(`${settings.apiBaseUrl}contactlist`, { headers: authHeader })
+  const data = await request(`${getApiBaseUrl(settings)}contactlist`, { headers: authHeader })
   const choices = []
   if (data && data.content) {
     const api_data = JSON.parse(data.content)

--- a/packages/destination-actions/src/destinations/emarsys/generated-types.ts
+++ b/packages/destination-actions/src/destinations/emarsys/generated-types.ts
@@ -2,11 +2,19 @@
 
 export interface Settings {
   /**
-   * Your Emarsys API username
+   * Authentication endpoint URL
    */
-  api_user: string
+  apiAuthEndpoint: string
   /**
-   * Your Emarsys API password.
+   * The base URL for API requests
    */
-  api_password: string
+  apiBaseUrl: string
+  /**
+   * The ClientId for API authentication
+   */
+  apiClientId: string
+  /**
+   * The Client Secret for API authentication
+   */
+  apiClientSecret: string
 }

--- a/packages/destination-actions/src/destinations/emarsys/generated-types.ts
+++ b/packages/destination-actions/src/destinations/emarsys/generated-types.ts
@@ -2,19 +2,27 @@
 
 export interface Settings {
   /**
-   * Authentication endpoint URL
+   * Your Emarsys API username. Set this together with API password to use legacy X-WSSE authentication against the v2 API.
    */
-  apiAuthEndpoint: string
+  api_user?: string
   /**
-   * The base URL for API requests
+   * Your Emarsys API password. Set this together with API username to use legacy X-WSSE authentication against the v2 API.
    */
-  apiBaseUrl: string
+  api_password?: string
   /**
-   * The ClientId for API authentication
+   * Authentication endpoint URL. Required when not using legacy API username/password.
    */
-  apiClientId: string
+  apiAuthEndpoint?: string
   /**
-   * The Client Secret for API authentication
+   * The base URL for API requests. Required when not using legacy API username/password.
    */
-  apiClientSecret: string
+  apiBaseUrl?: string
+  /**
+   * The ClientId for API authentication. Required when not using legacy API username/password.
+   */
+  apiClientId?: string
+  /**
+   * The Client Secret for API authentication. Required when not using legacy API username/password.
+   */
+  apiClientSecret?: string
 }

--- a/packages/destination-actions/src/destinations/emarsys/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/index.ts
@@ -4,7 +4,7 @@ import addToContactList from './addToContactList'
 import removeFromContactList from './removeFromContactList'
 import triggerEvent from './triggerEvent'
 import upsertContact from './upsertContact'
-import { createWsseHeader, API_BASE } from './emarsys-helper'
+import getAccessToken from './auth'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Emarsys (Actions)',
@@ -14,32 +14,49 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'custom',
     fields: {
-      api_user: {
-        label: 'API username',
-        description: 'Your Emarsys API username',
+      apiAuthEndpoint: {
+        label: 'Auth endpoint',
+        description: 'Authentication endpoint URL',
+        type: 'string',
+        required: true,
+        default: 'https://auth.emarsys.net/oauth2/token'
+      },
+      apiBaseUrl: {
+        label: 'API base URL',
+        description: 'The base URL for API requests',
+        type: 'string',
+        required: true,
+        default: 'https://api.emarsys.net/api/v3/'
+      },
+      apiClientId: {
+        label: 'API ClientId',
+        description: 'The ClientId for API authentication',
         type: 'string',
         required: true
       },
-      api_password: {
-        label: 'API password',
-        description: 'Your Emarsys API password.',
+      apiClientSecret: {
+        label: 'API Client Secret',
+        description: 'The Client Secret for API authentication',
         type: 'password',
         required: true
       }
     },
-    testAuthentication: async (request) => {
-      const data = await request(`${API_BASE}settings`)
-      if (data && data.content) {
-        const api_data = JSON.parse(data.content)
-        if (api_data && api_data.replyCode !== undefined && api_data.replyCode == 0) {
-          if (api_data.data && api_data.data.id) {
-            if (api_data.data.id > 0) {
-              return true
-            }
-          }
-        }
+    testAuthentication: async (request, { settings }) => {
+      if (!settings.apiAuthEndpoint) {
+        throw new Error('The authentication endpoint URL is required')
       }
-      throw new Error('Authentication failed')
+      if (!settings.apiBaseUrl) {
+        throw new Error('The base URL is required')
+      }
+      const { accessToken } = await getAccessToken(
+        request,
+        settings.apiAuthEndpoint,
+        settings.apiClientId,
+        settings.apiClientSecret
+      )
+      if (!accessToken) {
+        throw new Error('Authentication failed')
+      }
     }
   },
 
@@ -48,13 +65,6 @@ const destination: DestinationDefinition<Settings> = {
     addToContactList,
     removeFromContactList,
     triggerEvent
-  },
-
-  extendRequest: ({ settings }) => {
-    return {
-      headers: { 'X-WSSE': createWsseHeader(settings) },
-      responseType: 'json'
-    }
   }
 }
 

--- a/packages/destination-actions/src/destinations/emarsys/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/index.ts
@@ -5,6 +5,8 @@ import removeFromContactList from './removeFromContactList'
 import triggerEvent from './triggerEvent'
 import upsertContact from './upsertContact'
 import getAccessToken from './auth'
+import { isLegacyAuth, createWsseHeader, LEGACY_API_BASE } from './emarsys-helper'
+import { USER_AGENT_HEADER } from './constants'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Emarsys (Actions)',
@@ -14,49 +16,79 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'custom',
     fields: {
+      api_user: {
+        label: 'API username (legacy)',
+        description:
+          'Your Emarsys API username. Set this together with API password to use legacy X-WSSE authentication against the v2 API.',
+        type: 'string',
+        required: false
+      },
+      api_password: {
+        label: 'API password (legacy)',
+        description:
+          'Your Emarsys API password. Set this together with API username to use legacy X-WSSE authentication against the v2 API.',
+        type: 'password',
+        required: false
+      },
       apiAuthEndpoint: {
         label: 'Auth endpoint',
-        description: 'Authentication endpoint URL',
+        description: 'Authentication endpoint URL. Required when not using legacy API username/password.',
         type: 'string',
-        required: true,
+        format: 'uri',
+        required: false,
         default: 'https://auth.emarsys.net/oauth2/token'
       },
       apiBaseUrl: {
         label: 'API base URL',
-        description: 'The base URL for API requests',
+        description: 'The base URL for API requests. Required when not using legacy API username/password.',
         type: 'string',
-        required: true,
+        format: 'uri',
+        required: false,
         default: 'https://api.emarsys.net/api/v3/'
       },
       apiClientId: {
         label: 'API ClientId',
-        description: 'The ClientId for API authentication',
+        description: 'The ClientId for API authentication. Required when not using legacy API username/password.',
         type: 'string',
-        required: true
+        required: false
       },
       apiClientSecret: {
         label: 'API Client Secret',
-        description: 'The Client Secret for API authentication',
+        description: 'The Client Secret for API authentication. Required when not using legacy API username/password.',
         type: 'password',
-        required: true
+        required: false
       }
     },
     testAuthentication: async (request, { settings }) => {
+      if (isLegacyAuth(settings)) {
+        const wsseHeader = createWsseHeader(settings)
+        const data = await request(`${LEGACY_API_BASE}settings`, {
+          headers: { 'X-WSSE': wsseHeader }
+        })
+        if (data && data.content) {
+          const api_data = JSON.parse(data.content)
+          if (api_data?.replyCode === 0 && api_data?.data?.id > 0) {
+            return true
+          }
+        }
+        throw new Error('Authentication failed')
+      }
+
       if (!settings.apiAuthEndpoint) {
         throw new Error('The authentication endpoint URL is required')
       }
       if (!settings.apiBaseUrl) {
         throw new Error('The base URL is required')
       }
-      const { accessToken } = await getAccessToken(
+      if (!settings.apiClientId || !settings.apiClientSecret) {
+        throw new Error('Either legacy API username/password or OIDC client credentials are required')
+      }
+      await getAccessToken(
         request,
-        settings.apiAuthEndpoint,
+        settings.apiAuthEndpoint.replace(/\/$/, ''),
         settings.apiClientId,
         settings.apiClientSecret
       )
-      if (!accessToken) {
-        throw new Error('Authentication failed')
-      }
     }
   },
 
@@ -65,6 +97,12 @@ const destination: DestinationDefinition<Settings> = {
     addToContactList,
     removeFromContactList,
     triggerEvent
+  },
+
+  extendRequest: () => {
+    return {
+      headers: { 'User-Agent': USER_AGENT_HEADER }
+    }
   }
 }
 

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,12 +10,23 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for Emarsys's removeFromContactList destination action: required fields 1`] = `
-Object {
-  "contactlistid": 2204312625217536,
-  "external_ids": Array [
-    "cc%KG4p)Ar0bgD",
-  ],
-  "key_id": "cc%KG4p)Ar0bgD",
+exports[`Testing snapshot for Emarsys's removeFromContactList destination action: required fields 1`] = `"grant_type=client_credentials"`;
+
+exports[`Testing snapshot for Emarsys's removeFromContactList destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "Content-Type": Array [
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    ],
+    "accept": Array [
+      "application/json",
+    ],
+    "authorization": Array [
+      "Basic dGVzdGNsaWVudDpzdXBlcnNlY3JldA==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/index.test.ts
@@ -1,24 +1,32 @@
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
-import { API_HOST, API_PATH } from '../../emarsys-helper'
+import { createTestIntegration, RetryableError } from '@segment/actions-core'
 import Destination from '../../index'
-import { RetryableError } from '@segment/actions-core'
-// import { IntegrationError } from '@segment/actions-core'
-// import { RetryableError } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(Destination)
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
 const SETTINGS = {
-  api_user: 'testuser001',
-  api_password: 'supersecret'
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
 }
+
 const TESTPAYLOAD = {
   contactlistid: 1234567890,
-  key_field: 3,
+  key_field: '3',
   key_value: 'tester@emarsys.com'
 }
 
-const regex = new RegExp(`${API_PATH}contactlist/[0-9]+/delete`, 'g')
+const regex = new RegExp(`${API_BASE_PATH}contactlist/[0-9]+/delete`, 'g')
+
+function mockAuth() {
+  nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+}
 
 beforeEach(() => {
   nock.cleanAll()
@@ -26,6 +34,7 @@ beforeEach(() => {
 
 describe('Emarsys.removeFromContactList', () => {
   it('should get an error because of missing key value', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(
@@ -54,6 +63,7 @@ describe('Emarsys.removeFromContactList', () => {
   })
 
   it('should throw an RetryableError if the API responds with a server error', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(500, 'Internal server error')
     await expect(
       testDestination.testAction('removeFromContactList', {
@@ -64,6 +74,7 @@ describe('Emarsys.removeFromContactList', () => {
   })
 
   it('should throw an RetryableError if the rate limit was reached', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(429, 'Too many requests')
     await expect(
       testDestination.testAction('removeFromContactList', {
@@ -74,6 +85,7 @@ describe('Emarsys.removeFromContactList', () => {
   })
 
   it('should get a replyCode=0', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/snapshot.test.ts
@@ -8,21 +8,35 @@ const actionSlug = 'removeFromContactList'
 const destinationSlug = 'Emarsys'
 const seedName = `${destinationSlug}#${actionSlug}`
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
+const settingsData = {
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
+}
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    const [eventData] = generateTestData(seedName, destination, action, true)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
@@ -44,18 +58,20 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    const [eventData] = generateTestData(seedName, destination, action, false)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/__tests__/snapshot.test.ts
@@ -2,6 +2,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
 import nock from 'nock'
+import { tokenCache } from '../../emarsys-helper'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'removeFromContactList'
@@ -20,18 +21,20 @@ const settingsData = {
   apiClientSecret: 'supersecret'
 }
 
+beforeEach(() => {
+  nock.cleanAll()
+  tokenCache.clear()
+})
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, true)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -42,8 +45,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)
@@ -53,20 +57,17 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       expect(rawBody).toMatchSnapshot()
     }
 
-    expect(request.headers).toMatchSnapshot()
+    expect(Object.fromEntries(apiResponse.request.headers)).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, false)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -77,8 +78,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import {
   getContactLists,
   getFields,
-  API_BASE,
+  getAuthHeader,
   ContactListApiPayload,
   BufferBatchContactList,
   BufferBatchContactListItem
@@ -37,26 +37,28 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   dynamicFields: {
-    contactlistid: async (request) => {
-      return getContactLists(request)
+    contactlistid: async (request, data) => {
+      return getContactLists(request, data.settings)
     },
-    key_field: async (request) => {
-      return getFields(request)
+    key_field: async (request, data) => {
+      return getFields(request, data.settings)
     }
   },
   perform: async (request, data) => {
     data.payload.contactlistid = parseInt(data.payload.contactlistid.toString().replace(/[^0-9]/g, ''))
 
     if (data.payload.contactlistid > 0) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const payload: ContactListApiPayload = {
         contactlistid: data.payload.contactlistid,
         key_id: data.payload.key_field,
         external_ids: [data.payload.key_value]
       }
 
-      const response = await request(`${API_BASE}contactlist/${data.payload.contactlistid}/delete`, {
+      const response = await request(`${data.settings.apiBaseUrl}contactlist/${data.payload.contactlistid}/delete`, {
         method: 'post',
         json: payload,
+        headers: authHeader,
         throwHttpErrors: false
       })
 
@@ -86,6 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, data) => {
     if (data && data.payload && Array.isArray(data.payload)) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const batches: BufferBatchContactList = {}
       data.payload.forEach((payload: Payload) => {
         if (!batches[`${payload.contactlistid}-${payload.key_field}`]) {
@@ -105,9 +108,10 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           external_ids: batch.external_ids
         }
-        const response = request(`${API_BASE}contactlist/${batch.contactlistid}/delete`, {
+        const response = request(`${data.settings.apiBaseUrl}contactlist/${batch.contactlistid}/delete`, {
           method: 'post',
           json: payload,
+          headers: authHeader,
           throwHttpErrors: false
         })
         requests.push(response)

--- a/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/removeFromContactList/index.ts
@@ -5,6 +5,7 @@ import {
   getContactLists,
   getFields,
   getAuthHeader,
+  getApiBaseUrl,
   ContactListApiPayload,
   BufferBatchContactList,
   BufferBatchContactListItem
@@ -55,12 +56,15 @@ const action: ActionDefinition<Settings, Payload> = {
         external_ids: [data.payload.key_value]
       }
 
-      const response = await request(`${data.settings.apiBaseUrl}contactlist/${data.payload.contactlistid}/delete`, {
-        method: 'post',
-        json: payload,
-        headers: authHeader,
-        throwHttpErrors: false
-      })
+      const response = await request(
+        `${getApiBaseUrl(data.settings)}contactlist/${data.payload.contactlistid}/delete`,
+        {
+          method: 'post',
+          json: payload,
+          headers: authHeader,
+          throwHttpErrors: false
+        }
+      )
 
       switch (response?.status) {
         case 200:
@@ -108,7 +112,7 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           external_ids: batch.external_ids
         }
-        const response = request(`${data.settings.apiBaseUrl}contactlist/${batch.contactlistid}/delete`, {
+        const response = request(`${getApiBaseUrl(data.settings)}contactlist/${batch.contactlistid}/delete`, {
           method: 'post',
           json: payload,
           headers: authHeader,

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -10,10 +10,23 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for Emarsys's triggerEvent destination action: required fields 1`] = `
-Object {
-  "data": null,
-  "external_id": "FoVKp[FQnT",
-  "key_id": "FoVKp[FQnT",
+exports[`Testing snapshot for Emarsys's triggerEvent destination action: required fields 1`] = `"grant_type=client_credentials"`;
+
+exports[`Testing snapshot for Emarsys's triggerEvent destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "Content-Type": Array [
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    ],
+    "accept": Array [
+      "application/json",
+    ],
+    "authorization": Array [
+      "Basic dGVzdGNsaWVudDpzdXBlcnNlY3JldA==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/index.test.ts
@@ -1,16 +1,19 @@
 import nock from 'nock'
-import { APIError, createTestIntegration } from '@segment/actions-core'
+import { APIError, createTestIntegration, RetryableError } from '@segment/actions-core'
 import Destination from '../../index'
-import { API_HOST, API_PATH } from '../../emarsys-helper'
-import { RetryableError } from '@segment/actions-core'
-// import { IntegrationError } from '@segment/actions-core'
-// import { RetryableError } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(Destination)
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
 const SETTINGS = {
-  api_user: 'testuser001',
-  api_password: 'supersecret'
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
 }
 
 const TESTPAYLOAD = {
@@ -22,7 +25,11 @@ const TESTPAYLOAD = {
   }
 }
 
-const regex = new RegExp(`${API_PATH}event/[0-9]+/trigger$`, 'g')
+const regex = new RegExp(`${API_BASE_PATH}event/[0-9]+/trigger$`, 'g')
+
+function mockAuth() {
+  nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+}
 
 beforeEach(() => {
   nock.cleanAll()
@@ -30,6 +37,7 @@ beforeEach(() => {
 
 describe('Emarsys.triggerEvent', () => {
   it('should get a replyCode=0', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(
@@ -55,6 +63,7 @@ describe('Emarsys.triggerEvent', () => {
   })
 
   it('should throw an error because the value in key_field was not found', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .post(regex)
       .reply(
@@ -75,6 +84,7 @@ describe('Emarsys.triggerEvent', () => {
   })
 
   it('should throw an RetryableError if the API responds with a server error', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(500, 'Internal server error')
     await expect(
       testDestination.testAction('triggerEvent', {
@@ -85,6 +95,7 @@ describe('Emarsys.triggerEvent', () => {
   })
 
   it('should throw an RetryableError if the rate limit was reached', async () => {
+    mockAuth()
     nock(`${API_HOST}`).post(regex).reply(429, 'Too many requests')
     await expect(
       testDestination.testAction('triggerEvent', {

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/snapshot.test.ts
@@ -8,21 +8,35 @@ const actionSlug = 'triggerEvent'
 const destinationSlug = 'Emarsys'
 const seedName = `${destinationSlug}#${actionSlug}`
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
+const settingsData = {
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
+}
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    const [eventData] = generateTestData(seedName, destination, action, true)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
@@ -44,18 +58,20 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    const [eventData] = generateTestData(seedName, destination, action, false)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/__tests__/snapshot.test.ts
@@ -2,6 +2,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
 import nock from 'nock'
+import { tokenCache } from '../../emarsys-helper'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'triggerEvent'
@@ -20,18 +21,20 @@ const settingsData = {
   apiClientSecret: 'supersecret'
 }
 
+beforeEach(() => {
+  nock.cleanAll()
+  tokenCache.clear()
+})
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, true)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -42,8 +45,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)
@@ -53,20 +57,17 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       expect(rawBody).toMatchSnapshot()
     }
 
-    expect(request.headers).toMatchSnapshot()
+    expect(Object.fromEntries(apiResponse.request.headers)).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, false)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -77,8 +78,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
@@ -4,7 +4,7 @@ import type { Payload } from './generated-types'
 import {
   getEvents,
   getFields,
-  API_BASE,
+  getAuthHeader,
   BufferBatchTriggerEvent,
   BufferBatchTriggerEventItem,
   TriggerEventData,
@@ -49,26 +49,28 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   dynamicFields: {
-    eventid: async (request) => {
-      return getEvents(request)
+    eventid: async (request, data) => {
+      return getEvents(request, data.settings)
     },
-    key_field: async (request) => {
-      return getFields(request)
+    key_field: async (request, data) => {
+      return getFields(request, data.settings)
     }
   },
   perform: async (request, data) => {
     data.payload.eventid = parseInt(data.payload.eventid.toString().replace(/[^0-9]/g, ''))
 
     if (data.payload.eventid > 0) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const payload: TriggerEventApiPayload = {
         key_id: data.payload.key_field,
         external_id: data.payload.key_value,
         data: <TriggerEventData>data.payload.event_payload ?? null
       }
 
-      const response = await request(`${API_BASE}event/${data.payload.eventid}/trigger`, {
+      const response = await request(`${data.settings.apiBaseUrl}event/${data.payload.eventid}/trigger`, {
         method: 'post',
         json: payload,
+        headers: authHeader,
         throwHttpErrors: false
       })
 
@@ -86,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
             throw new APIError('Invalid JSON response', 400)
           }
         case 400:
-          throw new APIError('The event could not be triggered', 400)
+          throw new APIError('The event could not be triggered (event not connected to a program?)', 400)
         case 429:
           throw new RetryableError('Rate limit reached.')
         default:
@@ -98,6 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, data) => {
     if (data && data.payload && Array.isArray(data.payload)) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const batches: BufferBatchTriggerEvent = {}
       data.payload.forEach((payload: Payload) => {
         if (!batches[`${payload.eventid}-${payload.key_field}`]) {
@@ -120,9 +123,10 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           contacts: batch.keys
         }
-        const response = request(`${API_BASE}event/${batch.event_id}/trigger`, {
+        const response = request(`${data.settings.apiBaseUrl}event/${batch.event_id}/trigger`, {
           method: 'post',
           json: payload,
+          headers: authHeader,
           throwHttpErrors: false
         })
         requests.push(response)

--- a/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/triggerEvent/index.ts
@@ -5,6 +5,7 @@ import {
   getEvents,
   getFields,
   getAuthHeader,
+  getApiBaseUrl,
   BufferBatchTriggerEvent,
   BufferBatchTriggerEventItem,
   TriggerEventData,
@@ -67,7 +68,7 @@ const action: ActionDefinition<Settings, Payload> = {
         data: <TriggerEventData>data.payload.event_payload ?? null
       }
 
-      const response = await request(`${data.settings.apiBaseUrl}event/${data.payload.eventid}/trigger`, {
+      const response = await request(`${getApiBaseUrl(data.settings)}event/${data.payload.eventid}/trigger`, {
         method: 'post',
         json: payload,
         headers: authHeader,
@@ -123,7 +124,7 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           contacts: batch.keys
         }
-        const response = request(`${data.settings.apiBaseUrl}event/${batch.event_id}/trigger`, {
+        const response = request(`${getApiBaseUrl(data.settings)}event/${batch.event_id}/trigger`, {
           method: 'post',
           json: payload,
           headers: authHeader,

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -11,13 +11,23 @@ Object {
 }
 `;
 
-exports[`Testing snapshot for Emarsys's upsertContact destination action: required fields 1`] = `
-Object {
-  "contacts": Array [
-    Object {
-      "UAl@hlNFqwIzyXq": "UAl@hlNFqwIzyXq",
-    },
-  ],
-  "key_id": "UAl@hlNFqwIzyXq",
+exports[`Testing snapshot for Emarsys's upsertContact destination action: required fields 1`] = `"grant_type=client_credentials"`;
+
+exports[`Testing snapshot for Emarsys's upsertContact destination action: required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "Content-Type": Array [
+      "application/x-www-form-urlencoded;charset=UTF-8",
+    ],
+    "accept": Array [
+      "application/json",
+    ],
+    "authorization": Array [
+      "Basic dGVzdGNsaWVudDpzdXBlcnNlY3JldA==",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/index.test.ts
@@ -1,16 +1,19 @@
 import nock from 'nock'
-import { createTestIntegration } from '@segment/actions-core'
+import { createTestIntegration, RetryableError } from '@segment/actions-core'
 import Destination from '../../index'
-import { API_HOST, API_PATH } from '../../emarsys-helper'
-import { RetryableError } from '@segment/actions-core'
-// import { IntegrationError } from '@segment/actions-core'
-// import { RetryableError } from '@segment/actions-core'
 
 const testDestination = createTestIntegration(Destination)
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
 const SETTINGS = {
-  api_user: 'testuser001',
-  api_password: 'supersecret'
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
 }
 
 const TESTPAYLOAD = {
@@ -21,14 +24,19 @@ const TESTPAYLOAD = {
   }
 }
 
+function mockAuth() {
+  nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+}
+
 beforeEach(() => {
   nock.cleanAll()
 })
 
 describe('Emarsys.upsertContact', () => {
-  const regex = new RegExp(`${API_PATH}contact/`, 'g')
+  const regex = new RegExp(`${API_BASE_PATH}contact/`, 'g')
 
   it('should get a replyCode=0', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .put(regex)
       .reply(
@@ -50,6 +58,7 @@ describe('Emarsys.upsertContact', () => {
   })
 
   it('should get an error because of missing key value', async () => {
+    mockAuth()
     nock(`${API_HOST}`)
       .put(regex)
       .reply(
@@ -78,6 +87,7 @@ describe('Emarsys.upsertContact', () => {
   })
 
   it('should throw an RetryableError if the API responds with a server error', async () => {
+    mockAuth()
     nock(`${API_HOST}`).put(regex).reply(500, 'Internal server error')
     await expect(
       testDestination.testAction('upsertContact', {
@@ -88,6 +98,7 @@ describe('Emarsys.upsertContact', () => {
   })
 
   it('should throw an RetryableError if the rate limit was reached', async () => {
+    mockAuth()
     nock(`${API_HOST}`).put(regex).reply(429, 'Too many requests')
     await expect(
       testDestination.testAction('upsertContact', {

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 import { createTestIntegration, RetryableError } from '@segment/actions-core'
 import Destination from '../../index'
+import { tokenCache } from '../../emarsys-helper'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -30,6 +31,7 @@ function mockAuth() {
 
 beforeEach(() => {
   nock.cleanAll()
+  tokenCache.clear()
 })
 
 describe('Emarsys.upsertContact', () => {

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/snapshot.test.ts
@@ -8,21 +8,35 @@ const actionSlug = 'upsertContact'
 const destinationSlug = 'Emarsys'
 const seedName = `${destinationSlug}#${actionSlug}`
 
+const AUTH_HOST = 'https://auth.example.com'
+const AUTH_PATH = '/oauth/token'
+const API_HOST = 'https://api.example.com'
+const API_BASE_PATH = '/api/'
+
+const settingsData = {
+  apiAuthEndpoint: `${AUTH_HOST}${AUTH_PATH}`,
+  apiBaseUrl: `${API_HOST}${API_BASE_PATH}`,
+  apiClientId: 'testclient',
+  apiClientSecret: 'supersecret'
+}
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    const [eventData] = generateTestData(seedName, destination, action, true)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined
@@ -44,18 +58,20 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
-    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    const [eventData] = generateTestData(seedName, destination, action, false)
 
+    nock(AUTH_HOST)
+      .persist()
+      .post(AUTH_PATH)
+      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
     nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
     nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
 
-    const event = createTestEvent({
-      properties: eventData
-    })
+    const event = createTestEvent({ properties: eventData })
 
     const responses = await testDestination.testAction(actionSlug, {
-      event: event,
+      event,
       mapping: event.properties,
       settings: settingsData,
       auth: undefined

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/__tests__/snapshot.test.ts
@@ -2,6 +2,7 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import { generateTestData } from '../../../../lib/test-data'
 import destination from '../../index'
 import nock from 'nock'
+import { tokenCache } from '../../emarsys-helper'
 
 const testDestination = createTestIntegration(destination)
 const actionSlug = 'upsertContact'
@@ -20,18 +21,20 @@ const settingsData = {
   apiClientSecret: 'supersecret'
 }
 
+beforeEach(() => {
+  nock.cleanAll()
+  tokenCache.clear()
+})
+
 describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
   it('required fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, true)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -42,8 +45,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)
@@ -53,20 +57,17 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       expect(rawBody).toMatchSnapshot()
     }
 
-    expect(request.headers).toMatchSnapshot()
+    expect(Object.fromEntries(apiResponse.request.headers)).toMatchSnapshot()
   })
 
   it('all fields', async () => {
     const action = destination.actions[actionSlug]
     const [eventData] = generateTestData(seedName, destination, action, false)
 
-    nock(AUTH_HOST)
-      .persist()
-      .post(AUTH_PATH)
-      .reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
-    nock(/.*/).persist().get(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().post(/.*/).reply(200, { replyCode: 0 })
-    nock(/.*/).persist().put(/.*/).reply(200, { replyCode: 0 })
+    nock(AUTH_HOST).post(AUTH_PATH).reply(200, { token_type: 'Bearer', access_token: 'test-token', expires_in: 3600 })
+    nock(API_HOST).persist().get(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().post(/.*/).reply(200, { replyCode: 0 })
+    nock(API_HOST).persist().put(/.*/).reply(200, { replyCode: 0 })
 
     const event = createTestEvent({ properties: eventData })
 
@@ -77,8 +78,9 @@ describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination ac
       auth: undefined
     })
 
-    const request = responses[0].request
-    const rawBody = await request.text()
+    const apiResponse = responses.find((r) => new URL(r.request.url).host === new URL(API_HOST).host)
+    if (!apiResponse) throw new Error('No Emarsys API response found')
+    const rawBody = await apiResponse.request.text()
 
     try {
       const json = JSON.parse(rawBody)

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import {
   getFields,
-  API_BASE,
+  getAuthHeader,
   ContactData,
   ContactsApiPayload,
   BufferBatchContacts,
@@ -44,11 +44,12 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   dynamicFields: {
-    key_field: async (request) => {
-      return getFields(request)
+    key_field: async (request, data) => {
+      return getFields(request, data.settings)
     }
   },
   perform: async (request, data) => {
+    const authHeader = await getAuthHeader(request, data.settings)
     const contact: ContactData = {}
 
     contact[data.payload.key_field] = data.payload.key_value
@@ -57,9 +58,10 @@ const action: ActionDefinition<Settings, Payload> = {
       key_id: data.payload.key_field,
       contacts: [contact]
     }
-    const response = await request(`${API_BASE}contact/?create_if_not_exists=1`, {
+    const response = await request(`${data.settings.apiBaseUrl}contact/?create_if_not_exists=1`, {
       method: 'put',
       json: payload,
+      headers: authHeader,
       throwHttpErrors: false
     })
 
@@ -83,6 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (request, data) => {
     if (data && data.payload && Array.isArray(data.payload)) {
+      const authHeader = await getAuthHeader(request, data.settings)
       const batches: BufferBatchContacts = {}
       data.payload.forEach((payload: Payload) => {
         if (!batches[`${payload.key_field}`]) {
@@ -104,9 +107,10 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           contacts: batch.contacts
         }
-        const response = request(`${API_BASE}contact/?create_if_not_exists=1`, {
+        const response = request(`${data.settings.apiBaseUrl}contact/?create_if_not_exists=1`, {
           method: 'put',
           json: payload,
+          headers: authHeader,
           throwHttpErrors: false
         })
         requests.push(response)

--- a/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
+++ b/packages/destination-actions/src/destinations/emarsys/upsertContact/index.ts
@@ -4,6 +4,7 @@ import type { Payload } from './generated-types'
 import {
   getFields,
   getAuthHeader,
+  getApiBaseUrl,
   ContactData,
   ContactsApiPayload,
   BufferBatchContacts,
@@ -58,7 +59,7 @@ const action: ActionDefinition<Settings, Payload> = {
       key_id: data.payload.key_field,
       contacts: [contact]
     }
-    const response = await request(`${data.settings.apiBaseUrl}contact/?create_if_not_exists=1`, {
+    const response = await request(`${getApiBaseUrl(data.settings)}contact/?create_if_not_exists=1`, {
       method: 'put',
       json: payload,
       headers: authHeader,
@@ -107,7 +108,7 @@ const action: ActionDefinition<Settings, Payload> = {
           key_id: batch.key_id,
           contacts: batch.contacts
         }
-        const response = request(`${data.settings.apiBaseUrl}contact/?create_if_not_exists=1`, {
+        const response = request(`${getApiBaseUrl(data.settings)}contact/?create_if_not_exists=1`, {
           method: 'put',
           json: payload,
           headers: authHeader,


### PR DESCRIPTION
## Summary 

Updated the connector to use the Emarsys v3 API endpoints (replaced authentication from WSSE to OAuth2)

## Testing

Tested all actions against an Emarsys live account and checked the results in the platform

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] :exclamation: __Breaking change__ :exclamation:  Destination is already live, but new Emarsys API requires other type API credentials
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

