### PR TITLE
Fix StackAdapt Audience destination overwriting mapping issue

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/functions.test.ts
@@ -1,4 +1,69 @@
-import { stringifyJsonWithEscapedQuotes, stringifyMappingSchemaForGraphQL } from '../forwardAudienceEvent/functions'
+import {
+  getConfiguredFieldsToMap,
+  getConfiguredFieldTypes,
+  stringifyJsonWithEscapedQuotes,
+  stringifyMappingSchemaForGraphQL
+} from '../forwardAudienceEvent/functions'
+
+describe('getConfiguredFieldsToMap', () => {
+  it('includes default profile fields and custom traits from destination mapping', () => {
+    const fields = getConfiguredFieldsToMap({
+      custom_traits: {
+        stackadapt_audience_membership: { '@path': '$.traits.stackadapt_audience_membership' },
+        custom_trait_1: { '@path': '$.traits.custom_trait_1' }
+      }
+    })
+
+    expect(fields.has('email')).toBe(true)
+    expect(fields.has('first_name')).toBe(true)
+    expect(fields.has('stackadapt_audience_membership')).toBe(true)
+    expect(fields.has('custom_trait_1')).toBe(true)
+  })
+
+  it('excludes reserved audience computation keys from custom trait mappings', () => {
+    const fields = getConfiguredFieldsToMap(
+      {
+        custom_traits: {
+          first_time_buyer: { '@path': '$.traits.first_time_buyer' },
+          aud_123: { '@path': '$.traits.aud_123' },
+          other_trait: { '@path': '$.traits.other_trait' }
+        }
+      },
+      ['first_time_buyer', 'aud_123']
+    )
+
+    expect(fields.has('first_time_buyer')).toBe(false)
+    expect(fields.has('aud_123')).toBe(false)
+    expect(fields.has('other_trait')).toBe(true)
+  })
+
+  it('returns the same configured fields when custom traits are absent from batch payloads', () => {
+    const rawMapping = {
+      custom_traits: {
+        stackadapt_audience_membership: { '@path': '$.traits.stackadapt_audience_membership' }
+      }
+    }
+
+    const fieldsWithTrait = getConfiguredFieldsToMap(rawMapping)
+    const fieldsWithoutTrait = getConfiguredFieldsToMap(rawMapping)
+
+    expect(fieldsWithTrait).toEqual(fieldsWithoutTrait)
+    expect(fieldsWithTrait.has('stackadapt_audience_membership')).toBe(true)
+  })
+})
+
+describe('getConfiguredFieldTypes', () => {
+  it('defaults configured custom traits to STRING type', () => {
+    const fieldTypes = getConfiguredFieldTypes({
+      custom_traits: {
+        stackadapt_audience_membership: { '@path': '$.traits.stackadapt_audience_membership' }
+      }
+    })
+
+    expect(fieldTypes.birth_date).toBe('DATE')
+    expect(fieldTypes.stackadapt_audience_membership).toBe('STRING')
+  })
+})
 
 describe('stringifyJsonWithEscapedQuotes', () => {
   it('should escape quotes in a simple object', () => {
@@ -37,7 +102,6 @@ describe('stringifyJsonWithEscapedQuotes', () => {
     expect(stringifyJsonWithEscapedQuotes(true)).toBe('true')
     expect(stringifyJsonWithEscapedQuotes(null)).toBe('null')
   })
-
 })
 
 describe('stringifyMappingSchemaForGraphQL', () => {
@@ -59,7 +123,7 @@ describe('stringifyMappingSchemaForGraphQL', () => {
     expect(stringifyMappingSchemaForGraphQL(input)).toBe(expected)
   })
 
-  it('should transform type field when it\'s already uppercase', () => {
+  it("should transform type field when it's already uppercase", () => {
     const input = { type: 'STRING' }
     const expected = '{type:STRING}'
     expect(stringifyMappingSchemaForGraphQL(input)).toBe(expected)
@@ -82,7 +146,8 @@ describe('stringifyMappingSchemaForGraphQL', () => {
         label: 'Email Address'
       }
     ]
-    const expected = '[{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"},{incomingKey:"email",destinationKey:"email",type:STRING,isPii:true,label:"Email Address"}]'
+    const expected =
+      '[{incomingKey:"userId",destinationKey:"external_id",type:STRING,isPii:false,label:"External Profile ID"},{incomingKey:"email",destinationKey:"email",type:STRING,isPii:true,label:"Email Address"}]'
     expect(stringifyMappingSchemaForGraphQL(input)).toBe(expected)
   })
 
@@ -130,4 +195,4 @@ describe('stringifyMappingSchemaForGraphQL', () => {
     const expected = '{field:{incomingKey:"nested",type:STRING},type:OBJECT}'
     expect(stringifyMappingSchemaForGraphQL(input)).toBe(expected)
   })
-}) 
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -259,7 +259,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"user_id\\",destinationKey:\\"external_id\\",label:\\"User ID\\",type:STRING,isPii:false},{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true}],
+                mappingSchemaV2: [{incomingKey:\\"user_id\\",destinationKey:\\"external_id\\",label:\\"User ID\\",type:STRING,isPii:false},{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"custom_trait_1\\",destinationKey:\\"custom_trait_1\\",label:\\"Custom Trait 1\\",type:STRING,isPii:false},{incomingKey:\\"custom_trait_2\\",destinationKey:\\"custom_trait_2\\",label:\\"Custom Trait 2\\",type:STRING,isPii:false}],
                 isOptedIn: true,
                 mappableType: \\"segment_io\\"
               }
@@ -282,6 +282,52 @@ describe('forwardAudienceEvent', () => {
         }",
       }
     `)
+  })
+
+  it('should include custom trait mappings from destination config even when batch payloads omit them', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const eventWithoutCustomTraits = createTestEvent({
+      userId: mockUserId,
+      type: 'track',
+      properties: { email: mockEmail },
+      context: {
+        traits: {
+          email: mockEmail,
+          first_name: 'Saray',
+          last_name: 'James'
+        },
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    })
+
+    const mappingWithCustomTrait = {
+      ...mockTrackMapping,
+      custom_traits: {
+        stackadapt_audience_membership: { '@path': '$.context.traits.stackadapt_audience_membership' }
+      }
+    }
+
+    const responses = await testDestination.testAction('forwardAudienceEvent', {
+      event: eventWithoutCustomTraits,
+      useDefaultMappings: true,
+      mapping: mappingWithCustomTrait,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    expect(requestBody.query).toContain('stackadapt_audience_membership')
+    expect(requestBody.query).toContain('Stackadapt Audience Membership')
   })
 
   it('should batch multiple Audience events into a single request', async () => {
@@ -319,7 +365,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"user_id\\",destinationKey:\\"external_id\\",label:\\"User ID\\",type:STRING,isPii:false},{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true}],
+                mappingSchemaV2: [{incomingKey:\\"user_id\\",destinationKey:\\"external_id\\",label:\\"User ID\\",type:STRING,isPii:false},{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"custom_trait_1\\",destinationKey:\\"custom_trait_1\\",label:\\"Custom Trait 1\\",type:STRING,isPii:false},{incomingKey:\\"custom_trait_2\\",destinationKey:\\"custom_trait_2\\",label:\\"Custom Trait 2\\",type:STRING,isPii:false}],
                 isOptedIn: true,
                 mappableType: \\"segment_io\\"
               }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -1,32 +1,30 @@
 import { RequestClient } from '@segment/actions-core'
 import { Settings } from '../generated-types'
-import {PROFILE_DEFAULT_FIELDS, MAPPING_SCHEMA, MarketingStatus as MarketingStatuses } from './constants'
-import {GQL_ENDPOINT, EXTERNAL_PROVIDER } from '../common-constants'
-import {  Mapping, MarketingStatus, ProfileFieldConfig } from './types'
+import { PROFILE_DEFAULT_FIELDS, MAPPING_SCHEMA, MarketingStatus as MarketingStatuses } from './constants'
+import { GQL_ENDPOINT, EXTERNAL_PROVIDER } from '../common-constants'
+import { Mapping, MarketingStatus, ProfileFieldConfig, RawMapping } from './types'
 import type { Payload } from './generated-types'
 import { sha256hash } from '../common-functions'
 
-export async function send(request: RequestClient, payloads: Payload[], settings: Settings) {
+export async function send(request: RequestClient, payloads: Payload[], settings: Settings, rawMapping: RawMapping) {
+  const reservedKeys = [payloads[0]?.segment_computation_key, payloads[0]?.segment_computation_id].filter(
+    (key): key is string => Boolean(key)
+  )
 
-  const fieldTypes = getDefaultFieldTypes()
-  const fieldsToMap = getDefaultFieldsToMap()
+  const fieldTypes = getConfiguredFieldTypes(rawMapping, reservedKeys)
+  const fieldsToMap = getConfiguredFieldsToMap(rawMapping, reservedKeys)
   const advertiserId = settings.advertiser_id
   const marketingStatus = payloads[0].marketing_status as MarketingStatus
-  
-  const profileUpdates = payloads.map((p) => {  
-    const {
-      user_id,
-      standard_traits,
-      custom_traits,
-      email
-    } = p
+
+  const profileUpdates = payloads.map((p) => {
+    const { user_id, standard_traits, custom_traits, email } = p
 
     const { segment_computation_key, segment_computation_id, traits_or_props } = p
 
-    if(custom_traits) {
-        // Remove reserved keys from custom traits just incase the customer accidentally maps them
-        delete custom_traits[segment_computation_key] 
-        delete custom_traits[segment_computation_id] 
+    if (custom_traits) {
+      // Remove reserved keys from custom traits just incase the customer accidentally maps them
+      delete custom_traits[segment_computation_key]
+      delete custom_traits[segment_computation_id]
     }
 
     const profile: Record<string, string | number | undefined> = {
@@ -39,8 +37,6 @@ export async function send(request: RequestClient, payloads: Payload[], settings
     profile.audienceId = segment_computation_id
     profile.audienceName = segment_computation_key
     profile.action = traits_or_props[segment_computation_key] ? 'enter' : 'exit'
-
-    updateFieldsToMapAndFieldTypes(fieldsToMap, fieldTypes, custom_traits)
 
     return profile
   })
@@ -73,7 +69,7 @@ export async function send(request: RequestClient, payloads: Payload[], settings
           message
         }
       }
-      ${ audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
+      ${audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
   }`
 
   return await request(GQL_ENDPOINT, {
@@ -92,38 +88,37 @@ function audienceMutation(advertiserId: string, audienceMapping: string): string
           userErrors {
             message
           }
-        }`;
+        }`
 }
 
+/** Build profile field keys from destination mapping config, not per-batch payload values. */
+export function getConfiguredFieldsToMap(rawMapping: RawMapping, reservedKeys: string[] = []): Set<string> {
+  const fieldsToMap = getDefaultFieldsToMap()
+  const customTraitsMapping = rawMapping.custom_traits
 
-function updateFieldsToMapAndFieldTypes(fieldsToMap: Set<string>, fieldTypes: Record<string, string>, customTraits: Payload['custom_traits'] = {}) {
-   // Process trait keys (already in snake_case) and capture any non-standard fields as mappings 
-  return Object.keys(customTraits).reduce((acc: Record<string, unknown>, key) => {
-    const value = customTraits[key]
-    
-    // Skip if key is empty string or value is empty string
-    if (key === '' || value === '') {
-      return acc
-    }
-    
-    acc[key] = value
-    
-    const standardFields = getDefaultFieldsToMap()
-
-    if (!standardFields.has(key)) {
-      fieldsToMap.add(key)
-      // Field type should be the most specific type of the values we've seen so far, use string if there is a conflict of types
-      if (value || value === 0) {
-        const type = getType(value)
-        if (fieldTypes[key] && fieldTypes[key] !== type) {
-          fieldTypes[key] = 'STRING'
-        } else {
-          fieldTypes[key] = type
-        }
+  if (customTraitsMapping && typeof customTraitsMapping === 'object') {
+    for (const key of Object.keys(customTraitsMapping)) {
+      if (!key || reservedKeys.includes(key) || fieldsToMap.has(key)) {
+        continue
       }
+      fieldsToMap.add(key)
     }
-    return acc
-  }, {})
+  }
+
+  return fieldsToMap
+}
+
+export function getConfiguredFieldTypes(rawMapping: RawMapping, reservedKeys: string[] = []): Record<string, string> {
+  const fieldTypes = getDefaultFieldTypes()
+  const configuredCustomKeys = getConfiguredFieldsToMap(rawMapping, reservedKeys)
+
+  for (const key of configuredCustomKeys) {
+    if (!fieldTypes[key]) {
+      fieldTypes[key] = 'STRING'
+    }
+  }
+
+  return fieldTypes
 }
 
 function getProfileMappings(customFields: string[], fieldTypes: Record<string, string>) {
@@ -131,7 +126,7 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
   for (const field of customFields) {
     // Keys are already in snake_case, so find directly in PROFILE_DEFAULT_FIELDS
     const fieldConfig = PROFILE_DEFAULT_FIELDS.find((f: ProfileFieldConfig) => f.key === field)
-    
+
     if (fieldConfig) {
       // Special mapping cases for StackAdapt destination keys
       let destinationKey: string
@@ -142,8 +137,8 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
         default:
           destinationKey = fieldConfig.key
       }
-      
-      // StackAdapt uses destinationKey to look up global fields so it has to match 
+
+      // StackAdapt uses destinationKey to look up global fields so it has to match
       mappingSchema.push({
         incomingKey: field, // Use original snake_case field name as incomingKey
         destinationKey,
@@ -180,52 +175,29 @@ function generateLabel(field: string) {
   return label
 }
 
-function getType(value: unknown) {
-  if (isDateStr(value)) return 'DATE'
-  return (typeof value).toUpperCase()
-}
-
-function isDateStr(value: unknown) {
-  if (typeof value !== 'string') return false
-  
-  const datePatterns = [
-    /^\d{4}-\d{2}-\d{2}/, // YYYY-MM-DD
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
-    /^\d{1,2}\/\d{1,2}\/\d{4}/, // MM/DD/YYYY
-    /^\d{1,2}-\d{1,2}-\d{4}/ // MM-DD-YYYY
-  ]
-  
-  const hasDatePattern = datePatterns.some(pattern => pattern.test(value))
-  if (!hasDatePattern) return false
-  
-  const parsed = Date.parse(value)
-  return !isNaN(parsed)
-}
-
 // transform an array of mapping objects into a string which can be sent as parameter in a GQL request
 export function stringifyJsonWithEscapedQuotes(value: unknown) {
-  const jsonString = JSON.stringify(value);
-  
+  const jsonString = JSON.stringify(value)
+
   // Finally escape all remaining quotes
-  return jsonString.replace(/"/g, '\\"');
+  return jsonString.replace(/"/g, '\\"')
 }
 
 // transform mapping schema for direct insertion into GraphQL queries (no quote escaping)
 export function stringifyMappingSchemaForGraphQL(value: unknown) {
   let jsonString = JSON.stringify(value)
-  
+
   // Replace "type":"VALUE" with type:VALUE (unquoted enum and field)
-  jsonString = jsonString.replace(/"type":"([^"]+)"/g, (_, typeValue: string) => 
-    `type:${typeValue.toUpperCase()}`)
-  
+  jsonString = jsonString.replace(/"type":"([^"]+)"/g, (_, typeValue: string) => `type:${typeValue.toUpperCase()}`)
+
   // Remove quotes from all object keys to make it valid GraphQL syntax
-  jsonString = jsonString.replace(/"([a-zA-Z_][a-zA-Z0-9_]*)"\s*:/g, '$1:');
-  
+  jsonString = jsonString.replace(/"([a-zA-Z_][a-zA-Z0-9_]*)"\s*:/g, '$1:')
+
   return jsonString
 }
 
 const getDefaultFieldsToMap = (): Set<string> => {
-  return new Set(PROFILE_DEFAULT_FIELDS.map(field => field.key))
+  return new Set(PROFILE_DEFAULT_FIELDS.map((field) => field.key))
 }
 
 const getDefaultFieldTypes = (): Record<string, string> => {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -3,6 +3,7 @@ import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { send } from './functions'
 import { audience_only_fields, profile_fields } from './fields'
+import type { PerformData } from './types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
@@ -23,14 +24,18 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.properties.email' }
         }
-      } 
+      }
     }
   },
-  perform: async (request, { payload, settings }) => {
-    return await send(request, [payload], settings)
+  perform: async (request, data) => {
+    const { payload, settings } = data
+    const rawMapping = (data as PerformData).rawMapping
+    return await send(request, [payload], settings, rawMapping)
   },
-  performBatch: async (request, { payload, settings }) => {
-    return await send(request, payload, settings)
+  performBatch: async (request, data) => {
+    const { payload, settings } = data
+    const rawMapping = (data as PerformData).rawMapping
+    return await send(request, payload, settings, rawMapping)
   }
 }
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
@@ -35,8 +35,18 @@ export interface Mapping {
   destinationKey: string
   label: string
   type: string
-  isPii: boolean  
+  isPii: boolean
   value?: string
 }
 
 export type MarketingStatus = typeof MarketingStatus[keyof typeof MarketingStatus]
+
+/** Destination action mapping config (unresolved DSL) passed via perform context. */
+export interface RawMapping {
+  custom_traits?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface PerformData {
+  rawMapping: RawMapping
+}


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->
Fixes a bug where `upsertProfileMapping` could overwrite a customer's profile field schema when later batches omitted custom traits that earlier batches had included.

Previously, `mappingSchemaV2` was built from custom traits present on the resolved batch payload. During audience backfills, traits are sparse across batches (not every user has every mapped field). A batch without a configured custom trait would send a smaller schema and replace the full mapping on StackAdapt's side. Because `upsertProfiles` and `upsertProfileMapping` are processed asynchronously, this caused downstream fields to disappear after initially being registered.

This change builds `mappingSchemaV2` from the destination subscription mapping (rawMapping in the perform context — same pattern as SFTP), combining:
- Standard fields from `PROFILE_DEFAULT_FIELDS`
- Custom trait keys from `rawMapping.custom_traits `(customer-configured in the Segment UI)

Profile values in `upsertProfiles` are unchanged; only schema registration is stabilized.

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
