### PR TITLE
[Accoustic] - Removing unreferenced field

### DIFF
--- a/packages/destination-actions/src/destinations/acoustic/generated-types.ts
+++ b/packages/destination-actions/src/destinations/acoustic/generated-types.ts
@@ -33,10 +33,4 @@ export interface Settings {
    * A safety against mapping too many attributes into the Event, Event will be ignored if number of Event Attributes exceeds this maximum. Note: Before increasing the default max number, consult the Acoustic Destination documentation.
    */
   attributesMax?: number
-  /**
-   *
-   * Last-Modified: 06.28.2023 16.15.37
-   *
-   */
-  version?: string
 }

--- a/packages/destination-actions/src/destinations/acoustic/index.ts
+++ b/packages/destination-actions/src/destinations/acoustic/index.ts
@@ -119,13 +119,6 @@ const destination: DestinationDefinition<Settings> = {
         default: 15,
         type: 'number',
         required: false
-      },
-      version: {
-        label: `Version:`,
-        description: `${mod}`,
-        default: `Version 3.1   (nodeJS: ${process.version})`,
-        type: 'string',
-        required: false
       }
     },
     refreshAccessToken: async (request, { settings }) => {

--- a/packages/destination-actions/src/destinations/acoustic/index.ts
+++ b/packages/destination-actions/src/destinations/acoustic/index.ts
@@ -3,9 +3,6 @@ import type { Settings } from './generated-types'
 import receiveEvents from './receiveEvents'
 import { getAccessToken } from './Utility/tablemaintutilities'
 
-const mod = `
-Last-Modified: 06.28.2023 16.15.37
-`
 //May 30th, refactor for additional Customers
 export interface refreshTokenResult {
   access_token: string


### PR DESCRIPTION
removing an unreferenced field from Accoustic destination. 
- no customers using the destination. 
- Field references node version process on Segment infra, which is not something we allow. 
- Field is not referenced in code (it's not used). 

## Testing

Not required. 

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
