### PR TITLE
feat: enhance generate:metadata-payload with mode filtering, path targeting, and CI/lint-staged integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Assert generated types are up-to-date
         run: bash scripts/assert-types-updated.sh
 
+      - name: Assert metadata payloads are up-to-date
+        run: bash scripts/assert-metadata-payload.sh
+
   browser-destination-bundle-qa:
     name: Browser Destination Bundle QA
     # env: # Disable saucelabs - we blew through our quota.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "typecheck": "lerna run typecheck --stream",
     "types": "./bin/run generate:types",
     "validate": "./bin/run validate",
-    "generate:metadata-payload": "./bin/run generate:metadata-payload"
+    "generate:metadata-payload": "./bin/run generate:metadata-payload",
+    "generate:metadata-payload:cloud": "./bin/run generate:metadata-payload --mode=cloud",
+    "generate:metadata-payload:browser": "./bin/run generate:metadata-payload --mode=device",
+    "generate:metadata-payload:warehouse": "./bin/run generate:metadata-payload --mode=warehouse"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
   "lint-staged": {
     "**/{browser-destinations,destinations}/**/*.ts": [
       "./bin/run generate:types -p",
-      "git add **/generated-types.ts"
+      "git add **/generated-types.ts",
+      "bash scripts/update-metadata-payload.sh",
+      "git add **/metadata.json"
     ],
     "!(**/templates/**)/*.ts": [
       "eslint --fix --cache",

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -821,6 +821,81 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
   })
 })
 
+describe('GenerateMetadataPayload — warehouse filesystem discovery', () => {
+  const mockGetManifest = getManifest as jest.MockedFunction<typeof getManifest>
+  const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  const mockPathExists = fs.pathExists as unknown as jest.MockedFunction<(p: string) => Promise<boolean>>
+  const mockReaddir = fs.readdir as unknown as jest.MockedFunction<() => Promise<any[]>>
+  const mockLoadDestination = loadDestination as jest.MockedFunction<typeof loadDestination>
+
+  const warehouseDef = {
+    name: 'My Warehouse',
+    mode: 'warehouse',
+    actions: { load: { title: 'Load', description: 'Load data', fields: {}, perform: () => undefined } }
+  } as unknown as DestinationDefinition
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockWriteFile.mockResolvedValue(undefined as never)
+    mockGetManifest.mockReturnValue({})
+  })
+
+  it('discovers warehouse destinations from filesystem', async () => {
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (p.includes('warehouse-destinations/src/destinations')) return true
+      if (p.endsWith('my-wh/index.ts')) return true
+      return false
+    })
+    mockReaddir.mockImplementation(async (...args: any[]) => {
+      const p = args[0] as string
+      if (typeof p === 'string' && p.includes('warehouse-destinations')) return [makeDirent('my-wh')]
+      return []
+    })
+    mockLoadDestination.mockResolvedValue(warehouseDef)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockLoadDestination).toHaveBeenCalledWith(expect.stringContaining('warehouse-destinations'))
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('my-wh/metadata.json'),
+      expect.stringContaining('"name": "My Warehouse"')
+    )
+  })
+
+  it('filters warehouse destinations with --mode=warehouse', async () => {
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (p.includes('warehouse-destinations/src/destinations')) return true
+      if (p.endsWith('my-wh/index.ts')) return true
+      return false
+    })
+    mockReaddir.mockImplementation(async (...args: any[]) => {
+      const p = args[0] as string
+      if (typeof p === 'string' && p.includes('warehouse-destinations')) return [makeDirent('my-wh')]
+      return []
+    })
+    mockLoadDestination.mockResolvedValue(warehouseDef)
+
+    await GenerateMetadataPayload.run(['--mode=warehouse'])
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('excludes warehouse destinations with --mode=cloud', async () => {
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (p.includes('warehouse-destinations/src/destinations')) return true
+      if (p.endsWith('my-wh/index.ts')) return true
+      return false
+    })
+    mockReaddir.mockImplementation(async (...args: any[]) => {
+      const p = args[0] as string
+      if (typeof p === 'string' && p.includes('warehouse-destinations')) return [makeDirent('my-wh')]
+      return []
+    })
+    mockLoadDestination.mockResolvedValue(warehouseDef)
+
+    await GenerateMetadataPayload.run(['--mode=cloud'])
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})
+
 describe('extractDestinationDirs', () => {
   it('extracts cloud destination directory names', () => {
     const dirs = extractDestinationDirs([
@@ -908,6 +983,20 @@ describe('--path filtering (Command E2E)', () => {
     } as any)
 
     await GenerateMetadataPayload.run(['--path', 'packages/destination-actions/src/destinations/nonexistent/index.ts'])
+
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('generates nothing when --path values do not match any known layout', async () => {
+    mockGetManifest.mockReturnValue({
+      'actions-amplitude': {
+        definition: { name: 'Amplitude', mode: 'cloud', actions: {} },
+        directory: 'amplitude',
+        path: '/root/packages/destination-actions/src/destinations/amplitude/index.ts'
+      }
+    } as any)
+
+    await GenerateMetadataPayload.run(['--path', 'packages/core/src/index.ts'])
 
     expect(mockWriteFile).not.toHaveBeenCalled()
   })

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -1,18 +1,23 @@
 jest.mock('../lib/destinations', () => ({
   getManifest: jest.fn(),
+  loadDestination: jest.fn(),
   hasOauthAuthentication: jest.requireActual('../lib/destinations').hasOauthAuthentication
 }))
 
 jest.mock('fs-extra', () => ({
   __esModule: true,
-  default: { writeFile: jest.fn().mockResolvedValue(undefined) }
+  default: {
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    pathExists: jest.fn().mockResolvedValue(false),
+    readdir: jest.fn().mockResolvedValue([])
+  }
 }))
 
 import fs from 'fs-extra'
 import { generatePublicMetadata } from '../commands/generate/metadata-payload'
 import { resolveSourceDir } from '../commands/generate/metadata-payload'
 import GenerateMetadataPayload from '../commands/generate/metadata-payload'
-import { getManifest } from '../lib/destinations'
+import { getManifest, loadDestination } from '../lib/destinations'
 import type { DestinationDefinition } from '../lib/destinations'
 
 // ---- Fixtures ----
@@ -515,6 +520,8 @@ describe('resolveSourceDir()', () => {
 describe('GenerateMetadataPayload command', () => {
   const mockGetManifest = getManifest as jest.MockedFunction<typeof getManifest>
   const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  const mockPathExists = fs.pathExists as unknown as jest.MockedFunction<() => Promise<boolean>>
+  const mockReaddir = fs.readdir as unknown as jest.MockedFunction<() => Promise<string[]>>
 
   const validEntry = {
     path: '/repo/packages/destination-actions/dist/destinations/test-dest/index.js',
@@ -524,6 +531,8 @@ describe('GenerateMetadataPayload command', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockWriteFile.mockResolvedValue(undefined as never)
+    mockPathExists.mockResolvedValue(false)
+    mockReaddir.mockResolvedValue([])
   })
 
   it('writes metadata.json to the resolved source dir', async () => {
@@ -610,5 +619,93 @@ describe('GenerateMetadataPayload command', () => {
     })
     await expect(GenerateMetadataPayload.run([])).rejects.toThrow('1 destination(s) failed to generate metadata')
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---- Filesystem Discovery ----
+
+describe('GenerateMetadataPayload — filesystem discovery', () => {
+  const mockGetManifest = getManifest as jest.MockedFunction<typeof getManifest>
+  const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  const mockPathExists = fs.pathExists as unknown as jest.MockedFunction<(p: string) => Promise<boolean>>
+  const mockReaddir = fs.readdir as unknown as jest.MockedFunction<() => Promise<string[]>>
+  const mockLoadDestination = loadDestination as jest.MockedFunction<typeof loadDestination>
+
+  const unregisteredDef = {
+    ...cloudDef,
+    name: 'Unregistered Dest',
+    slug: 'actions-unregistered'
+  } as unknown as DestinationDefinition
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockWriteFile.mockResolvedValue(undefined as never)
+    mockGetManifest.mockReturnValue({})
+  })
+
+  it('discovers an unregistered destination directory with an index.ts', async () => {
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (p.includes('destination-actions/src/destinations')) return true
+      if (p.endsWith('new-dest/index.ts')) return true
+      return false
+    })
+    mockReaddir.mockResolvedValue(['new-dest'] as any)
+    mockLoadDestination.mockResolvedValue(unregisteredDef)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockLoadDestination).toHaveBeenCalledWith(expect.stringContaining('new-dest/index.ts'))
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('new-dest/metadata.json'),
+      expect.stringContaining('"slug": "actions-unregistered"')
+    )
+  })
+
+  it('skips directories without an index.ts', async () => {
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (p.includes('destination-actions/src/destinations') && !p.includes('index.ts')) return true
+      return false
+    })
+    mockReaddir.mockResolvedValue(['no-index-dir'] as any)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockLoadDestination).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('skips directories where loadDestination returns null', async () => {
+    mockPathExists.mockResolvedValue(true)
+    mockReaddir.mockResolvedValue(['invalid-dest'] as any)
+    mockLoadDestination.mockResolvedValue(null)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('skips directories where loadDestination throws and continues', async () => {
+    mockPathExists.mockResolvedValue(true)
+    mockReaddir.mockResolvedValue(['broken-dest', 'good-dest'] as any)
+    mockLoadDestination.mockRejectedValueOnce(new Error('syntax error')).mockResolvedValueOnce(unregisteredDef)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledWith(expect.stringContaining('good-dest/metadata.json'), expect.any(String))
+  })
+
+  it('does not re-discover directories already in the manifest', async () => {
+    mockGetManifest.mockReturnValue({
+      'meta-1': {
+        path: '/repo/packages/destination-actions/dist/destinations/existing-dest/index.js',
+        definition: { ...cloudDef, slug: 'existing-dest' },
+        directory: 'existing-dest'
+      } as any
+    })
+    mockPathExists.mockImplementation(async (p: string) => {
+      if (typeof p === 'string' && p.includes('destination-actions/src/destinations')) return true
+      return false
+    })
+    mockReaddir.mockResolvedValue(['existing-dest'] as any)
+
+    await GenerateMetadataPayload.run([])
+    expect(mockLoadDestination).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -174,6 +174,29 @@ describe('generatePublicMetadata() — authentication fields', () => {
       { label: 'staging', value: 'staging' }
     ])
   })
+
+  it('serializes multiple and depends_on on auth fields', () => {
+    const def = {
+      ...cloudDef,
+      authentication: {
+        scheme: 'custom',
+        fields: {
+          tags: { label: 'Tags', description: 'Tags.', type: 'string', multiple: true },
+          region: {
+            label: 'Region',
+            description: 'Region.',
+            type: 'string',
+            depends_on: { conditions: [{ fieldKey: 'env', operator: 'is', value: 'prod' }] }
+          }
+        }
+      }
+    } as unknown as DestinationDefinition
+    const { authentication } = generatePublicMetadata('slug', def)
+    expect(authentication?.fields.tags.multiple).toBe(true)
+    expect(authentication?.fields.region.depends_on).toEqual({
+      conditions: [{ fieldKey: 'env', operator: 'is', value: 'prod' }]
+    })
+  })
 })
 
 // ---- Action fields ----
@@ -249,6 +272,31 @@ describe('generatePublicMetadata() — action fields', () => {
       }
     } as unknown as DestinationDefinition
     expect(generatePublicMetadata('slug', def).actions.dynAction.fields.staticField.dynamic).toBe(false)
+  })
+
+  it('serializes displayMode and additionalProperties on action fields', () => {
+    const def = {
+      ...cloudDef,
+      actions: {
+        testAction: {
+          title: 'Test',
+          description: '',
+          fields: {
+            traits: {
+              label: 'Traits',
+              description: 'User traits.',
+              type: 'object',
+              displayMode: 'key-value',
+              additionalProperties: true
+            }
+          },
+          perform: () => undefined
+        }
+      }
+    } as unknown as DestinationDefinition
+    const field = generatePublicMetadata('slug', def).actions.testAction.fields.traits
+    expect(field.displayMode).toBe('key-value')
+    expect(field.additionalProperties).toBe(true)
   })
 })
 
@@ -506,6 +554,18 @@ describe('resolveSourceDir()', () => {
     )
   })
 
+  it('resolves compiled warehouse dist path to src directory', () => {
+    expect(resolveSourceDir('/repo/packages/warehouse-destinations/dist/destinations/my-wh/index.js')).toBe(
+      '/repo/packages/warehouse-destinations/src/destinations/my-wh'
+    )
+  })
+
+  it('resolves ts-node warehouse src path to its own directory', () => {
+    expect(resolveSourceDir('/repo/packages/warehouse-destinations/src/destinations/my-wh/index.ts')).toBe(
+      '/repo/packages/warehouse-destinations/src/destinations/my-wh'
+    )
+  })
+
   it('returns null for an unrecognized path pattern', () => {
     expect(resolveSourceDir('/some/random/path/index.js')).toBeNull()
   })
@@ -620,15 +680,57 @@ describe('GenerateMetadataPayload command', () => {
     await expect(GenerateMetadataPayload.run([])).rejects.toThrow('1 destination(s) failed to generate metadata')
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
   })
+
+  it('filters to only cloud destinations when --mode=cloud is passed', async () => {
+    mockGetManifest.mockReturnValue({
+      'meta-cloud': {
+        path: '/repo/packages/destination-actions/dist/destinations/cloud-dest/index.js',
+        definition: { ...cloudDef, slug: 'cloud-dest', mode: 'cloud' }
+      } as any,
+      'meta-device': {
+        path: '/repo/packages/browser-destinations/destinations/browser-dest/dist/cjs/index.js',
+        definition: { ...browserDef, slug: 'browser-dest', mode: 'device' }
+      } as any
+    })
+    await GenerateMetadataPayload.run(['--mode=cloud'])
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/repo/packages/destination-actions/src/destinations/cloud-dest/metadata.json',
+      expect.any(String)
+    )
+  })
+
+  it('filters to only device destinations when --mode=device is passed', async () => {
+    mockGetManifest.mockReturnValue({
+      'meta-cloud': {
+        path: '/repo/packages/destination-actions/dist/destinations/cloud-dest/index.js',
+        definition: { ...cloudDef, slug: 'cloud-dest', mode: 'cloud' }
+      } as any,
+      'meta-device': {
+        path: '/repo/packages/browser-destinations/destinations/browser-dest/dist/cjs/index.js',
+        definition: { ...browserDef, slug: 'browser-dest', mode: 'device' }
+      } as any
+    })
+    await GenerateMetadataPayload.run(['--mode=device'])
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/repo/packages/browser-destinations/destinations/browser-dest/metadata.json',
+      expect.any(String)
+    )
+  })
 })
 
 // ---- Filesystem Discovery ----
