### PR TITLE
STRATCONN-6815 - [Twilio Messaging] - String if non string payload values

### DIFF
--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/__tests__/index.test.ts
@@ -228,6 +228,37 @@ describe('TwilioMessaging.sendMessage', () => {
     })
   })
 
+  it('should stringify non-string ContentVariables values (numbers, booleans)', async () => {
+    const expectedBody = 'To=%2B1234567890&MessagingServiceSid=MG1234567890abcdef1234567890abcdef&ContentSid=HX1234567890abcdef1234567890abcdef&ContentVariables=%7B%22amount_to_finance%22%3A%2212899%22%2C%22cash_price%22%3A%2212500%22%2C%22monthly_payment%22%3A%22285.28%22%2C%22term%22%3A%2260%22%2C%22is_approved%22%3A%22true%22%2C%22vehicle%22%3A%22500+Mhev%22%7D'
+
+    nock('https://api.twilio.com')
+      .post(`/2010-04-01/Accounts/${defaultSettings.accountSID}/Messages.json`, expectedBody)
+      .reply(200, {
+        sid: 'SM1234567890abcdef1234567890abcdef',
+        status: 'sent'
+      })
+
+    await testDestination.testAction('sendMessage', {
+      settings: defaultSettings,
+      mapping: {
+        channel: CHANNELS.SMS,
+        senderType: SENDER_TYPE.MESSAGING_SERVICE,
+        toPhoneNumber: '+1234567890',
+        messagingServiceSid: 'SMS Service [MG1234567890abcdef1234567890abcdef]',
+        contentTemplateType: 'Text',
+        contentSid: 'Template Name [HX1234567890abcdef1234567890abcdef]',
+        contentVariables: {
+          amount_to_finance: 12899,
+          cash_price: 12500,
+          monthly_payment: 285.28,
+          term: 60,
+          is_approved: true,
+          vehicle: '500 Mhev'
+        }
+      }
+    })
+  })
+
   it('should send MMS with phone number and inline template', async () => {
     nock('https://api.twilio.com').post(`/2010-04-01/Accounts/${defaultSettings.accountSID}/Messages.json`).reply(200, {
       sid: 'SM1234567890abcdef1234567890abcdef',

--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { createTestIntegration } from '@segment/actions-core'
 import { PayloadValidationError } from '@segment/actions-core'
 import Destination from '../../index'
 import nock from 'nock'
-import { CHANNELS, SENDER_TYPE } from '../constants'
+import { CHANNELS, SENDER_TYPE, FLAGON_NAME_STRINGIFY_CONTENT_VARIABLES } from '../constants'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -240,6 +240,7 @@ describe('TwilioMessaging.sendMessage', () => {
 
     await testDestination.testAction('sendMessage', {
       settings: defaultSettings,
+      features: { [FLAGON_NAME_STRINGIFY_CONTENT_VARIABLES]: true },
       mapping: {
         channel: CHANNELS.SMS,
         senderType: SENDER_TYPE.MESSAGING_SERVICE,

--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/constants.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/constants.ts
@@ -124,3 +124,5 @@ export const SENDER_TYPE = {
   FACEBOOK_PAGE_ID: 'Facebook Page ID',
   MESSAGING_SERVICE: 'Messaging Service'
 }
+
+export const FLAGON_NAME_STRINGIFY_CONTENT_VARIABLES = 'twilio-messaging-stringify-content-variables'

--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/index.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/index.ts
@@ -42,8 +42,8 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { payload, settings }) => {
-    return await send(request, payload, settings)
+  perform: async (request, { payload, settings, features }) => {
+    return await send(request, payload, settings, features)
   }
 }
 

--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/utils.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/utils.ts
@@ -1,4 +1,4 @@
-import { RequestClient, PayloadValidationError } from '@segment/actions-core'
+import { RequestClient, PayloadValidationError, Features } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import {
@@ -13,7 +13,8 @@ import {
   CHANNELS,
   ALL_CONTENT_TYPES,
   MIN_SCHEDULE_TIME_MS,
-  MAX_SCHEDULE_TIME_MS
+  MAX_SCHEDULE_TIME_MS,
+  FLAGON_NAME_STRINGIFY_CONTENT_VARIABLES
 } from './constants'
 import { 
   TwilioPayload, 
@@ -22,7 +23,7 @@ import {
   Schedule,
 } from './types'
 
-export async function send(request: RequestClient, payload: Payload, settings: Settings) {
+export async function send(request: RequestClient, payload: Payload, settings: Settings, features?: Features) {
   let { toPhoneNumber, contentSid, toMessengerUserId} = payload
 
   const {
@@ -96,10 +97,14 @@ export async function send(request: RequestClient, payload: Payload, settings: S
     }
 
     if (Object.keys(contentVariables ?? {}).length > 0) {
-      const stringified = Object.fromEntries(
-        Object.entries(contentVariables ?? {}).map(([k, v]) => [k, String(v)])
-      )
-      contentTemplate.ContentVariables = JSON.stringify(stringified)
+      if (features && features[FLAGON_NAME_STRINGIFY_CONTENT_VARIABLES]) {
+        const stringified = Object.fromEntries(
+          Object.entries(contentVariables ?? {}).map(([k, v]) => [k, String(v)])
+        )
+        contentTemplate.ContentVariables = JSON.stringify(stringified)
+      } else {
+        contentTemplate.ContentVariables = JSON.stringify(contentVariables)
+      }
     }
 
     return contentTemplate
@@ -193,6 +198,7 @@ export async function send(request: RequestClient, payload: Payload, settings: S
   }))()
 
   const encodedBody = encode(twilioPayload)
+  
   return await request(SEND_SMS_URL.replace(ACCOUNT_SID_TOKEN, settings.accountSID), {
     method: 'post',
     body: encodedBody

--- a/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/utils.ts
+++ b/packages/destination-actions/src/destinations/twilio-messaging/sendMessage/utils.ts
@@ -96,7 +96,10 @@ export async function send(request: RequestClient, payload: Payload, settings: S
     }
 
     if (Object.keys(contentVariables ?? {}).length > 0) {
-      contentTemplate.ContentVariables = JSON.stringify(contentVariables)
+      const stringified = Object.fromEntries(
+        Object.entries(contentVariables ?? {}).map(([k, v]) => [k, String(v)])
+      )
+      contentTemplate.ContentVariables = JSON.stringify(stringified)
     }
 
     return contentTemplate
@@ -190,7 +193,6 @@ export async function send(request: RequestClient, payload: Payload, settings: S
   }))()
 
   const encodedBody = encode(twilioPayload)
-
   return await request(SEND_SMS_URL.replace(ACCOUNT_SID_TOKEN, settings.accountSID), {
     method: 'post',
     body: encodedBody


### PR DESCRIPTION
 - Fixes Twilio error 21656 by stringifying ContentVariables values (numbers, booleans) before sending to the Twilio API, which requires all template variable values to be strings
  - Gated behind feature flag twilio-messaging-stringify-content-variables for safe rollout


## Testing
  - Added test verifying non-string ContentVariables values (numbers, booleans) are stringified when flag is enabled
  - All 55 existing Twilio Messaging tests continue to pass

Tested locally - but sent to production twilio - which sent an SMS with the correct values. 

See video for full test walkthrough. https://drive.google.com/file/d/1ULAU6TMb3yZUltXSUwy5y6yAUIwkjw7Z/view?usp=sharing

<img width="1125" height="2436" alt="joe mobile test with bool and numbers" src="https://github.com/user-attachments/assets/c82ca61c-db64-4d38-9d68-20859cbe4d57" />


## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
