### PR TITLE
STRATCONN-6802 - [Facebook Custom Audiences] - journeys bugfix

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
@@ -6,4 +6,6 @@ export const CANARY_API_VERSION = FACEBOOK_CUSTOM_AUDIENCES_CANARY_API_VERSION
 
 export const FACEBOOK_CUSTOM_AUDIENCE_FLAGON = 'facebook-custom-audience-actions-canary-version'
 
+export const FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON = 'facebook-custom-audience-actions-journeys-support'
+
 export const BASE_URL = 'https://graph.facebook.com'

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
@@ -98,6 +98,16 @@ describe('getJourneysMemberships', () => {
     const result = getJourneysMemberships(rawDatas)
     expect(result).toEqual([true])
   })
+
+  it('returns all true even when properties[computation_key] is a boolean', () => {
+    const rawDatas: RawData[] = [
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: { my_audience: true } },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: { my_audience: false } },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: { my_audience: true } }
+    ]
+    const result = getJourneysMemberships(rawDatas)
+    expect(result).toEqual([true, true, true])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -136,6 +146,77 @@ describe('FacebookCustomAudiences.sync - journey_step with feature flag', () => 
     expect(responses).toBeDefined()
     const successResponses = responses.filter((r: any) => r.status === 200)
     expect(successResponses).toHaveLength(2)
+  })
+
+  it('should not override audienceMemberships when properties[computation_key] is already a boolean', async () => {
+    const events = [
+      createTestEvent({
+        type: 'track',
+        event: 'Journey Step Entered',
+        userId: 'user-1',
+        properties: {
+          email: 'user1@test.com',
+          [AUDIENCE_KEY]: true
+        },
+        context: {
+          personas: {
+            external_audience_id: AUDIENCE_ID,
+            computation_class: 'journey_step',
+            computation_key: AUDIENCE_KEY
+          }
+        }
+      }),
+      createTestEvent({
+        type: 'track',
+        event: 'Journey Step Entered',
+        userId: 'user-2',
+        properties: {
+          email: 'user2@test.com',
+          [AUDIENCE_KEY]: false
+        },
+        context: {
+          personas: {
+            external_audience_id: AUDIENCE_ID,
+            computation_class: 'journey_step',
+            computation_key: AUDIENCE_KEY
+          }
+        }
+      })
+    ]
+
+    const addNock = nock(BASE_URL)
+      .post(new RegExp(`/${AUDIENCE_ID}/users`))
+      .reply(200, {
+        audience_id: AUDIENCE_ID,
+        session_id: '111',
+        num_received: 1,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {}
+      })
+
+    const deleteNock = nock(BASE_URL)
+      .delete(new RegExp(`/${AUDIENCE_ID}/users`))
+      .reply(200, {
+        audience_id: AUDIENCE_ID,
+        session_id: '222',
+        num_received: 1,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {}
+      })
+
+    const responses = await testDestination.executeBatch('sync', {
+      events,
+      settings,
+      mapping: journeyMapping,
+      auth,
+      features: { [FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]: true }
+    })
+
+    expect(responses).toBeDefined()
+    const successResponses = responses.filter((r: any) => r.status === 200)
+    expect(successResponses).toHaveLength(2)
+    expect(addNock.isDone()).toBe(true)
+    expect(deleteNock.isDone()).toBe(true)
   })
 
   it('should fail with missing membership details when feature flag is disabled', async () => {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
@@ -1,0 +1,49 @@
+import { getJourneysMemberships } from '../functions'
+import { RawData } from '../types'
+
+describe('getJourneysMemberships', () => {
+  it('returns undefined when rawDatas is undefined', () => {
+    expect(getJourneysMemberships(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when rawDatas is an empty array', () => {
+    expect(getJourneysMemberships([])).toBeUndefined()
+  })
+
+  it('returns undefined when no events are journey_step', () => {
+    const rawDatas: RawData[] = [
+      { context: { personas: { computation_class: 'audience' } } },
+      { context: { personas: { computation_class: 'audience' } } }
+    ]
+    expect(getJourneysMemberships(rawDatas)).toBeUndefined()
+  })
+
+  it('returns an array of true values when all events are journey_step', () => {
+    const rawDatas: RawData[] = [
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: false } }
+    ]
+    const result = getJourneysMemberships(rawDatas)
+    expect(result).toEqual([true, true, true])
+    expect(result).toHaveLength(3)
+  })
+
+  it('throws PayloadValidationError when batch contains a mix of journey_step and non-journey_step', () => {
+    const rawDatas: RawData[] = [
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
+      { context: { personas: { computation_class: 'audience' } } }
+    ]
+    expect(() => getJourneysMemberships(rawDatas)).toThrow(
+      'Batch contains a mix of journey_step and non-journey_step events. All events in a batch must be the same computation_class.'
+    )
+  })
+
+  it('returns array matching rawDatas length for single event', () => {
+    const rawDatas: RawData[] = [
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } }
+    ]
+    const result = getJourneysMemberships(rawDatas)
+    expect(result).toEqual([true])
+  })
+})

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/journeys.test.ts
@@ -1,6 +1,58 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
 import { getJourneysMemberships } from '../functions'
 import { RawData } from '../types'