+
+function makeDirent(name: string, isDir = true) {
+  return { name, isDirectory: () => isDir, isFile: () => !isDir } as any
+}
 
 describe('GenerateMetadataPayload — filesystem discovery', () => {
   const mockGetManifest = getManifest as jest.MockedFunction<typeof getManifest>
   const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   const mockPathExists = fs.pathExists as unknown as jest.MockedFunction<(p: string) => Promise<boolean>>
-  const mockReaddir = fs.readdir as unknown as jest.MockedFunction<() => Promise<string[]>>
+  const mockReaddir = fs.readdir as unknown as jest.MockedFunction<() => Promise<any[]>>
   const mockLoadDestination = loadDestination as jest.MockedFunction<typeof loadDestination>
 
   const unregisteredDef = {
@@ -649,7 +751,7 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
       if (p.endsWith('new-dest/index.ts')) return true
       return false
     })
-    mockReaddir.mockResolvedValue(['new-dest'] as any)
+    mockReaddir.mockResolvedValue([makeDirent('new-dest')])
     mockLoadDestination.mockResolvedValue(unregisteredDef)
 
     await GenerateMetadataPayload.run([])
@@ -660,12 +762,21 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
     )
   })
 
+  it('skips non-directory entries', async () => {
+    mockPathExists.mockResolvedValue(true)
+    mockReaddir.mockResolvedValue([makeDirent('utils.ts', false), makeDirent('.DS_Store', false)])
+
+    await GenerateMetadataPayload.run([])
+    expect(mockLoadDestination).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
   it('skips directories without an index.ts', async () => {
     mockPathExists.mockImplementation(async (p: string) => {
       if (p.includes('destination-actions/src/destinations') && !p.includes('index.ts')) return true
       return false
     })
-    mockReaddir.mockResolvedValue(['no-index-dir'] as any)
+    mockReaddir.mockResolvedValue([makeDirent('no-index-dir')])
 
     await GenerateMetadataPayload.run([])
     expect(mockLoadDestination).not.toHaveBeenCalled()
@@ -674,7 +785,7 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
 
   it('skips directories where loadDestination returns null', async () => {
     mockPathExists.mockResolvedValue(true)
-    mockReaddir.mockResolvedValue(['invalid-dest'] as any)
+    mockReaddir.mockResolvedValue([makeDirent('invalid-dest')])
     mockLoadDestination.mockResolvedValue(null)
 
     await GenerateMetadataPayload.run([])
@@ -683,7 +794,7 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
 
   it('skips directories where loadDestination throws and continues', async () => {
     mockPathExists.mockResolvedValue(true)
-    mockReaddir.mockResolvedValue(['broken-dest', 'good-dest'] as any)
+    mockReaddir.mockResolvedValue([makeDirent('broken-dest'), makeDirent('good-dest')])
     mockLoadDestination.mockRejectedValueOnce(new Error('syntax error')).mockResolvedValueOnce(unregisteredDef)
 
     await GenerateMetadataPayload.run([])
@@ -703,7 +814,7 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
       if (typeof p === 'string' && p.includes('destination-actions/src/destinations')) return true
       return false
     })
-    mockReaddir.mockResolvedValue(['existing-dest'] as any)
+    mockReaddir.mockResolvedValue([makeDirent('existing-dest')])
 
     await GenerateMetadataPayload.run([])
     expect(mockLoadDestination).not.toHaveBeenCalled()

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -278,7 +278,7 @@ describe('generatePublicMetadata() — syncMode', () => {
     expect(generatePublicMetadata('actions-cloud', cloudDef).actions.trackEvent.syncMode).toBeNull()
   })
 
-  it('serializes syncMode with default and supportedModes', () => {
+  it('serializes syncMode with default, label, description, and choices', () => {
     const def = {
       ...cloudDef,
       actions: {
@@ -300,18 +300,26 @@ describe('generatePublicMetadata() — syncMode', () => {
       }
     } as unknown as DestinationDefinition
     const { syncMode } = generatePublicMetadata('slug', def).actions.syncAction
-    expect(syncMode).toEqual({ default: 'add', supportedModes: ['add', 'delete'] })
+    expect(syncMode).toEqual({
+      default: 'add',
+      label: 'Sync Mode',
+      description: 'How to sync.',
+      choices: [
+        { label: 'Add', value: 'add' },
+        { label: 'Delete', value: 'delete' }
+      ]
+    })
   })
 })
 
 // ---- hooks ----
 
 describe('generatePublicMetadata() — hooks', () => {
-  it('is empty array when action has no hooks', () => {
-    expect(generatePublicMetadata('actions-cloud', cloudDef).actions.trackEvent.hooks).toEqual([])
+  it('is null when action has no hooks', () => {
+    expect(generatePublicMetadata('actions-cloud', cloudDef).actions.trackEvent.hooks).toBeNull()
   })
 
-  it('lists valid hook type names present on the action', () => {
+  it('serializes hooks with label, description, inputFields, and outputFields', () => {
     const def = {
       ...cloudDef,
       actions: {
@@ -320,13 +328,31 @@ describe('generatePublicMetadata() — hooks', () => {
           description: 'Has hooks.',
           fields: {},
           hooks: {
-            onMappingSave: { label: 'On Save', description: 'Fires on save.', inputFields: {} }
+            onMappingSave: {
+              label: 'On Save',
+              description: 'Fires on save.',
+              inputFields: {
+                webhookUrl: { label: 'Webhook URL', description: 'URL to call.', type: 'string', required: true }
+              },
+              outputTypes: {
+                id: { label: 'ID', description: 'Generated ID.', type: 'string' }
+              }
+            }
           },
           perform: () => undefined
         }
       }
     } as unknown as DestinationDefinition
-    expect(generatePublicMetadata('slug', def).actions.hookAction.hooks).toEqual(['onMappingSave'])
+    const { hooks } = generatePublicMetadata('slug', def).actions.hookAction
+    expect(hooks).not.toBeNull()
+    expect(hooks).toHaveProperty('onMappingSave')
+    expect(hooks!.onMappingSave.label).toBe('On Save')
+    expect(hooks!.onMappingSave.description).toBe('Fires on save.')
+    expect(hooks!.onMappingSave.inputFields).toHaveProperty('webhookUrl')
+    expect(hooks!.onMappingSave.inputFields.webhookUrl.label).toBe('Webhook URL')
+    expect(hooks!.onMappingSave.inputFields.webhookUrl.required).toBe(true)
+    expect(hooks!.onMappingSave.outputFields).toHaveProperty('id')
+    expect(hooks!.onMappingSave.outputFields.id.label).toBe('ID')
   })
 })
 
@@ -337,7 +363,7 @@ describe('generatePublicMetadata() — audienceConfig', () => {
     expect(generatePublicMetadata('actions-cloud', cloudDef).audienceConfig).toBeNull()
   })
 
-  it('serializes audienceConfig mode and audienceFields, strips functions', () => {
+  it('serializes audienceConfig mode, audienceFields, and supportsAudienceFunctions', () => {
     const def = {
       ...cloudDef,
       audienceConfig: {
@@ -353,7 +379,22 @@ describe('generatePublicMetadata() — audienceConfig', () => {
     expect(audienceConfig).not.toBeNull()
     expect(audienceConfig?.mode).toEqual({ type: 'realtime' })
     expect(audienceConfig?.audienceFields).toHaveProperty('listId')
+    expect(audienceConfig?.supportsAudienceFunctions).toBe(true)
     expect(typeof (audienceConfig as any)?.createAudience).toBe('undefined')
+  })
+
+  it('sets supportsAudienceFunctions to false when functions are missing', () => {
+    const def = {
+      ...cloudDef,
+      audienceConfig: {
+        mode: { type: 'synced', full_audience_sync: true }
+      },
+      audienceFields: {}
+    } as unknown as DestinationDefinition
+    const { audienceConfig } = generatePublicMetadata('slug', def)
+    expect(audienceConfig).not.toBeNull()
+    expect(audienceConfig?.mode).toEqual({ type: 'synced', full_audience_sync: true })
+    expect(audienceConfig?.supportsAudienceFunctions).toBe(false)
   })
 })
 

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -15,7 +15,7 @@ jest.mock('fs-extra', () => ({
 
 import fs from 'fs-extra'
 import { generatePublicMetadata } from '../commands/generate/metadata-payload'
-import { resolveSourceDir } from '../commands/generate/metadata-payload'
+import { resolveSourceDir, extractDestinationDirs } from '../commands/generate/metadata-payload'
 import GenerateMetadataPayload from '../commands/generate/metadata-payload'
 import { getManifest, loadDestination } from '../lib/destinations'
 import type { DestinationDefinition } from '../lib/destinations'
@@ -818,5 +818,97 @@ describe('GenerateMetadataPayload — filesystem discovery', () => {
 
     await GenerateMetadataPayload.run([])
     expect(mockLoadDestination).not.toHaveBeenCalled()
+  })
+})
+
+describe('extractDestinationDirs', () => {
+  it('extracts cloud destination directory names', () => {
+    const dirs = extractDestinationDirs([
+      'packages/destination-actions/src/destinations/amplitude/index.ts',
+      'packages/destination-actions/src/destinations/slack/track/index.ts'
+    ])
+    expect(dirs).toEqual(new Set(['amplitude', 'slack']))
+  })
+
+  it('extracts browser destination directory names', () => {
+    const dirs = extractDestinationDirs(['packages/browser-destinations/destinations/braze/src/index.ts'])
+    expect(dirs).toEqual(new Set(['braze']))
+  })
+
+  it('extracts warehouse destination directory names', () => {
+    const dirs = extractDestinationDirs(['packages/warehouse-destinations/src/destinations/snowflake/index.ts'])
+    expect(dirs).toEqual(new Set(['snowflake']))
+  })
+
+  it('deduplicates directories from multiple files in same destination', () => {
+    const dirs = extractDestinationDirs([
+      'packages/destination-actions/src/destinations/amplitude/track/index.ts',
+      'packages/destination-actions/src/destinations/amplitude/identify/index.ts'
+    ])
+    expect(dirs).toEqual(new Set(['amplitude']))
+  })
+
+  it('returns empty set for unrecognized paths', () => {
+    const dirs = extractDestinationDirs(['packages/core/src/index.ts', 'some/random/path.ts'])
+    expect(dirs.size).toBe(0)
+  })
+
+  it('handles mixed path types', () => {
+    const dirs = extractDestinationDirs([
+      'packages/destination-actions/src/destinations/amplitude/index.ts',
+      'packages/browser-destinations/destinations/braze/src/index.ts',
+      'packages/warehouse-destinations/src/destinations/snowflake/index.ts'
+    ])
+    expect(dirs).toEqual(new Set(['amplitude', 'braze', 'snowflake']))
+  })
+})
+
+describe('--path filtering (Command E2E)', () => {
+  const mockGetManifest = getManifest as jest.MockedFunction<typeof getManifest>
+  const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  const mockPathExists = fs.pathExists as unknown as jest.MockedFunction<() => Promise<boolean>>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPathExists.mockResolvedValue(false)
+  })
+
+  it('generates metadata only for matching path destinations', async () => {
+    mockGetManifest.mockReturnValue({
+      'actions-amplitude': {
+        definition: { name: 'Amplitude', mode: 'cloud', actions: {} },
+        directory: 'amplitude',
+        path: '/root/packages/destination-actions/src/destinations/amplitude/index.ts'
+      },
+      'actions-slack': {
+        definition: { name: 'Slack', mode: 'cloud', actions: {} },
+        directory: 'slack',
+        path: '/root/packages/destination-actions/src/destinations/slack/index.ts'
+      }
+    } as any)
+
+    await GenerateMetadataPayload.run([
+      '--path',
+      'packages/destination-actions/src/destinations/amplitude/track/index.ts'
+    ])
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    const writtenPath = (mockWriteFile as any).mock.calls[0][0] as string
+    expect(writtenPath).toContain('amplitude')
+    expect(writtenPath).not.toContain('slack')
+  })
+
+  it('skips all destinations when path matches none', async () => {
+    mockGetManifest.mockReturnValue({
+      'actions-amplitude': {
+        definition: { name: 'Amplitude', mode: 'cloud', actions: {} },
+        directory: 'amplitude',
+        path: '/root/packages/destination-actions/src/destinations/amplitude/index.ts'
+      }
+    } as any)
+
+    await GenerateMetadataPayload.run(['--path', 'packages/destination-actions/src/destinations/nonexistent/index.ts'])
+
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -125,9 +125,11 @@ describe('generatePublicMetadata() — authentication fields', () => {
     })
   })
 
-  it('flattens conditional required to false', () => {
+  it('preserves conditional required object', () => {
     const { authentication } = generatePublicMetadata('actions-cloud', cloudDef)
-    expect(authentication?.fields.modeField.required).toBe(false)
+    expect(authentication?.fields.modeField.required).toEqual({
+      conditions: [{ fieldKey: 'x', operator: 'is', value: 'y' }]
+    })
   })
 
   it('uses browser settings as auth fields for device-mode destinations', () => {

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -288,7 +288,7 @@ describe('generatePublicMetadata() — action fields', () => {
               label: 'Traits',
               description: 'User traits.',
               type: 'object',
-              displayMode: 'key-value',
+              displayMode: 'expanded',
               additionalProperties: true
             }
           },
@@ -297,7 +297,7 @@ describe('generatePublicMetadata() — action fields', () => {
       }
     } as unknown as DestinationDefinition
     const field = generatePublicMetadata('slug', def).actions.testAction.fields.traits
-    expect(field.displayMode).toBe('key-value')
+    expect(field.displayMode).toBe('expanded')
     expect(field.additionalProperties).toBe(true)
   })
 })

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -17,8 +17,10 @@ export interface PublicAuthField {
   description: string | undefined
   type: string
   required: boolean
+  multiple: boolean
   choices: Array<{ label: string; value: unknown }> | null
   default: unknown
+  depends_on: unknown
 }
 
 export interface PublicActionField {
@@ -41,6 +43,8 @@ export interface PublicActionField {
   maximum: number | null
   defaultObjectUI: string | null
   disabledInputMethods: string[] | null
+  displayMode: string | null
+  additionalProperties: boolean
 }
 
 export interface PublicAction {
@@ -50,8 +54,21 @@ export interface PublicAction {
   defaultSubscription: string | null
   hidden: boolean
   hasPerformBatch: boolean
-  syncMode: { default: string; supportedModes: string[] } | null
-  hooks: string[]
+  syncMode: {
+    default: string
+    label: string
+    description: string
+    choices: Array<{ label: string; value: string }>
+  } | null
+  hooks: Record<
+    string,
+    {
+      label: string
+      description: string
+      inputFields: Record<string, PublicActionField>
+      outputFields: Record<string, PublicActionField>
+    }
+  > | null
   fields: Record<string, PublicActionField>
 }
 
@@ -70,7 +87,11 @@ export interface PublicDestinationMetadata {
   mode: 'cloud' | 'device' | 'warehouse'
   description: string | undefined
   authentication: { scheme: string; fields: Record<string, PublicAuthField> } | null
-  audienceConfig: { mode: unknown; audienceFields: Record<string, PublicAuthField> } | null
+  audienceConfig: {
+    mode: { type: 'synced' | 'realtime'; full_audience_sync?: boolean }
+    audienceFields: Record<string, PublicAuthField>
+    supportsAudienceFunctions: boolean
+  } | null
   actions: Record<string, PublicAction>
   presets: PublicPreset[]
 }
@@ -93,8 +114,10 @@ export function serializeAuthField(schema: any): PublicAuthField {
     description: schema.description,
     type: schema.type,
     required: schema.required === true,
+    multiple: schema.multiple ?? false,
     choices: normalizeChoices(schema.choices),
-    default: schema.default ?? null
+    default: schema.default ?? null,
+    depends_on: schema.depends_on ?? null
   }
 }
 
@@ -134,7 +157,9 @@ export function serializeActionField(field: any): PublicActionField {
     minimum: field.minimum ?? null,
     maximum: field.maximum ?? null,
     defaultObjectUI: field.defaultObjectUI ?? null,
-    disabledInputMethods: field.disabledInputMethods ?? null
+    disabledInputMethods: field.disabledInputMethods ?? null,
+    displayMode: field.displayMode ?? null,
+    additionalProperties: field.additionalProperties ?? false
   }
 }
 
@@ -148,11 +173,35 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
   if (action.syncMode) {
     syncMode = {
       default: action.syncMode.default,
-      supportedModes: (action.syncMode.choices ?? []).map((c: { value: string }) => c.value)
+      label: action.syncMode.label ?? 'Sync Mode',
+      description: action.syncMode.description ?? '',
+      choices: (action.syncMode.choices ?? []).map((c: { value: string; label: string }) => ({
+        value: c.value,
+        label: c.label
+      }))
     }
   }
 
-  const hooks: string[] = Object.keys(action.hooks ?? {}).filter((k) => hookTypeStrings.includes(k as any))
+  const hooks: PublicAction['hooks'] = {}
+  if (action.hooks) {
+    for (const [hookKey, hook] of Object.entries(action.hooks as Record<string, any>)) {
+      if (!hookTypeStrings.includes(hookKey as any)) continue
+      const inputFields: Record<string, PublicActionField> = {}
+      for (const [fieldKey, fieldDef] of Object.entries((hook.inputFields ?? {}) as Record<string, any>)) {
+        inputFields[fieldKey] = serializeActionField(fieldDef)
+      }
+      const outputFields: Record<string, PublicActionField> = {}
+      for (const [fieldKey, fieldDef] of Object.entries((hook.outputTypes ?? {}) as Record<string, any>)) {
+        outputFields[fieldKey] = serializeActionField(fieldDef)
+      }
+      hooks[hookKey] = {
+        label: hook.label ?? hookKey,
+        description: hook.description ?? '',
+        inputFields,
+        outputFields
+      }
+    }
+  }
 
   return {
     title: action.title ?? actionKey,
@@ -162,7 +211,7 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
     hidden: action.hidden ?? false,
     hasPerformBatch: typeof action.performBatch === 'function',
     syncMode,
-    hooks,
+    hooks: Object.keys(hooks).length > 0 ? hooks : null,
     fields
   }
 }
@@ -193,12 +242,17 @@ export function generatePublicMetadata(
     }
   }
 
-  // audienceConfig: strip functions, keep mode + audienceFields
+  // audienceConfig: strip functions, keep mode + audienceFields + supportsAudienceFunctions
   let audienceConfig: PublicDestinationMetadata['audienceConfig'] = null
   if (audienceDef.audienceConfig) {
+    const mode = audienceDef.audienceConfig.mode as { type: string; full_audience_sync?: boolean }
+    const audienceConfigAny = audienceDef.audienceConfig as any
+    const supportsAudienceFunctions =
+      typeof audienceConfigAny.createAudience === 'function' && typeof audienceConfigAny.getAudience === 'function'
     audienceConfig = {
-      mode: audienceDef.audienceConfig.mode,
-      audienceFields: serializeAuthFields(audienceDef.audienceFields ?? {})
+      mode: { type: mode.type as 'synced' | 'realtime', full_audience_sync: mode.full_audience_sync },
+      audienceFields: serializeAuthFields(audienceDef.audienceFields ?? {}),
+      supportsAudienceFunctions
     }
   }
 

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -347,6 +347,32 @@ function resolveSourceDir(entryPath: string): string | null {
 
 export { resolveSourceDir }
 
+// Extracts destination directory names from file paths using known package layout patterns.
+export function extractDestinationDirs(paths: string[]): Set<string> {
+  const dirs = new Set<string>()
+  for (const p of paths) {
+    // Cloud: packages/destination-actions/src/destinations/<name>/...
+    const cloudMatch = p.match(/packages\/destination-actions\/src\/destinations\/([^/]+)/)
+    if (cloudMatch) {
+      dirs.add(cloudMatch[1])
+      continue
+    }
+    // Browser: packages/browser-destinations/destinations/<name>/...
+    const browserMatch = p.match(/packages\/browser-destinations\/destinations\/([^/]+)/)
+    if (browserMatch) {
+      dirs.add(browserMatch[1])
+      continue
+    }
+    // Warehouse: packages/warehouse-destinations/src/destinations/<name>/...
+    const warehouseMatch = p.match(/packages\/warehouse-destinations\/src\/destinations\/([^/]+)/)
+    if (warehouseMatch) {
+      dirs.add(warehouseMatch[1])
+      continue
+    }
+  }
+  return dirs
+}
+
 // ---- Command ----
 
 export default class GenerateMetadataPayload extends Command {
@@ -357,7 +383,8 @@ export default class GenerateMetadataPayload extends Command {
   static examples = [
     `$ ./bin/run generate:metadata-payload`,
     `$ ./bin/run generate:metadata-payload --slug=actions-amplitude`,
-    `$ ./bin/run generate:metadata-payload --mode=cloud`
+    `$ ./bin/run generate:metadata-payload --mode=cloud`,
+    `$ ./bin/run generate:metadata-payload -p packages/destination-actions/src/destinations/amplitude/index.ts`
   ]
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -373,6 +400,11 @@ export default class GenerateMetadataPayload extends Command {
       description: 'Only generate payload for destinations matching this mode (cloud, device, warehouse)',
       options: ['cloud', 'device', 'warehouse'],
       multiple: true
+    }),
+    path: flags.string({
+      char: 'p',
+      description: 'Only generate for destinations matching these file paths (extracts directory names)',
+      multiple: true
     })
   }
 
@@ -382,6 +414,10 @@ export default class GenerateMetadataPayload extends Command {
     const { flags: parsedFlags } = this.parse(GenerateMetadataPayload)
     const filterSlugs: string[] | undefined = parsedFlags['slug']
     const filterModes: string[] | undefined = parsedFlags['mode']
+    const filterPaths: string[] | undefined = parsedFlags['path']
+
+    // Extract destination directory names from --path values
+    const filterDirs: Set<string> | undefined = filterPaths ? extractDestinationDirs(filterPaths) : undefined
 
     this.spinner.start('Loading destination manifest...')
     let manifest: Record<string, any>
@@ -467,6 +503,14 @@ export default class GenerateMetadataPayload extends Command {
       if (filterModes && filterModes.length > 0) {
         const definitionMode = ((definition as any).mode ?? 'cloud') as string
         if (!filterModes.includes(definitionMode)) {
+          skipped++
+          continue
+        }
+      }
+
+      if (filterDirs && filterDirs.size > 0) {
+        const entryDir: string = entry.directory?.split('/').pop() ?? ''
+        if (!filterDirs.has(entryDir)) {
           skipped++
           continue
         }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -416,8 +416,13 @@ export default class GenerateMetadataPayload extends Command {
     const filterModes: string[] | undefined = parsedFlags['mode']
     const filterPaths: string[] | undefined = parsedFlags['path']
 
-    // Extract destination directory names from --path values
+    // Extract destination directory names from --path values.
+    // If --path is provided but no paths match known layouts, generate nothing.
     const filterDirs: Set<string> | undefined = filterPaths ? extractDestinationDirs(filterPaths) : undefined
+    if (filterPaths && filterDirs && filterDirs.size === 0) {
+      this.log('No destination directories matched the provided --path values. Nothing to generate.')
+      return
+    }
 
     this.spinner.start('Loading destination manifest...')
     let manifest: Record<string, any>

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -114,7 +114,8 @@ export function serializeAuthField(schema: any): PublicAuthField {
     label: schema.label,
     description: schema.description,
     type: schema.type,
-    required: typeof schema.required === 'object' && schema.required !== null ? schema.required : schema.required === true,
+    required:
+      typeof schema.required === 'object' && schema.required !== null ? schema.required : schema.required === true,
     multiple: schema.multiple ?? false,
     choices: normalizeChoices(schema.choices),
     default: schema.default ?? null,
@@ -520,6 +521,38 @@ export default class GenerateMetadataPayload extends Command {
           }
         } catch (err) {
           this.debug(`Skipping warehouse destination "${dir}": ${(err as Error).message}`)
+        }
+      }
+    }
+
+    // Discover browser destinations from the filesystem that don't have their own manifest entry.
+    // Browser "plugin" destinations share a metadata ID with their cloud counterpart and get merged,
+    // so they never get a standalone metadata.json unless we discover them independently.
+    const browserDestDir = path.join(process.cwd(), 'packages', 'browser-destinations', 'destinations')
+    if (await fs.pathExists(browserDestDir)) {
+      const coveredBrowserDirs = new Set(
+        Object.values(manifest)
+          .map((entry: any) => resolveSourceDir(entry.path))
+          .filter((p): p is string => p !== null && p.startsWith(browserDestDir))
+          .map((p) => path.basename(p))
+      )
+      const browserEntries = await fs.readdir(browserDestDir, { withFileTypes: true })
+      for (const entry of browserEntries) {
+        if (!entry.isDirectory()) continue
+        const dir = entry.name
+        if (coveredBrowserDirs.has(dir)) continue
+        const indexPath = path.join(browserDestDir, dir, 'src', 'index.ts')
+        if (!(await fs.pathExists(indexPath))) continue
+        try {
+          const definition = await loadDestination(indexPath)
+          if (!definition) continue
+          manifest[`browser:${dir}`] = {
+            definition,
+            directory: dir,
+            path: indexPath
+          }
+        } catch (err) {
+          this.debug(`Skipping browser destination "${dir}": ${(err as Error).message}`)
         }
       }
     }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -4,6 +4,7 @@ import type {
   DestinationDefinition as CloudDestinationDefinition
 } from '@segment/actions-core'
 import { hookTypeStrings } from '@segment/actions-core/destination-kit'
+import { execFileSync } from 'child_process'
 import fs from 'fs-extra'
 import path from 'path'
 import ora from 'ora'
@@ -526,6 +527,7 @@ export default class GenerateMetadataPayload extends Command {
     this.spinner.succeed(`Loaded ${Object.keys(manifest).length} destinations`)
 
     const entries = Object.entries(manifest)
+    const generatedFiles: string[] = []
     let generated = 0
     let skipped = 0
     let failed = 0
@@ -568,11 +570,22 @@ export default class GenerateMetadataPayload extends Command {
         const payload = generatePublicMetadata(slug, definition)
         const filePath = path.join(sourceDir, 'metadata.json')
         await fs.writeFile(filePath, JSON.stringify(payload, null, 2) + '\n')
+        generatedFiles.push(filePath)
         generated++
         this.spinner.succeed(`${definition.name} → ${filePath}`)
       } catch (err) {
         this.spinner.fail(`Failed for ${slug}: ${(err as Error).message}`)
         failed++
+      }
+    }
+
+    if (generatedFiles.length > 0) {
+      this.spinner.start('Formatting generated files with prettier...')
+      try {
+        execFileSync('npx', ['prettier', '--write', ...generatedFiles], { stdio: 'ignore' })
+        this.spinner.succeed('Formatted generated files with prettier')
+      } catch {
+        this.spinner.warn('prettier formatting failed — files may not match repo style')
       }
     }
 

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -525,22 +525,16 @@ export default class GenerateMetadataPayload extends Command {
       }
     }
 
-    // Discover browser destinations from the filesystem that don't have their own manifest entry.
-    // Browser "plugin" destinations share a metadata ID with their cloud counterpart and get merged,
-    // so they never get a standalone metadata.json unless we discover them independently.
+    // Discover ALL browser destinations from the filesystem independently.
+    // Browser destinations that share a metadataId with cloud get merged into the cloud entry,
+    // which means resolveSourceDir points to the cloud directory — so the browser directory
+    // never gets its own metadata.json unless we discover it here unconditionally.
     const browserDestDir = path.join(process.cwd(), 'packages', 'browser-destinations', 'destinations')
     if (await fs.pathExists(browserDestDir)) {
-      const coveredBrowserDirs = new Set(
-        Object.values(manifest)
-          .map((entry: any) => resolveSourceDir(entry.path))
-          .filter((p): p is string => p !== null && p.startsWith(browserDestDir))
-          .map((p) => path.basename(p))
-      )
       const browserEntries = await fs.readdir(browserDestDir, { withFileTypes: true })
       for (const entry of browserEntries) {
         if (!entry.isDirectory()) continue
         const dir = entry.name
-        if (coveredBrowserDirs.has(dir)) continue
         const indexPath = path.join(browserDestDir, dir, 'src', 'index.ts')
         if (!(await fs.pathExists(indexPath))) continue
         try {

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -34,6 +34,7 @@ export interface PublicActionField {
   dynamic: boolean
   default: unknown
   choices: Array<{ label: string; value: unknown }> | null
+  format: string | null
   placeholder: string | null
   properties: Record<string, PublicActionField> | null
   category: string | null
@@ -161,6 +162,7 @@ export function serializeActionField(field: any): PublicActionField {
     defaultObjectUI: field.defaultObjectUI ?? null,
     disabledInputMethods: field.disabledInputMethods ?? null,
     displayMode: field.displayMode ?? null,
+    format: field.format ?? null,
     additionalProperties: field.additionalProperties ?? false
   }
 }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -38,8 +38,8 @@ export interface PublicActionField {
   properties: Record<string, PublicActionField> | null
   category: string | null
   depends_on: unknown
-  readOnly: boolean
-  hidden: boolean
+  readOnly: boolean | null
+  hidden: boolean | null
   minimum: number | null
   maximum: number | null
   defaultObjectUI: string | null
@@ -153,8 +153,8 @@ export function serializeActionField(field: any): PublicActionField {
     properties,
     category: field.category ?? null,
     depends_on: field.depends_on ?? null,
-    readOnly: field.readOnly ?? false,
-    hidden: field.unsafe_hidden ?? false,
+    readOnly: field.readOnly ?? null,
+    hidden: field.unsafe_hidden ?? null,
     minimum: field.minimum ?? null,
     maximum: field.maximum ?? null,
     defaultObjectUI: field.defaultObjectUI ?? null,

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -490,6 +490,13 @@ export default class GenerateMetadataPayload extends Command {
       throw err
     }
 
+    // Register ts-node so loadDestination() can require .ts source files
+    try {
+      require('ts-node/register/transpile-only')
+    } catch {
+      // ts-node not available — filesystem discovery of .ts sources will be skipped
+    }
+
     // Discover unregistered cloud destinations from the filesystem
     const cloudDestDir = path.join(process.cwd(), 'packages', 'destination-actions', 'src', 'destinations')
     const registeredDirs = new Set(

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -88,7 +88,7 @@ export interface PublicDestinationMetadata {
   description: string | undefined
   authentication: { scheme: string; fields: Record<string, PublicAuthField> } | null
   audienceConfig: {
-    mode: { type: 'synced' | 'realtime'; full_audience_sync?: boolean }
+    mode: { type: 'synced'; full_audience_sync: boolean } | { type: 'realtime' }
     audienceFields: Record<string, PublicAuthField>
     supportsAudienceFunctions: boolean
   } | null
@@ -191,7 +191,9 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
         inputFields[fieldKey] = serializeActionField(fieldDef)
       }
       const outputFields: Record<string, PublicActionField> = {}
-      for (const [fieldKey, fieldDef] of Object.entries((hook.outputTypes ?? {}) as Record<string, any>)) {
+      for (const [fieldKey, fieldDef] of Object.entries(
+        (hook.outputTypes ?? hook.outputFields ?? {}) as Record<string, any>
+      )) {
         outputFields[fieldKey] = serializeActionField(fieldDef)
       }
       hooks[hookKey] = {
@@ -245,12 +247,16 @@ export function generatePublicMetadata(
   // audienceConfig: strip functions, keep mode + audienceFields + supportsAudienceFunctions
   let audienceConfig: PublicDestinationMetadata['audienceConfig'] = null
   if (audienceDef.audienceConfig) {
-    const mode = audienceDef.audienceConfig.mode as { type: string; full_audience_sync?: boolean }
+    const rawMode = audienceDef.audienceConfig.mode as { type: string; full_audience_sync?: boolean }
     const audienceConfigAny = audienceDef.audienceConfig as any
     const supportsAudienceFunctions =
       typeof audienceConfigAny.createAudience === 'function' && typeof audienceConfigAny.getAudience === 'function'
+    const mode =
+      rawMode.type === 'synced'
+        ? { type: 'synced' as const, full_audience_sync: rawMode.full_audience_sync ?? false }
+        : { type: 'realtime' as const }
     audienceConfig = {
-      mode: { type: mode.type as 'synced' | 'realtime', full_audience_sync: mode.full_audience_sync },
+      mode,
       audienceFields: serializeAuthFields(audienceDef.audienceFields ?? {}),
       supportsAudienceFunctions
     }
@@ -390,13 +396,18 @@ export default class GenerateMetadataPayload extends Command {
     const cloudDestDir = path.join(process.cwd(), 'packages', 'destination-actions', 'src', 'destinations')
     const registeredDirs = new Set(
       Object.values(manifest)
-        .filter((entry: any) => entry.path?.includes('packages/destination-actions'))
+        .filter((entry: any) => {
+          const entryPath: string = entry.path ?? ''
+          return entryPath.startsWith(cloudDestDir) || entryPath.includes('packages/destination-actions')
+        })
         .map((entry: any) => entry.directory as string)
     )
 
     if (await fs.pathExists(cloudDestDir)) {
-      const dirs = await fs.readdir(cloudDestDir)
-      for (const dir of dirs) {
+      const entries = await fs.readdir(cloudDestDir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue
+        const dir = entry.name
         if (registeredDirs.has(dir)) continue
         const indexPath = path.join(cloudDestDir, dir, 'index.ts')
         if (!(await fs.pathExists(indexPath))) continue
@@ -417,9 +428,10 @@ export default class GenerateMetadataPayload extends Command {
     // Discover warehouse destinations from the filesystem
     const warehouseDestDir = path.join(process.cwd(), 'packages', 'warehouse-destinations', 'src', 'destinations')
     if (await fs.pathExists(warehouseDestDir)) {
-      const dirs = await fs.readdir(warehouseDestDir)
-      for (const dir of dirs) {
-        if (dir === 'index.ts') continue
+      const entries = await fs.readdir(warehouseDestDir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue
+        const dir = entry.name
         const indexPath = path.join(warehouseDestDir, dir, 'index.ts')
         if (!(await fs.pathExists(indexPath))) continue
         try {

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -17,7 +17,7 @@ export interface PublicAuthField {
   label: string | undefined
   description: string | undefined
   type: string
-  required: boolean
+  required: boolean | { conditions: Array<{ fieldKey: string; operator: string; value: unknown }> }
   multiple: boolean
   choices: Array<{ label: string; value: unknown }> | null
   default: unknown
@@ -114,7 +114,7 @@ export function serializeAuthField(schema: any): PublicAuthField {
     label: schema.label,
     description: schema.description,
     type: schema.type,
-    required: schema.required === true,
+    required: typeof schema.required === 'object' && schema.required !== null ? schema.required : schema.required === true,
     multiple: schema.multiple ?? false,
     choices: normalizeChoices(schema.choices),
     default: schema.default ?? null,

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -8,6 +8,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import ora from 'ora'
 import { getManifest, DestinationDefinition, loadDestination } from '../../lib/destinations'
+import type { WarehouseDestinationDefinition } from '@segment/actions-core'
 
 // ---- Public output interfaces ----
 
@@ -166,20 +167,25 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
   }
 }
 
-export function generatePublicMetadata(slug: string, definition: DestinationDefinition): PublicDestinationMetadata {
+export function generatePublicMetadata(
+  slug: string,
+  definition: DestinationDefinition | WarehouseDestinationDefinition
+): PublicDestinationMetadata {
   if (!slug) {
     throw new Error(`metadata.json generation requires a slug but received: "${slug}"`)
   }
 
   const cloudDef = definition as CloudDestinationDefinition
   const browserDef = definition as any // BrowserDestinationDefinition
+  const warehouseDef = definition as unknown as WarehouseDestinationDefinition
   const audienceDef = definition as AudienceDestinationDefinition
 
-  // Authentication fields: cloud uses authentication.fields, browser uses settings
+  // Authentication fields: cloud uses authentication.fields, browser uses settings, warehouse uses settings
   let authentication: PublicDestinationMetadata['authentication'] = null
   const authFields = cloudDef.authentication?.fields
   const browserSettings = browserDef.settings
-  const rawFields = authFields ?? browserSettings
+  const warehouseSettings = warehouseDef.settings
+  const rawFields = authFields ?? browserSettings ?? warehouseSettings
   if (cloudDef.authentication || (rawFields && Object.keys(rawFields).length > 0)) {
     authentication = {
       scheme: cloudDef.authentication?.scheme ?? 'custom',
@@ -260,6 +266,22 @@ function resolveSourceDir(entryPath: string): string | null {
     return browserSrcMatch[1]
   }
 
+  // Compiled warehouse: .../packages/warehouse-destinations/dist/destinations/<name>/index.js
+  const warehouseDistMatch = entryPath.match(
+    /^(.+\/packages\/warehouse-destinations)\/dist\/destinations\/([^/]+)\/index\.js$/
+  )
+  if (warehouseDistMatch) {
+    return path.join(warehouseDistMatch[1], 'src', 'destinations', warehouseDistMatch[2])
+  }
+
+  // Source warehouse: .../packages/warehouse-destinations/src/destinations/<name>/index.ts
+  const warehouseSrcMatch = entryPath.match(
+    /^(.+\/packages\/warehouse-destinations\/src\/destinations\/[^/]+)\/index\.ts$/
+  )
+  if (warehouseSrcMatch) {
+    return warehouseSrcMatch[1]
+  }
+
   return null
 }
 
@@ -288,7 +310,7 @@ export default class GenerateMetadataPayload extends Command {
     }),
     mode: flags.string({
       char: 'm',
-      description: 'Only generate payload for destinations matching this mode (cloud, device)',
+      description: 'Only generate payload for destinations matching this mode (cloud, device, warehouse)',
       multiple: true
     })
   }
@@ -329,6 +351,28 @@ export default class GenerateMetadataPayload extends Command {
           }
         } catch {
           // Skip directories that fail to load (e.g. not valid destinations)
+        }
+      }
+    }
+
+    // Discover warehouse destinations from the filesystem
+    const warehouseDestDir = path.join(process.cwd(), 'packages', 'warehouse-destinations', 'src', 'destinations')
+    if (await fs.pathExists(warehouseDestDir)) {
+      const dirs = await fs.readdir(warehouseDestDir)
+      for (const dir of dirs) {
+        if (dir === 'index.ts') continue
+        const indexPath = path.join(warehouseDestDir, dir, 'index.ts')
+        if (!(await fs.pathExists(indexPath))) continue
+        try {
+          const definition = await loadDestination(indexPath)
+          if (!definition) continue
+          manifest[`warehouse:${dir}`] = {
+            definition,
+            directory: dir,
+            path: indexPath
+          }
+        } catch {
+          // Skip directories that fail to load
         }
       }
     }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -362,9 +362,10 @@ export default class GenerateMetadataPayload extends Command {
       description: 'Only generate payload for a specific destination slug',
       multiple: true
     }),
-    mode: flags.string({
+    mode: flags.enum({
       char: 'm',
       description: 'Only generate payload for destinations matching this mode (cloud, device, warehouse)',
+      options: ['cloud', 'device', 'warehouse'],
       multiple: true
     })
   }
@@ -387,7 +388,11 @@ export default class GenerateMetadataPayload extends Command {
 
     // Discover unregistered cloud destinations from the filesystem
     const cloudDestDir = path.join(process.cwd(), 'packages', 'destination-actions', 'src', 'destinations')
-    const registeredDirs = new Set(Object.values(manifest).map((entry: any) => entry.directory as string))
+    const registeredDirs = new Set(
+      Object.values(manifest)
+        .filter((entry: any) => entry.path?.includes('packages/destination-actions'))
+        .map((entry: any) => entry.directory as string)
+    )
 
     if (await fs.pathExists(cloudDestDir)) {
       const dirs = await fs.readdir(cloudDestDir)
@@ -403,8 +408,8 @@ export default class GenerateMetadataPayload extends Command {
             directory: dir,
             path: indexPath
           }
-        } catch {
-          // Skip directories that fail to load (e.g. not valid destinations)
+        } catch (err) {
+          this.debug(`Skipping unregistered destination "${dir}": ${(err as Error).message}`)
         }
       }
     }
@@ -425,8 +430,8 @@ export default class GenerateMetadataPayload extends Command {
             directory: dir,
             path: indexPath
           }
-        } catch {
-          // Skip directories that fail to load
+        } catch (err) {
+          this.debug(`Skipping warehouse destination "${dir}": ${(err as Error).message}`)
         }
       }
     }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -294,6 +294,32 @@ export function generatePublicMetadata(
 
 // ---- Path helpers ----
 
+// Lazily-built map from browser package name to source directory.
+let browserPkgMap: Map<string, string> | null = null
+
+function getBrowserPackageMap(): Map<string, string> {
+  if (browserPkgMap) return browserPkgMap
+  browserPkgMap = new Map()
+  const browsersDir = path.join(process.cwd(), 'packages', 'browser-destinations', 'destinations')
+  try {
+    const dirs = fs.readdirSync(browsersDir)
+    for (const dir of dirs) {
+      const pkgPath = path.join(browsersDir, dir, 'package.json')
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+        if (pkg.name) {
+          browserPkgMap.set(pkg.name, path.join(browsersDir, dir))
+        }
+      } catch {
+        // skip directories without valid package.json
+      }
+    }
+  } catch {
+    // browsersDir doesn't exist
+  }
+  return browserPkgMap
+}
+
 // Derives the source directory for a destination from its compiled entry path.
 // Cloud:   .../packages/destination-actions/dist/destinations/<name>/index.js
 //       →  .../packages/destination-actions/src/destinations/<name>
@@ -340,6 +366,14 @@ function resolveSourceDir(entryPath: string): string | null {
   )
   if (warehouseSrcMatch) {
     return warehouseSrcMatch[1]
+  }
+
+  // Browser via node_modules: .../node_modules/@segment/<pkg-name>/dist/cjs/index.js
+  const nodeModulesBrowserMatch = entryPath.match(/node_modules\/(@segment\/[^/]+)\/dist\//)
+  if (nodeModulesBrowserMatch) {
+    const pkgName = nodeModulesBrowserMatch[1]
+    const sourceDir = getBrowserPackageMap().get(pkgName)
+    if (sourceDir) return sourceDir
   }
 
   return null

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -28,7 +28,7 @@ export interface PublicActionField {
   label: string | undefined
   description: string | undefined
   type: string
-  required: boolean
+  required: boolean | { conditions: Array<{ fieldKey: string; operator: string; value: unknown }> }
   multiple: boolean
   allowNull: boolean
   dynamic: boolean
@@ -71,6 +71,7 @@ export interface PublicAction {
       outputFields: Record<string, PublicActionField>
     }
   > | null
+  dynamicFields: Record<string, string[]> | null
   fields: Record<string, PublicActionField>
 }
 
@@ -145,7 +146,7 @@ export function serializeActionField(field: any): PublicActionField {
     label: field.label,
     description: field.description,
     type: field.type,
-    required: field.required === true,
+    required: typeof field.required === 'object' && field.required !== null ? field.required : field.required === true,
     multiple: field.multiple ?? false,
     allowNull: field.allowNull ?? false,
     dynamic: typeof field.dynamic === 'function' ? true : field.dynamic ?? false,
@@ -209,6 +210,23 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
     }
   }
 
+  let dynamicFields: Record<string, string[]> | null = null
+  if (action.dynamicFields && typeof action.dynamicFields === 'object') {
+    dynamicFields = {}
+    for (const [fieldKey, fieldDynamic] of Object.entries(action.dynamicFields as Record<string, any>)) {
+      if (typeof fieldDynamic === 'function') continue
+      if (typeof fieldDynamic === 'object' && fieldDynamic !== null) {
+        const keys = Object.keys(fieldDynamic).filter((k) => k === '__keys__' || k === '__values__')
+        if (keys.length > 0) {
+          dynamicFields[fieldKey] = keys
+        }
+      }
+    }
+    if (Object.keys(dynamicFields).length === 0) {
+      dynamicFields = null
+    }
+  }
+
   return {
     title: action.title ?? actionKey,
     description: action.description ?? '',
@@ -218,6 +236,7 @@ export function serializeAction(actionKey: string, action: any): PublicAction {
     hasPerformBatch: typeof action.performBatch === 'function',
     syncMode,
     hooks: Object.keys(hooks).length > 0 ? hooks : null,
+    dynamicFields,
     fields
   }
 }

--- a/packages/cli/src/commands/generate/metadata-payload.ts
+++ b/packages/cli/src/commands/generate/metadata-payload.ts
@@ -7,7 +7,7 @@ import { hookTypeStrings } from '@segment/actions-core/destination-kit'
 import fs from 'fs-extra'
 import path from 'path'
 import ora from 'ora'
-import { getManifest, DestinationDefinition } from '../../lib/destinations'
+import { getManifest, DestinationDefinition, loadDestination } from '../../lib/destinations'
 
 // ---- Public output interfaces ----
 
@@ -274,7 +274,8 @@ export default class GenerateMetadataPayload extends Command {
 
   static examples = [
     `$ ./bin/run generate:metadata-payload`,
-    `$ ./bin/run generate:metadata-payload --slug=actions-amplitude`
+    `$ ./bin/run generate:metadata-payload --slug=actions-amplitude`,
+    `$ ./bin/run generate:metadata-payload --mode=cloud`
   ]
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -284,6 +285,11 @@ export default class GenerateMetadataPayload extends Command {
       char: 's',
       description: 'Only generate payload for a specific destination slug',
       multiple: true
+    }),
+    mode: flags.string({
+      char: 'm',
+      description: 'Only generate payload for destinations matching this mode (cloud, device)',
+      multiple: true
     })
   }
 
@@ -292,6 +298,7 @@ export default class GenerateMetadataPayload extends Command {
   async run() {
     const { flags: parsedFlags } = this.parse(GenerateMetadataPayload)
     const filterSlugs: string[] | undefined = parsedFlags['slug']
+    const filterModes: string[] | undefined = parsedFlags['mode']
 
     this.spinner.start('Loading destination manifest...')
     let manifest: Record<string, any>
@@ -301,6 +308,31 @@ export default class GenerateMetadataPayload extends Command {
       this.spinner.fail('Failed to load manifest')
       throw err
     }
+
+    // Discover unregistered cloud destinations from the filesystem
+    const cloudDestDir = path.join(process.cwd(), 'packages', 'destination-actions', 'src', 'destinations')
+    const registeredDirs = new Set(Object.values(manifest).map((entry: any) => entry.directory as string))
+
+    if (await fs.pathExists(cloudDestDir)) {
+      const dirs = await fs.readdir(cloudDestDir)
+      for (const dir of dirs) {
+        if (registeredDirs.has(dir)) continue
+        const indexPath = path.join(cloudDestDir, dir, 'index.ts')
+        if (!(await fs.pathExists(indexPath))) continue
+        try {
+          const definition = await loadDestination(indexPath)
+          if (!definition) continue
+          manifest[`unregistered:${dir}`] = {
+            definition,
+            directory: dir,
+            path: indexPath
+          }
+        } catch {
+          // Skip directories that fail to load (e.g. not valid destinations)
+        }
+      }
+    }
+
     this.spinner.succeed(`Loaded ${Object.keys(manifest).length} destinations`)
 
     const entries = Object.entries(manifest)
@@ -315,6 +347,14 @@ export default class GenerateMetadataPayload extends Command {
       if (filterSlugs && filterSlugs.length > 0 && !filterSlugs.includes(slug)) {
         skipped++
         continue
+      }
+
+      if (filterModes && filterModes.length > 0) {
+        const definitionMode = ((definition as any).mode ?? 'cloud') as string
+        if (!filterModes.includes(definitionMode)) {
+          skipped++
+          continue
+        }
       }
 
       this.spinner.start(`Generating payload for ${definition.name} (${slug})...`)

--- a/packages/cli/src/lib/destinations.ts
+++ b/packages/cli/src/lib/destinations.ts
@@ -58,6 +58,13 @@ export const getManifest: () => Record<string, CloudManifest | BrowserManifest> 
       }
 
       objValue.definition.actions[actionKey] = action
+
+      const cloudDef = objValue.definition as any
+      for (const [settingsKey, setting] of Object.entries((srcValue as any).definition?.settings ?? {})) {
+        if (cloudDef.authentication) {
+          cloudDef.authentication.fields[settingsKey] = setting
+        }
+      }
     }
 
     return objValue

--- a/scripts/assert-metadata-payload.sh
+++ b/scripts/assert-metadata-payload.sh
@@ -5,7 +5,8 @@ echo "Checking if metadata payloads are up-to-date"
 
 yarn generate:metadata-payload
 
-STALE=$(git status --porcelain -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
+# Only check already-tracked metadata.json files for modifications (ignore untracked)
+STALE=$(git diff --name-only -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
 
 if [ -n "$STALE" ]; then
   echo "The following metadata files are out of date:"

--- a/scripts/assert-metadata-payload.sh
+++ b/scripts/assert-metadata-payload.sh
@@ -5,11 +5,17 @@ echo "Checking if metadata payloads are up-to-date"
 
 yarn generate:metadata-payload
 
-# Only check already-tracked metadata.json files for modifications (ignore untracked)
-STALE=$(git diff --name-only -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
+# Check for modified tracked metadata.json files
+MODIFIED=$(git diff --name-only -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
+
+# Check for new untracked metadata.json files
+UNTRACKED=$(git ls-files --others --exclude-standard -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
+
+STALE="${MODIFIED}${UNTRACKED:+${MODIFIED:+
+}${UNTRACKED}}"
 
 if [ -n "$STALE" ]; then
-  echo "The following metadata files are out of date:"
+  echo "The following metadata files are out of date or missing from the commit:"
   echo "$STALE"
   echo ""
   echo "Please run 'yarn generate:metadata-payload' and commit the result!"

--- a/scripts/assert-metadata-payload.sh
+++ b/scripts/assert-metadata-payload.sh
@@ -5,7 +5,7 @@ echo "Checking if metadata payloads are up-to-date"
 
 yarn generate:metadata-payload
 
-STALE=$(git status --porcelain -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json')
+STALE=$(git status --porcelain -- 'packages/destination-actions/src/destinations/*/metadata.json' 'packages/browser-destinations/destinations/*/metadata.json' 'packages/warehouse-destinations/src/destinations/*/metadata.json')
 
 if [ -n "$STALE" ]; then
   echo "The following metadata files are out of date:"

--- a/scripts/update-metadata-payload.sh
+++ b/scripts/update-metadata-payload.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Regenerates metadata.json for destinations whose source files are staged.
+# Called by lint-staged with the list of staged file paths as arguments.
+set -e
+
+DIRS=""
+
+for file in "$@"; do
+  # Cloud: packages/destination-actions/src/destinations/<name>/...
+  dir=$(echo "$file" | sed -n 's|.*packages/destination-actions/src/destinations/\([^/]*\)/.*|\1|p')
+  if [ -n "$dir" ]; then
+    DIRS="$DIRS packages/destination-actions/src/destinations/$dir"
+    continue
+  fi
+
+  # Browser: packages/browser-destinations/destinations/<name>/...
+  dir=$(echo "$file" | sed -n 's|.*packages/browser-destinations/destinations/\([^/]*\)/.*|\1|p')
+  if [ -n "$dir" ]; then
+    DIRS="$DIRS packages/browser-destinations/destinations/$dir"
+    continue
+  fi
+
+  # Warehouse: packages/warehouse-destinations/src/destinations/<name>/...
+  dir=$(echo "$file" | sed -n 's|.*packages/warehouse-destinations/src/destinations/\([^/]*\)/.*|\1|p')
+  if [ -n "$dir" ]; then
+    DIRS="$DIRS packages/warehouse-destinations/src/destinations/$dir"
+    continue
+  fi
+done
+
+# Deduplicate
+DIRS=$(echo "$DIRS" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+
+if [ -z "$DIRS" ]; then
+  exit 0
+fi
+
+# Build --path arguments for each directory
+PATH_ARGS=""
+for dir in $DIRS; do
+  PATH_ARGS="$PATH_ARGS --path $dir"
+done
+
+# Regenerate metadata only for affected destinations
+./bin/run generate:metadata-payload $PATH_ARGS


### PR DESCRIPTION
## Summary

Comprehensive enhancements to the `generate:metadata-payload` CLI command:

- **`--mode` flag** (`-m`): Filter metadata generation by destination mode (cloud, device, warehouse)
- **`--path` flag** (`-p`): Generate metadata only for destinations matching given file paths — enables efficient targeted regeneration from lint-staged
- **Unregistered destination discovery**: Scans the filesystem for destinations not registered in `index.ts`, so metadata.json can be generated for WIP destinations
- **Warehouse destination support**: Discovers and generates metadata for warehouse destinations in `packages/warehouse-destinations/`
- **Lint-staged pre-commit hook**: Automatically regenerates and stages `metadata.json` when destination source files are modified
- **CI validation step**: Fails the build if any `metadata.json` is stale (runs full generation and checks for uncommitted diffs)
- **Enhanced serialization**: Includes syncMode, hooks (with inputFields/outputFields), audienceConfig (discriminated union mode), and all field properties (hidden, readOnly, minimum, maximum, defaultObjectUI, disabledInputMethods, displayMode, additionalProperties)
- **Deep review fixes**: Proper `outputTypes ?? outputFields` fallback for hooks, discriminated union for audienceConfig mode, robust `hookTypeStrings` filtering

### New files
- `scripts/update-metadata-payload.sh` — called by lint-staged to regenerate affected destinations' metadata
- `scripts/assert-metadata-payload.sh` — CI script that asserts no stale metadata.json files

### Modified files
- `packages/cli/src/commands/generate/metadata-payload.ts` — `--mode`, `--path` flags, `extractDestinationDirs()`, filesystem discovery
- `.github/workflows/ci.yml` — new validate step
- `package.json` — lint-staged config for metadata regeneration
- `packages/cli/src/__tests__/generate-metadata-payload.test.ts` — 63+ test cases covering all features

## Test plan
- [x] `./bin/run generate:metadata-payload --mode=cloud` generates only cloud destinations
- [x] `./bin/run generate:metadata-payload --path packages/destination-actions/src/destinations/amplitude` generates only amplitude
- [x] Unregistered destinations discovered from filesystem
- [x] Warehouse destinations discovered and processed
- [x] `--slug` flag still works
- [x] TypeScript compiles cleanly
- [x] lint-staged hook triggers `update-metadata-payload.sh` and stages metadata.json
- [x] CI `assert-metadata-payload.sh` checks cloud, browser, and warehouse metadata staleness

🤖 Generated with [Claude Code](https://claude.com/claude-code)