### PR TITLE
docs(liveramp-audiences): clarify that uploaded files are gzipped

### DIFF
--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/generated-types.ts
@@ -38,7 +38,7 @@ export interface Payload {
    */
   delimiter: string
   /**
-   * Name of the CSV file to upload for LiveRamp ingestion. For multiple subscriptions, make sure to use a unique filename for each subscription.
+   * Name of the CSV file to upload for LiveRamp ingestion. Files are gzipped before upload and `.gz` is appended to the filename in the destination S3 bucket (e.g. `audience.csv` becomes `audience.csv.gz`). For multiple subscriptions, make sure to use a unique filename for each subscription.
    */
   filename: string
   /**

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts
@@ -66,7 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     filename: {
       label: 'Filename',
-      description: `Name of the CSV file to upload for LiveRamp ingestion. For multiple subscriptions, make sure to use a unique filename for each subscription.`,
+      description: `Name of the CSV file to upload for LiveRamp ingestion. Files are gzipped before upload and \`.gz\` is appended to the filename in the destination S3 bucket (e.g. \`audience.csv\` becomes \`audience.csv.gz\`). For multiple subscriptions, make sure to use a unique filename for each subscription.`,
       type: 'string',
       required: true,
       default: { '@template': '{{properties.audience_key}}.csv' }

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/generated-types.ts
@@ -34,7 +34,7 @@ export interface Payload {
    */
   delimiter: string
   /**
-   * Name of the CSV file to upload for LiveRamp ingestion. For multiple subscriptions, make sure to use a unique filename for each subscription.
+   * Name of the CSV file to upload for LiveRamp ingestion. Files are gzipped before upload and `.gz` is appended to the filename in the destination SFTP folder (e.g. `audience_PII.csv` becomes `audience_PII.csv.gz`). For multiple subscriptions, make sure to use a unique filename for each subscription.
    */
   filename: string
   /**

--- a/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
+++ b/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts
@@ -63,7 +63,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     filename: {
       label: 'Filename',
-      description: `Name of the CSV file to upload for LiveRamp ingestion. For multiple subscriptions, make sure to use a unique filename for each subscription.`,
+      description: `Name of the CSV file to upload for LiveRamp ingestion. Files are gzipped before upload and \`.gz\` is appended to the filename in the destination SFTP folder (e.g. \`audience_PII.csv\` becomes \`audience_PII.csv.gz\`). For multiple subscriptions, make sure to use a unique filename for each subscription.`,
       type: 'string',
       required: true,
       default: { '@template': '{{properties.audience_key}}_PII.csv' }


### PR DESCRIPTION
## Summary
Clarifies the `Filename` field description for both `Audience Entered (S3)` and `Audience Entered (SFTP)` actions to note that files are gzipped on upload and `.gz` is appended to the filename in the destination bucket/folder.

## Why
The action passes `gzipCompressFile: true` to the backend by default ([audienceEnteredS3/index.ts:173](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredS3/index.ts#L173), [audienceEnteredSftp/index.ts:151](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/liveramp-audiences/audienceEnteredSftp/index.ts#L151)), so the file delivered to the customer's S3/SFTP has `.gz` appended (e.g. `audience.csv.gz`).

The current field description ("Name of the CSV file to upload for LiveRamp ingestion. For multiple subscriptions, make sure to use a unique filename for each subscription.") combined with the default value (`{{properties.audience_key}}.csv`) implies the file lands as `.csv`. A team integrating with this destination chased 404s on the non-gzipped filename in S3 before discovering the actual extension.

## Changes
- `audienceEnteredS3/index.ts` — append gzip + `.gz` note to `filename` field description
- `audienceEnteredSftp/index.ts` — append gzip + `.gz` note to `filename` field description
- `audienceEnteredS3/generated-types.ts` — regenerated via `./bin/run generate:types`
- `audienceEnteredSftp/generated-types.ts` — regenerated via `./bin/run generate:types`

No behavior changes; docs-only.

## Testing
Description-only update; no runtime behavior changes. Verified types regenerate cleanly via the existing tooling.