+import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON } from '../../constants'
 
+let testDestination = createTestIntegration(Destination)
+
+const auth = {
+  accessToken: '123',
+  refreshToken: '321'
+}
+
+const settings = {
+  retlAdAccountId: '123'
+}
+
+const AUDIENCE_ID = '1234'
+const AUDIENCE_KEY = 'journey_step_key'
+
+const journeyMapping = {
+  __segment_internal_sync_mode: 'mirror',
+  externalId: { '@path': '$.userId' },
+  email: { '@path': '$.properties.email' },
+  external_audience_id: { '@path': '$.context.personas.external_audience_id' },
+  retlOnMappingSave: {
+    inputs: {},
+    outputs: {}
+  },
+  enable_batching: true,
+  batch_size: 10000
+}
+
+function makeJourneyEvent(email: string, userId: string) {
+  return createTestEvent({
+    type: 'track',
+    event: 'Journey Step Entered',
+    userId,
+    properties: {
+      email
+    },
+    context: {
+      personas: {
+        external_audience_id: AUDIENCE_ID,
+        computation_class: 'journey_step',
+        computation_key: AUDIENCE_KEY
+      }
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// getJourneysMemberships (unit tests)
+// ---------------------------------------------------------------------------
 describe('getJourneysMemberships', () => {
   it('returns undefined when rawDatas is undefined', () => {
     expect(getJourneysMemberships(undefined)).toBeUndefined()
@@ -20,9 +72,9 @@ describe('getJourneysMemberships', () => {
 
   it('returns an array of true values when all events are journey_step', () => {
     const rawDatas: RawData[] = [
-      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
-      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
-      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: false } }
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: {} },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: {} },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: {} }
     ]
     const result = getJourneysMemberships(rawDatas)
     expect(result).toEqual([true, true, true])
@@ -31,7 +83,7 @@ describe('getJourneysMemberships', () => {
 
   it('throws PayloadValidationError when batch contains a mix of journey_step and non-journey_step', () => {
     const rawDatas: RawData[] = [
-      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } },
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: {} },
       { context: { personas: { computation_class: 'audience' } } }
     ]
     expect(() => getJourneysMemberships(rawDatas)).toThrow(
@@ -41,9 +93,69 @@ describe('getJourneysMemberships', () => {
 
   it('returns array matching rawDatas length for single event', () => {
     const rawDatas: RawData[] = [
-      { context: { personas: { computation_class: 'journey_step', computation_key: 'step_1' } }, properties: { step_1: true } }
+      { context: { personas: { computation_class: 'journey_step', computation_key: 'my_audience' } }, properties: {} }
     ]
     const result = getJourneysMemberships(rawDatas)
     expect(result).toEqual([true])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Feature flag gating (integration tests)
+// ---------------------------------------------------------------------------
+describe('FacebookCustomAudiences.sync - journey_step with feature flag', () => {
+  beforeEach(() => {
+    testDestination = createTestIntegration(Destination)
+    nock.cleanAll()
+  })
+
+  it('should add all journey_step users when feature flag is enabled', async () => {
+    const events = [
+      makeJourneyEvent('user1@test.com', 'user-1'),
+      makeJourneyEvent('user2@test.com', 'user-2')
+    ]
+
+    nock(BASE_URL)
+      .post(new RegExp(`/${AUDIENCE_ID}/users`))
+      .reply(200, {
+        audience_id: AUDIENCE_ID,
+        session_id: '111',
+        num_received: 2,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {}
+      })
+
+    const responses = await testDestination.executeBatch('sync', {
+      events,
+      settings,
+      mapping: journeyMapping,
+      auth,
+      features: { [FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]: true }
+    })
+
+    expect(responses).toBeDefined()
+    const successResponses = responses.filter((r: any) => r.status === 200)
+    expect(successResponses).toHaveLength(2)
+  })
+
+  it('should fail with missing membership details when feature flag is disabled', async () => {
+    const events = [
+      makeJourneyEvent('user1@test.com', 'user-1'),
+      makeJourneyEvent('user2@test.com', 'user-2')
+    ]
+
+    const responses = await testDestination.executeBatch('sync', {
+      events,
+      settings,
+      mapping: journeyMapping,
+      auth,
+      features: {}
+    })
+
+    expect(responses).toBeDefined()
+    const errorResponses = responses.filter((r: any) => r.status >= 400)
+    expect(errorResponses).toHaveLength(2)
+    expect(errorResponses[0].errormessage).toBe('Audience membership details missing')
+    expect(errorResponses[1].errormessage).toBe('Audience membership details missing')
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -188,8 +188,6 @@ export function getJSON(payloads: Payload[]): AudienceJSON {
 
 export function validate(payloads: Payload[], audienceId: unknown, audienceMemberships?: AudienceMembership[]): string | undefined {
   
-  // TODO handle journey step entered 
-
   if(!Array.isArray(audienceMemberships)){
     return 'Audience membership details for batch missing.'
   }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -5,14 +5,15 @@ import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { processHashing } from '../../../lib/hashing-utils'
 import { PayloadMap, AudienceJSON, FacebookDataRow, RawData } from './types'
-import { BASE_URL } from '../constants'
+import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON } from '../constants'
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 
 /* 
- * Temporary function to handle journey step membership
- * when preset journeys_step_entered_track is in use.
- * All users will be added to the audience (no removals) 
+ * Temporary function to handle audience membership when preset journeys_step_entered_track is in use.
+ * All users will be added to the audience (no removals). 
+ * This function will be removed once the Journeys team have migrated customers off of the  
+ * journeys_step_entered_track preset. 
  */ 
 export function getJourneysMemberships(
   rawDatas: RawData[] | undefined
@@ -47,10 +48,14 @@ export async function send(
   rawData?: RawData[]
 ): Promise<MultiStatusResponse | void> {
   const msResponse = new MultiStatusResponse()
-  const journeyMemberships = getJourneysMemberships(rawData)
-  if(Array.isArray(journeyMemberships) && journeyMemberships.length>0){
-    audienceMemberships = journeyMemberships
+  
+  if (features && features[FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]) {
+    const journeyMemberships = getJourneysMemberships(rawData)
+    if (Array.isArray(journeyMemberships) && journeyMemberships.length > 0) {
+      audienceMemberships = journeyMemberships
+    }
   }
+
   const audienceId = getAudienceId(payloads[0], hookOutputs)
   const errorMessage = validate(payloads, audienceId, audienceMemberships)
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -52,7 +52,10 @@ export async function send(
   if (features && features[FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]) {
     const journeyMemberships = getJourneysMemberships(rawData)
     if (Array.isArray(journeyMemberships) && journeyMemberships.length > 0) {
-      audienceMemberships = journeyMemberships
+      if (!audienceMemberships?.every((m) => typeof m === 'boolean')) {
+        // The above check is to ensure that the future JourneysVs preset will be able to add + remove users from the audience. 
+        audienceMemberships = journeyMemberships
+      }
     }
   }
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -4,21 +4,53 @@ import { RequestClient, PayloadValidationError, IntegrationError, MultiStatusRes
 import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { processHashing } from '../../../lib/hashing-utils'
-import { PayloadMap, AudienceJSON, FacebookDataRow } from './types'
+import { PayloadMap, AudienceJSON, FacebookDataRow, RawData } from './types'
 import { BASE_URL } from '../constants'
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 
+/* 
+ * Temporary function to handle journey step membership
+ * when preset journeys_step_entered_track is in use.
+ * All users will be added to the audience (no removals) 
+ */ 
+export function getJourneysMemberships(
+  rawDatas: RawData[] | undefined
+): boolean[] | undefined {
+  if (!rawDatas || (Array.isArray(rawDatas) && rawDatas.length === 0)) {
+    return undefined
+  }
+
+  const isJourneyStep = rawDatas.map((raw) => raw?.context?.personas?.computation_class === 'journey_step')
+  const allJourney = isJourneyStep.every(Boolean)
+  const noneJourney = isJourneyStep.every((v) => !v)
+
+  if (!allJourney && !noneJourney) {
+    throw new PayloadValidationError('Batch contains a mix of journey_step and non-journey_step events. All events in a batch must be the same computation_class.')
+  }
+
+  if (noneJourney) {
+    return undefined
+  }
+
+  return new Array(rawDatas.length).fill(true)
+}
+
 export async function send(
-  request: RequestClient, 
-  payloads: Payload[], 
-  isBatch: boolean, 
+  request: RequestClient,
+  payloads: Payload[],
+  isBatch: boolean,
   audienceMemberships?: AudienceMembership[],
-  hookOutputs?: { retlOnMappingSave?: { outputs?: { audienceId?: string } } }, 
-  features?: Features, 
-  statsContext?: StatsContext
+  hookOutputs?: { retlOnMappingSave?: { outputs?: { audienceId?: string } } },
+  features?: Features,
+  statsContext?: StatsContext,
+  rawData?: RawData[]
 ): Promise<MultiStatusResponse | void> {
   const msResponse = new MultiStatusResponse()
+  const journeyMemberships = getJourneysMemberships(rawData)
+  if(Array.isArray(journeyMemberships) && journeyMemberships.length>0){
+    audienceMemberships = journeyMemberships
+  }
   const audienceId = getAudienceId(payloads[0], hookOutputs)
   const errorMessage = validate(payloads, audienceId, audienceMemberships)
 
@@ -151,6 +183,8 @@ export function getJSON(payloads: Payload[]): AudienceJSON {
 
 export function validate(payloads: Payload[], audienceId: unknown, audienceMemberships?: AudienceMembership[]): string | undefined {
   
+  // TODO handle journey step entered 
+
   if(!Array.isArray(audienceMemberships)){
     return 'Audience membership details for batch missing.'
   }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
@@ -77,6 +77,14 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size: number
+  /**
+   * The keys to use for batching events.
+   */
+  batch_keys?: string[]
+  /**
+   * The Engage computation class. Used to determine if the event is a generaed from the journeys_step_entered_track preset
+   */
+  computation_class?: string
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/generated-types.ts
@@ -77,14 +77,6 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size: number
-  /**
-   * The keys to use for batching events.
-   */
-  batch_keys?: string[]
-  /**
-   * The Engage computation class. Used to determine if the event is a generaed from the journeys_step_entered_track preset
-   */
-  computation_class?: string
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -46,13 +46,21 @@ const action: ActionDefinition<Settings, Payload> = {
     request,
     { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload, RawData, unknown, AudienceMembership>
   ) => {
-    return await send(request, [payload], false, [audienceMembership], hookOutputs, features, statsContext, rawData ? [rawData] : undefined)
+    return await send(
+      request, [payload], false, [audienceMembership],
+      hookOutputs as { retlOnMappingSave?: { outputs?: { audienceId?: string } } },
+      features, statsContext, rawData ? [rawData] : undefined
+    )
   },
   performBatch: async (
     request,
     { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload[], RawData[], unknown, AudienceMembership[]>
   ) => {
-    return await send(request, payload, true, audienceMembership, hookOutputs, features, statsContext, rawData)
+    return await send(
+      request, payload, true, audienceMembership,
+      hookOutputs as { retlOnMappingSave?: { outputs?: { audienceId?: string } } },
+      features, statsContext, rawData
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -1,10 +1,10 @@
-import { ActionDefinition, AudienceMembership } from '@segment/actions-core'
+import { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { fields, retlHookInputFields, retlHookOutputTypes } from './fields'
 import { send } from './functions'
 import { performHook } from './hook-functions'
-import type { RawData, ExecuteInputRaw } from './types'
+import type { RawData } from './types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
@@ -44,8 +44,10 @@ const action: ActionDefinition<Settings, Payload> = {
   fields,
   perform: async (
     request,
-    { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload, RawData, unknown, AudienceMembership>
+    data
   ) => {
+    const { payload, audienceMembership, hookOutputs, features, statsContext } = data
+    const rawData = (data as unknown as { rawData?: RawData }).rawData
     return await send(
       request, [payload], false, [audienceMembership],
       hookOutputs as { retlOnMappingSave?: { outputs?: { audienceId?: string } } },
@@ -54,8 +56,10 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   performBatch: async (
     request,
-    { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload[], RawData[], unknown, AudienceMembership[]>
+    data
   ) => {
+    const { payload, audienceMembership, hookOutputs, features, statsContext } = data
+    const rawData = (data as unknown as { rawData?: RawData[] }).rawData
     return await send(
       request, payload, true, audienceMembership,
       hookOutputs as { retlOnMappingSave?: { outputs?: { audienceId?: string } } },

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/index.ts
@@ -1,9 +1,10 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, AudienceMembership } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { fields, retlHookInputFields, retlHookOutputTypes } from './fields'
 import { send } from './functions'
 import { performHook } from './hook-functions'
+import type { RawData, ExecuteInputRaw } from './types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
@@ -41,11 +42,17 @@ const action: ActionDefinition<Settings, Payload> = {
     ]
   },
   fields,
-  perform: async (request, { payload, audienceMembership, hookOutputs, features, statsContext }) => {
-    return await send(request, [payload],false, [audienceMembership], hookOutputs, features, statsContext)
+  perform: async (
+    request,
+    { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload, RawData, unknown, AudienceMembership>
+  ) => {
+    return await send(request, [payload], false, [audienceMembership], hookOutputs, features, statsContext, rawData ? [rawData] : undefined)
   },
-  performBatch: async (request, { payload, audienceMembership, hookOutputs, features, statsContext }) => {
-    return await send(request, payload, true, audienceMembership, hookOutputs, features, statsContext)
+  performBatch: async (
+    request,
+    { payload, audienceMembership, hookOutputs, features, statsContext, rawData }: ExecuteInputRaw<Settings, Payload[], RawData[], unknown, AudienceMembership[]>
+  ) => {
+    return await send(request, payload, true, audienceMembership, hookOutputs, features, statsContext, rawData)
   }
 }
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
@@ -16,8 +16,8 @@ export type ExecuteInputRaw<Settings, Payload, RawData, AudienceSettings = unkno
   Settings,
   Payload,
   AudienceSettings,
-  any,
-  any,
+  unknown,
+  unknown,
   AudienceMembershipType
 > & { rawData?: RawData }
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
@@ -6,7 +6,6 @@ export type RawData = {
   context?: {
     personas?: {
       computation_class?: string
-      computation_key?: string
     }
   }
   properties?: Record<string, unknown>

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
@@ -1,6 +1,5 @@
 import { SCHEMA_PROPERTIES } from './constants'
 import { Payload } from './generated-types'
-import { ExecuteInput } from '@segment/actions-core'
 
 export type RawData = {
   context?: {
@@ -10,15 +9,6 @@ export type RawData = {
   }
   properties?: Record<string, unknown>
 }
-
-export type ExecuteInputRaw<Settings, Payload, RawData, AudienceSettings = unknown, AudienceMembershipType = unknown> = ExecuteInput<
-  Settings,
-  Payload,
-  AudienceSettings,
-  unknown,
-  unknown,
-  AudienceMembershipType
-> & { rawData?: RawData }
 
 export type PayloadMap = Map<number, Payload> 
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/types.ts
@@ -1,5 +1,25 @@
 import { SCHEMA_PROPERTIES } from './constants'
 import { Payload } from './generated-types'
+import { ExecuteInput } from '@segment/actions-core'
+
+export type RawData = {
+  context?: {
+    personas?: {
+      computation_class?: string
+      computation_key?: string
+    }
+  }
+  properties?: Record<string, unknown>
+}
+
+export type ExecuteInputRaw<Settings, Payload, RawData, AudienceSettings = unknown, AudienceMembershipType = unknown> = ExecuteInput<
+  Settings,
+  Payload,
+  AudienceSettings,
+  any,
+  any,
+  AudienceMembershipType
+> & { rawData?: RawData }
 
 export type PayloadMap = Map<number, Payload> 
 


### PR DESCRIPTION
**Summary:** 

Handles audience membership correctly for events generated via from the journeys_step_entered_track preset. 

Accesses raw event data (context.personas.computation_class) to detect journey step events and overrides audienceMembership to true for all users in the batch (add-only, no removals)
  - Gated behind the facebook-custom-audience-actions-journeys-support feature flag for safe rollout
  - Validates that batches are homogeneous — all journey_step or all non-journey_step — and throws a  PayloadValidationError on mixed batches

**Context for this change:** 

Events from Journeys arrive as track events with event: "Journey Step Entered" and context.personas.computation_class: "journey_step".

Unlike audience events, they do not carry a properties[computation_key] boolean indicating membership. Since the sync action doesn't define fields for computation_class or computation_key, we use rawData to inspect the raw event payload and infer membership (always true for journey steps).

## Testing
  - To be tested in Stage. 
  - Unit tests for getJourneysMemberships — undefined/empty input, all journey, all non-journey, mixed batch error, single event
  - Integration tests verifying feature flag gating — journey events succeed with flag enabled, fail with expected error when flag disabled
  - Verify in staging with feature flag enabled against real journey step events
  - Gradual rollout via feature flag in production

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
