### PR TITLE
[Stackadapt Audiences] - fix schema overwrite during sparse batches 

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,24 +3,24 @@
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - all fields 1`] = `
 Object {
   "query": "mutation {
-      upsertProfiles(
-        input: {
-          advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"d2fb3835dfccf5a564aeabd342d74bb1b9afd34dfb6e0f96b1c2c16e2ef40a0e\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"email\\\\\\":\\\\\\"kagaca@til.zw\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-03-24\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"John\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Doe\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"10 pleasant st.\\\\\\",\\\\\\"city\\\\\\":\\\\\\"Pleasantville\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"12345\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"testType\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
-        }
-      ) {
-        userErrors {
-          message
-        }
-      }
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"testType\\",destinationKey:\\"testType\\",label:\\"TestType\\",type:STRING,isPii:false}],
           isOptedIn: false,
           mappableType: \\"segment_io\\"
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      upsertProfiles(
+        input: {
+          advertiserId: 84GW[vK%wv2xv@UF5iy,
+          externalProvider: \\"segment_io\\",
+          syncId: \\"d2fb3835dfccf5a564aeabd342d74bb1b9afd34dfb6e0f96b1c2c16e2ef40a0e\\",
+          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"email\\\\\\":\\\\\\"kagaca@til.zw\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-03-24\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"John\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Doe\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"10 pleasant st.\\\\\\",\\\\\\"city\\\\\\":\\\\\\"Pleasantville\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"12345\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"testType\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
       ) {
         userErrors {
@@ -45,24 +45,24 @@ Object {
 exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardAudienceEvent action - required fields 1`] = `
 Object {
   "query": "mutation {
-      upsertProfiles(
-        input: {
-          advertiserId: 84GW[vK%wv2xv@UF5iy,
-          externalProvider: \\"segment_io\\",
-          syncId: \\"873aa585063338b3efd50b2092fd15a1eaa98d1496f56b96624418b0a723578e\\",
-          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"email\\\\\\":\\\\\\"kagaca@til.zw\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-03-24\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"John\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Doe\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"10 pleasant st.\\\\\\",\\\\\\"city\\\\\\":\\\\\\"Pleasantville\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"12345\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
-        }
-      ) {
-        userErrors {
-          message
-        }
-      }
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
           mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true}],
           isOptedIn: false,
           mappableType: \\"segment_io\\"
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      upsertProfiles(
+        input: {
+          advertiserId: 84GW[vK%wv2xv@UF5iy,
+          externalProvider: \\"segment_io\\",
+          syncId: \\"873aa585063338b3efd50b2092fd15a1eaa98d1496f56b96624418b0a723578e\\",
+          profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"email\\\\\\":\\\\\\"kagaca@til.zw\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-03-24\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"John\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Doe\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"10 pleasant st.\\\\\\",\\\\\\"city\\\\\\":\\\\\\"Pleasantville\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"12345\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"84GW[vK%wv2xv@UF5iy\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
         }
       ) {
         userErrors {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -123,8 +123,8 @@ const mockTrackMapping = {
     birth_date: { '@path': '$.context.traits.birth_date' }
   },
   custom_traits: {
-    custom_trait_1: { '@path': '$.traits.custom_trait_1' },
-    custom_trait_2: { '@path': '$.traits.custom_trait_2' }
+    custom_trait_1: { '@path': '$.context.traits.custom_trait_1' },
+    custom_trait_2: { '@path': '$.context.traits.custom_trait_2' }
   },
   computation_class: { '@path': '$.context.personas.computation_class' },
   computation_key: { '@path': '$.context.personas.computation_key' },
@@ -248,8 +248,8 @@ describe('forwardAudienceEvent', () => {
               input: {
                 advertiserId: 23,
                 externalProvider: \\"segment_io\\",
-                syncId: \\"c89d66b1eed79b7dcd6a2bd3745b81be559bb3077d543cdccb57c023394b0044\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
+                syncId: \\"7032157de1ee57b5a7f9512fb65fbe2dff58e53c998cc6095199dac55741e6f8\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"custom_trait_1\\\\\\":\\\\\\"custom_value_1\\\\\\",\\\\\\"custom_trait_2\\\\\\":\\\\\\"custom_value_2\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -259,7 +259,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true}],
+                mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"custom_trait_1\\",destinationKey:\\"custom_trait_1\\",label:\\"Custom Trait 1\\",type:STRING,isPii:false},{incomingKey:\\"custom_trait_2\\",destinationKey:\\"custom_trait_2\\",label:\\"Custom Trait 2\\",type:STRING,isPii:false}],
                 isOptedIn: true,
                 mappableType: \\"segment_io\\"
               }
@@ -301,46 +301,174 @@ describe('forwardAudienceEvent', () => {
     })
     expect(responses.length).toBe(1)
     expect(responses[0].status).toBe(200)
-    expect(requestBody).toMatchInlineSnapshot(`
-      Object {
-        "query": "mutation {
-            upsertProfiles(
-              input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"869391dc2b8136c0d7bff13ce4e84645e04860e7cdf0a05794cdf60e7a938393\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"},{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
-              }
-            ) {
-              userErrors {
-                message
-              }
-            }
-            upsertProfileMapping(
-              input: {
-                advertiserId: 23,
-                mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true}],
-                isOptedIn: true,
-                mappableType: \\"segment_io\\"
-              }
-            ) {
-              userErrors {
-                message
-              }
-            }
-            upsertExternalAudienceMapping(
-                input: {
-                  advertiserId: 23,
-                  mappingSchema: [{incomingKey:\\"audienceId\\",destinationKey:\\"external_id\\",type:STRING,label:\\"External Audience ID\\",isPii:false},{incomingKey:\\"audienceName\\",destinationKey:\\"name\\",type:STRING,label:\\"External Audience Name\\",isPii:false}],
-                  mappableType: \\"segment_io\\"
-                }
-              ) {
-                userErrors {
-                  message
-                }
-              }
-        }",
+    expect(requestBody.query).toContain('upsertProfiles')
+    expect(requestBody.query).toContain('upsertProfileMapping')
+    expect(requestBody.query).toContain('custom_trait_1')
+    expect(requestBody.query).toContain('custom_trait_2')
+  })
+
+  it('should include custom trait in schema when only some payloads have it', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const eventWithCustomTrait: Partial<SegmentEvent> = {
+      userId: mockUserId,
+      type: 'identify',
+      traits: {
+        email: mockEmail,
+        first_name: 'Billy',
+        loyalty_tier: 'gold',
+        first_time_buyer: true
+      },
+      context: {
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
       }
-    `)
+    }
+
+    const eventWithoutCustomTrait: Partial<SegmentEvent> = {
+      userId: 'user-2',
+      type: 'identify',
+      traits: {
+        email: 'other@test.com',
+        first_name: 'Jane',
+        first_time_buyer: true
+      },
+      context: {
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    }
+
+    const mapping = {
+      ...mockIdentifyMapping,
+      custom_traits: {
+        loyalty_tier: { '@path': '$.traits.loyalty_tier' }
+      }
+    }
+
+    const events = [createTestEvent(eventWithCustomTrait), createTestEvent(eventWithoutCustomTrait)]
+    const responses = await testDestination.testBatchAction('forwardAudienceEvent', {
+      events,
+      useDefaultMappings: true,
+      mapping,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    // The schema should include loyalty_tier even though only the first payload has it
+    expect(requestBody.query).toContain('loyalty_tier')
+    expect(requestBody.query).toContain('Loyalty Tier')
+  })
+
+  it('should exclude reserved computation keys from schema', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const event: Partial<SegmentEvent> = {
+      userId: mockUserId,
+      type: 'identify',
+      traits: {
+        email: mockEmail,
+        first_time_buyer: true,
+        aud_123: true,
+        real_custom_trait: 'value'
+      },
+      context: {
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    }
+
+    const mapping = {
+      ...mockIdentifyMapping,
+      custom_traits: {
+        first_time_buyer: { '@path': '$.traits.first_time_buyer' },
+        aud_123: { '@path': '$.traits.aud_123' },
+        real_custom_trait: { '@path': '$.traits.real_custom_trait' }
+      }
+    }
+
+    const responses = await testDestination.testAction('forwardAudienceEvent', {
+      event: createTestEvent(event),
+      useDefaultMappings: true,
+      mapping,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    // Schema should include the real custom trait but NOT the reserved computation keys
+    const schemaSection = requestBody.query.split('mappingSchemaV2:')[1]
+    expect(schemaSection).toContain('real_custom_trait')
+    expect(schemaSection).not.toContain('"first_time_buyer"')
+    expect(schemaSection).not.toContain('"aud_123"')
+  })
+
+  it('should not duplicate standard fields when they appear in custom_traits', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const event: Partial<SegmentEvent> = {
+      userId: mockUserId,
+      type: 'identify',
+      traits: {
+        email: mockEmail,
+        first_name: 'Billy',
+        first_time_buyer: true
+      },
+      context: {
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    }
+
+    const mapping = {
+      ...mockIdentifyMapping,
+      custom_traits: {
+        email: { '@path': '$.traits.email' },
+        first_name: { '@path': '$.traits.first_name' }
+      }
+    }
+
+    const responses = await testDestination.testAction('forwardAudienceEvent', {
+      event: createTestEvent(event),
+      useDefaultMappings: true,
+      mapping,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    // email and first_name are standard fields — they should not be duplicated in the schema
+    // even when the customer also maps them in custom_traits
+    const schemaSection = requestBody.query.split('mappingSchemaV2:')[1]
+    const emailOccurrences = schemaSection.split('incomingKey').filter((s: string) => s.startsWith(':\\"email\\"') || s.startsWith(':"email"'))
+    expect(emailOccurrences).toHaveLength(1)
   })
 })

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -470,6 +470,51 @@ describe('forwardAudienceEvent', () => {
     expect(requestBody.query).toContain('vip_status')
   })
 
+  it('should ignore mapping directive keys starting with @ in custom_traits', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const event: Partial<SegmentEvent> = {
+      userId: mockUserId,
+      type: 'identify',
+      traits: {
+        email: mockEmail,
+        first_name: 'Billy',
+        first_time_buyer: true
+      },
+      context: {
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    }
+
+    const mapping = {
+      ...mockIdentifyMapping,
+      custom_traits: {
+        '@path': '$.traits'
+      }
+    }
+
+    const responses = await testDestination.testAction('forwardAudienceEvent', {
+      event: createTestEvent(event),
+      useDefaultMappings: true,
+      mapping,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    const schemaSection = requestBody.query.split('mappingSchemaV2:')[1]
+    expect(schemaSection).not.toContain('@path')
+  })
+
   it('should not duplicate standard fields when they appear in custom_traits', async () => {
     let requestBody
     nock(gqlHostUrl)

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -423,6 +423,53 @@ describe('forwardAudienceEvent', () => {
     expect(schemaSection).not.toContain('"aud_123"')
   })
 
+  it('should include configured custom traits in schema even when no payloads contain them', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+
+    const eventWithoutCustomTraits: Partial<SegmentEvent> = {
+      userId: mockUserId,
+      type: 'track',
+      properties: { email: mockEmail },
+      context: {
+        traits: {
+          email: mockEmail,
+          first_name: 'Saray',
+          last_name: 'James'
+        },
+        personas: {
+          computation_class: 'audience',
+          computation_key: 'first_time_buyer',
+          computation_id: 'aud_123'
+        }
+      }
+    }
+
+    const mapping = {
+      ...mockTrackMapping,
+      custom_traits: {
+        loyalty_tier: { '@path': '$.context.traits.loyalty_tier' },
+        vip_status: { '@path': '$.context.traits.vip_status' }
+      }
+    }
+
+    const responses = await testDestination.testAction('forwardAudienceEvent', {
+      event: createTestEvent(eventWithoutCustomTraits),
+      useDefaultMappings: true,
+      mapping,
+      settings: { apiKey: mockGqlKey, advertiser_id: mockAdvertiserId }
+    })
+
+    expect(responses[0].status).toBe(200)
+    expect(requestBody.query).toContain('loyalty_tier')
+    expect(requestBody.query).toContain('vip_status')
+  })
+
   it('should not duplicate standard fields when they appear in custom_traits', async () => {
     let requestBody
     nock(gqlHostUrl)

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -169,24 +169,24 @@ describe('forwardAudienceEvent', () => {
     expect(requestBody).toMatchInlineSnapshot(`
       Object {
         "query": "mutation {
-            upsertProfiles(
-              input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"737a606596d5e41e69595b9fbf8ea4b3f61400cc172ac05cf1a0811d90a5b5dd\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Billy\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Bob\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Main St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"San Francisco\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"94105\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"custom_trait_1\\\\\\":\\\\\\"custom_value_1\\\\\\",\\\\\\"custom_trait_2\\\\\\":\\\\\\"custom_value_2\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
-              }
-            ) {
-              userErrors {
-                message
-              }
-            }
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"custom_trait_1\\",destinationKey:\\"custom_trait_1\\",label:\\"Custom Trait 1\\",type:STRING,isPii:false},{incomingKey:\\"custom_trait_2\\",destinationKey:\\"custom_trait_2\\",label:\\"Custom Trait 2\\",type:STRING,isPii:false}],
                 isOptedIn: true,
                 mappableType: \\"segment_io\\"
+              }
+            ) {
+              userErrors {
+                message
+              }
+            }
+            upsertProfiles(
+              input: {
+                advertiserId: 23,
+                externalProvider: \\"segment_io\\",
+                syncId: \\"737a606596d5e41e69595b9fbf8ea4b3f61400cc172ac05cf1a0811d90a5b5dd\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Billy\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"Bob\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"1234567890\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Main St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"San Francisco\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"CA\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"94105\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"PST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"custom_trait_1\\\\\\":\\\\\\"custom_value_1\\\\\\",\\\\\\"custom_trait_2\\\\\\":\\\\\\"custom_value_2\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -244,24 +244,24 @@ describe('forwardAudienceEvent', () => {
     expect(requestBody).toMatchInlineSnapshot(`
       Object {
         "query": "mutation {
-            upsertProfiles(
-              input: {
-                advertiserId: 23,
-                externalProvider: \\"segment_io\\",
-                syncId: \\"7032157de1ee57b5a7f9512fb65fbe2dff58e53c998cc6095199dac55741e6f8\\",
-                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"custom_trait_1\\\\\\":\\\\\\"custom_value_1\\\\\\",\\\\\\"custom_trait_2\\\\\\":\\\\\\"custom_value_2\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
-              }
-            ) {
-              userErrors {
-                message
-              }
-            }
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
                 mappingSchemaV2: [{incomingKey:\\"email\\",destinationKey:\\"email\\",label:\\"Email\\",type:STRING,isPii:true},{incomingKey:\\"first_name\\",destinationKey:\\"first_name\\",label:\\"First Name\\",type:STRING,isPii:true},{incomingKey:\\"last_name\\",destinationKey:\\"last_name\\",label:\\"Last Name\\",type:STRING,isPii:true},{incomingKey:\\"phone\\",destinationKey:\\"phone\\",label:\\"Phone\\",type:STRING,isPii:true},{incomingKey:\\"address\\",destinationKey:\\"address\\",label:\\"Address\\",type:STRING,isPii:true},{incomingKey:\\"city\\",destinationKey:\\"city\\",label:\\"City\\",type:STRING,isPii:false},{incomingKey:\\"state\\",destinationKey:\\"state\\",label:\\"State\\",type:STRING,isPii:false},{incomingKey:\\"country\\",destinationKey:\\"country\\",label:\\"Country\\",type:STRING,isPii:false},{incomingKey:\\"postal_code\\",destinationKey:\\"postal_code\\",label:\\"Postal Code\\",type:STRING,isPii:false},{incomingKey:\\"timezone\\",destinationKey:\\"timezone\\",label:\\"Timezone\\",type:STRING,isPii:false},{incomingKey:\\"birth_date\\",destinationKey:\\"birth_date\\",label:\\"Birth Date\\",type:DATE,isPii:true},{incomingKey:\\"custom_trait_1\\",destinationKey:\\"custom_trait_1\\",label:\\"Custom Trait 1\\",type:STRING,isPii:false},{incomingKey:\\"custom_trait_2\\",destinationKey:\\"custom_trait_2\\",label:\\"Custom Trait 2\\",type:STRING,isPii:false}],
                 isOptedIn: true,
                 mappableType: \\"segment_io\\"
+              }
+            ) {
+              userErrors {
+                message
+              }
+            }
+            upsertProfiles(
+              input: {
+                advertiserId: 23,
+                externalProvider: \\"segment_io\\",
+                syncId: \\"7032157de1ee57b5a7f9512fb65fbe2dff58e53c998cc6095199dac55741e6f8\\",
+                profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"email\\\\\\":\\\\\\"test@email.com\\\\\\",\\\\\\"first_name\\\\\\":\\\\\\"Saray\\\\\\",\\\\\\"last_name\\\\\\":\\\\\\"James\\\\\\",\\\\\\"phone\\\\\\":\\\\\\"45678765\\\\\\",\\\\\\"address\\\\\\":\\\\\\"123 Barn St\\\\\\",\\\\\\"city\\\\\\":\\\\\\"NYC\\\\\\",\\\\\\"country\\\\\\":\\\\\\"USA\\\\\\",\\\\\\"state\\\\\\":\\\\\\"NY\\\\\\",\\\\\\"postal_code\\\\\\":\\\\\\"29323\\\\\\",\\\\\\"timezone\\\\\\":\\\\\\"EST\\\\\\",\\\\\\"birth_date\\\\\\":\\\\\\"1990-06-15\\\\\\",\\\\\\"custom_trait_1\\\\\\":\\\\\\"custom_value_1\\\\\\",\\\\\\"custom_trait_2\\\\\\":\\\\\\"custom_value_2\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"exit\\\\\\"}]\\"
               }
             ) {
               userErrors {
@@ -515,7 +515,9 @@ describe('forwardAudienceEvent', () => {
     // email and first_name are standard fields — they should not be duplicated in the schema
     // even when the customer also maps them in custom_traits
     const schemaSection = requestBody.query.split('mappingSchemaV2:')[1]
-    const emailOccurrences = schemaSection.split('incomingKey').filter((s: string) => s.startsWith(':\\"email\\"') || s.startsWith(':"email"'))
+    const emailOccurrences = schemaSection
+      .split('incomingKey')
+      .filter((s: string) => s.startsWith(':\\"email\\"') || s.startsWith(':"email"'))
     expect(emailOccurrences).toHaveLength(1)
   })
 })

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/fields.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/fields.ts
@@ -187,7 +187,7 @@ export const profile_fields: Record<string, InputField> = {
       label: 'Custom User Properties',
       type: 'object',
       description: 'Custom properties for the user.',
-      defaultObjectUI: 'keyvalue',
+      defaultObjectUI: 'keyvalue:only',
       required: false
     },
     user_id: {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -13,7 +13,9 @@ export async function send(request: RequestClient, payloads: Payload[], settings
   const advertiserId = settings.advertiser_id
   const marketingStatus = payloads[0].marketing_status as MarketingStatus
   
-  const profileUpdates = payloads.map((p) => {  
+  const reservedKeys = [payloads[0]?.segment_computation_key, payloads[0]?.segment_computation_id]
+
+  const profileUpdates = payloads.map((p) => {
     const {
       user_id,
       standard_traits,
@@ -24,9 +26,8 @@ export async function send(request: RequestClient, payloads: Payload[], settings
     const { segment_computation_key, segment_computation_id, traits_or_props } = p
 
     if(custom_traits) {
-        // Remove reserved keys from custom traits just incase the customer accidentally maps them
-        delete custom_traits[segment_computation_key] 
-        delete custom_traits[segment_computation_id] 
+        delete custom_traits[segment_computation_key]
+        delete custom_traits[segment_computation_id]
     }
 
     const profile: Record<string, string | number | undefined> = {
@@ -40,10 +41,20 @@ export async function send(request: RequestClient, payloads: Payload[], settings
     profile.audienceName = segment_computation_key
     profile.action = traits_or_props[segment_computation_key] ? 'enter' : 'exit'
 
-    updateFieldsToMapAndFieldTypes(fieldsToMap, fieldTypes, custom_traits)
-
     return profile
   })
+
+  // Build schema from the union of all custom trait keys across all payloads.
+  // This ensures the schema is stable even when individual payloads are sparse.
+  for (const p of payloads) {
+    if (p.custom_traits) {
+      for (const key of Object.keys(p.custom_traits)) {
+        if (!key || reservedKeys.includes(key) || fieldsToMap.has(key)) continue
+        fieldsToMap.add(key)
+        fieldTypes[key] = 'STRING'
+      }
+    }
+  }
 
   const mappings = getProfileMappings(Array.from(fieldsToMap), fieldTypes)
   const profiles = stringifyJsonWithEscapedQuotes(profileUpdates)
@@ -93,37 +104,6 @@ function audienceMutation(advertiserId: string, audienceMapping: string): string
             message
           }
         }`;
-}
-
-
-function updateFieldsToMapAndFieldTypes(fieldsToMap: Set<string>, fieldTypes: Record<string, string>, customTraits: Payload['custom_traits'] = {}) {
-   // Process trait keys (already in snake_case) and capture any non-standard fields as mappings 
-  return Object.keys(customTraits).reduce((acc: Record<string, unknown>, key) => {
-    const value = customTraits[key]
-    
-    // Skip if key is empty string or value is empty string
-    if (key === '' || value === '') {
-      return acc
-    }
-    
-    acc[key] = value
-    
-    const standardFields = getDefaultFieldsToMap()
-
-    if (!standardFields.has(key)) {
-      fieldsToMap.add(key)
-      // Field type should be the most specific type of the values we've seen so far, use string if there is a conflict of types
-      if (value || value === 0) {
-        const type = getType(value)
-        if (fieldTypes[key] && fieldTypes[key] !== type) {
-          fieldTypes[key] = 'STRING'
-        } else {
-          fieldTypes[key] = type
-        }
-      }
-    }
-    return acc
-  }, {})
 }
 
 function getProfileMappings(customFields: string[], fieldTypes: Record<string, string>) {
@@ -178,28 +158,6 @@ function generateLabel(field: string) {
   }
 
   return label
-}
-
-function getType(value: unknown) {
-  if (isDateStr(value)) return 'DATE'
-  return (typeof value).toUpperCase()
-}
-
-function isDateStr(value: unknown) {
-  if (typeof value !== 'string') return false
-  
-  const datePatterns = [
-    /^\d{4}-\d{2}-\d{2}/, // YYYY-MM-DD
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
-    /^\d{1,2}\/\d{1,2}\/\d{4}/, // MM/DD/YYYY
-    /^\d{1,2}-\d{1,2}-\d{4}/ // MM-DD-YYYY
-  ]
-  
-  const hasDatePattern = datePatterns.some(pattern => pattern.test(value))
-  if (!hasDatePattern) return false
-  
-  const parsed = Date.parse(value)
-  return !isNaN(parsed)
 }
 
 // transform an array of mapping objects into a string which can be sent as parameter in a GQL request

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -2,32 +2,27 @@ import { RequestClient } from '@segment/actions-core'
 import { Settings } from '../generated-types'
 import {PROFILE_DEFAULT_FIELDS, MAPPING_SCHEMA, MarketingStatus as MarketingStatuses } from './constants'
 import {GQL_ENDPOINT, EXTERNAL_PROVIDER } from '../common-constants'
-import {  Mapping, MarketingStatus, ProfileFieldConfig } from './types'
+import { Mapping, MarketingStatus, ProfileFieldConfig, RawMapping } from './types'
 import type { Payload } from './generated-types'
 import { sha256hash } from '../common-functions'
 
-export async function send(request: RequestClient, payloads: Payload[], settings: Settings) {
+export async function send(request: RequestClient, payloads: Payload[], settings: Settings, rawMapping: RawMapping) {
+  const reservedKeys = [payloads[0]?.segment_computation_key, payloads[0]?.segment_computation_id].filter(
+    (key): key is string => Boolean(key)
+  )
 
-  const fieldTypes = getDefaultFieldTypes()
-  const fieldsToMap = getDefaultFieldsToMap()
+  const fieldsToMap = getConfiguredFieldsToMap(rawMapping, reservedKeys)
+  const fieldTypes = getConfiguredFieldTypes(fieldsToMap)
   const advertiserId = settings.advertiser_id
   const marketingStatus = payloads[0].marketing_status as MarketingStatus
-  
-  const reservedKeys = [payloads[0]?.segment_computation_key, payloads[0]?.segment_computation_id]
 
   const profileUpdates = payloads.map((p) => {
-    const {
-      user_id,
-      standard_traits,
-      custom_traits,
-      email
-    } = p
-
+    const { user_id, standard_traits, custom_traits, email } = p
     const { segment_computation_key, segment_computation_id, traits_or_props } = p
 
-    if(custom_traits) {
-        delete custom_traits[segment_computation_key]
-        delete custom_traits[segment_computation_id]
+    if (custom_traits) {
+      delete custom_traits[segment_computation_key]
+      delete custom_traits[segment_computation_id]
     }
 
     const profile: Record<string, string | number | undefined> = {
@@ -43,18 +38,6 @@ export async function send(request: RequestClient, payloads: Payload[], settings
 
     return profile
   })
-
-  // Build schema from the union of all custom trait keys across all payloads.
-  // This ensures the schema is stable even when individual payloads are sparse.
-  for (const p of payloads) {
-    if (p.custom_traits) {
-      for (const key of Object.keys(p.custom_traits)) {
-        if (!key || reservedKeys.includes(key) || fieldsToMap.has(key)) continue
-        fieldsToMap.add(key)
-        fieldTypes[key] = 'STRING'
-      }
-    }
-  }
 
   const mappings = getProfileMappings(Array.from(fieldsToMap), fieldTypes)
   const profiles = stringifyJsonWithEscapedQuotes(profileUpdates)
@@ -182,13 +165,34 @@ export function stringifyMappingSchemaForGraphQL(value: unknown) {
   return jsonString
 }
 
-const getDefaultFieldsToMap = (): Set<string> => {
-  return new Set(PROFILE_DEFAULT_FIELDS.map(field => field.key))
+function getConfiguredFieldsToMap(rawMapping: RawMapping, reservedKeys: string[] = []): Set<string> {
+  const fieldsToMap = new Set(PROFILE_DEFAULT_FIELDS.map((field) => field.key))
+  const customTraitsMapping = rawMapping.custom_traits
+
+  if (customTraitsMapping && typeof customTraitsMapping === 'object') {
+    for (const rawKey of Object.keys(customTraitsMapping)) {
+      const key = rawKey.trim()
+      if (!key || reservedKeys.includes(key) || fieldsToMap.has(key)) {
+        continue
+      }
+      fieldsToMap.add(key)
+    }
+  }
+
+  return fieldsToMap
 }
 
-const getDefaultFieldTypes = (): Record<string, string> => {
-  return PROFILE_DEFAULT_FIELDS.reduce((acc, field) => {
+function getConfiguredFieldTypes(fieldsToMap: Set<string>): Record<string, string> {
+  const fieldTypes = PROFILE_DEFAULT_FIELDS.reduce((acc, field) => {
     acc[field.key] = field.type.toUpperCase()
     return acc
   }, {} as Record<string, string>)
+
+  for (const key of fieldsToMap) {
+    if (!fieldTypes[key]) {
+      fieldTypes[key] = 'STRING'
+    }
+  }
+
+  return fieldTypes
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -172,7 +172,7 @@ function getConfiguredFieldsToMap(rawMapping: RawMapping, reservedKeys: string[]
   if (customTraitsMapping && typeof customTraitsMapping === 'object') {
     for (const rawKey of Object.keys(customTraitsMapping)) {
       const key = rawKey.trim()
-      if (!key || reservedKeys.includes(key) || fieldsToMap.has(key)) {
+      if (!key || key.startsWith('@') || reservedKeys.includes(key) || fieldsToMap.has(key)) {
         continue
       }
       fieldsToMap.add(key)

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -43,18 +43,6 @@ export async function send(request: RequestClient, payloads: Payload[], settings
   const profiles = stringifyJsonWithEscapedQuotes(profileUpdates)
 
   const mutation = `mutation {
-      upsertProfiles(
-        input: {
-          advertiserId: ${advertiserId},
-          externalProvider: "${EXTERNAL_PROVIDER}",
-          syncId: "${sha256hash(profiles)}",
-          profiles: "${profiles}"
-        }
-      ) {
-        userErrors {
-          message
-        }
-      }
       upsertProfileMapping(
         input: {
           advertiserId: ${advertiserId},
@@ -67,7 +55,19 @@ export async function send(request: RequestClient, payloads: Payload[], settings
           message
         }
       }
-      ${ audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
+      upsertProfiles(
+        input: {
+          advertiserId: ${advertiserId},
+          externalProvider: "${EXTERNAL_PROVIDER}",
+          syncId: "${sha256hash(profiles)}",
+          profiles: "${profiles}"
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      ${audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
   }`
 
   return await request(GQL_ENDPOINT, {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -28,12 +28,14 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: async (request, data) => {
-    const { payload, settings, rawMapping } = data
-    return await send(request, [payload], settings, rawMapping as RawMapping)
+    const { payload, settings } = data
+    const rawMapping = (data as unknown as { rawMapping: RawMapping }).rawMapping
+    return await send(request, [payload], settings, rawMapping)
   },
   performBatch: async (request, data) => {
-    const { payload, settings, rawMapping } = data
-    return await send(request, payload, settings, rawMapping as RawMapping)
+    const { payload, settings } = data
+    const rawMapping = (data as unknown as { rawMapping: RawMapping }).rawMapping
+    return await send(request, payload, settings, rawMapping)
   }
 }
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/index.ts
@@ -3,6 +3,7 @@ import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { send } from './functions'
 import { audience_only_fields, profile_fields } from './fields'
+import type { RawMapping } from './types'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
@@ -23,14 +24,16 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.traits.email' },
           else: { '@path': '$.properties.email' }
         }
-      } 
+      }
     }
   },
-  perform: async (request, { payload, settings }) => {
-    return await send(request, [payload], settings)
+  perform: async (request, data) => {
+    const { payload, settings, rawMapping } = data
+    return await send(request, [payload], settings, rawMapping as RawMapping)
   },
-  performBatch: async (request, { payload, settings }) => {
-    return await send(request, payload, settings)
+  performBatch: async (request, data) => {
+    const { payload, settings, rawMapping } = data
+    return await send(request, payload, settings, rawMapping as RawMapping)
   }
 }
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
@@ -40,3 +40,8 @@ export interface Mapping {
 }
 
 export type MarketingStatus = typeof MarketingStatus[keyof typeof MarketingStatus]
+
+export interface RawMapping {
+  custom_traits?: Record<string, unknown>
+  [key: string]: unknown
+}


### PR DESCRIPTION
Based off of Partner raised PR by @Vanessa-SSY https://github.com/segmentio/action-destinations/pull/3812/

Fixes a bug where upsertProfileMapping could overwrite a customer's profile field schema when batches were sparse (not every user has every mapped custom trait).

Previously, mappingSchemaV2 was built from custom trait keys present in the batch payloads. During audience backfills, traits are sparse across batches — a batch without a configured custom trait would send a smaller schema, and since upsertProfileMapping does a full replace, this would cause fields to disappear on StackAdapt's side.

This change:
- Builds mappingSchemaV2 from rawMapping.custom_traits (the destination subscription config) so the full set of configured fields is always sent, regardless of what's in the current batch
- Restricts custom_traits to defaultObjectUI: 'keyvalue:only' to prevent customers from mapping a whole JSON object (which would break the rawMapping key extraction)
- Trims custom trait keys and excludes empty/reserved/duplicate keys
- Reorders mutations so upsertProfileMapping runs before upsertProfiles (StackAdapt processes mutations sequentially, so schema is registered before data is ingested)

## Testing

- [x] Unit tests pass locally
- [x] Vanessa tersted locally with sparse batches (see below)

**Unit tests added in this PR:**
1. should include custom trait in schema when only some payloads have it — sparse batch where only one payload has loyalty_tier, confirms it still appears in schema
2. should exclude reserved computation keys from schema — confirms segment_computation_key/segment_computation_id values are filtered out of mappingSchemaV2
3. should include configured custom traits in schema even when no payloads contain them — payload has no custom trait values at all, confirms schema still includes the configured fields from rawMapping
4. should not duplicate standard fields when they appear in custom_traits — customer maps email/first_name in both standard and custom traits, confirms no duplication in schema

**Tests to be done by Vanessa:**
1. Configure 2-3 custom traits mapped via key-value. Send a batch where all users have all traits. Confirm mappingSchemaV2 includes all custom traits.
2. Send a batch where only some users have a particular custom trait. Confirm the schema still includes it.
3. Send a batch where no users have a particular configured custom trait. Confirm the schema still includes it.
4. Confirm reserved keys (computation_key value, computation_id value) are excluded from the schema.
5. Confirm profile data in upsertProfiles is unaffected — correct values still flow through for users who have them.
6. Confirm custom_traits field in the UI no longer allows mapping to a whole JSON object (only key-value editor available).