### PR TITLE
[Survicate] Replace Segment Cloud Mode endpoints

### DIFF
--- a/packages/destination-actions/src/destinations/survicate/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/survicate/__tests__/index.test.ts
@@ -15,13 +15,13 @@ describe('Survicate Cloud Mode', () => {
     }
 
     it('should validate authentication inputs', async () => {
-      nock('https://integrations.survicate.com').get('/endpoint/segment/check').reply(200, {})
+      nock('https://hv.survicate.com').get('/integrations/partners/segment/check').reply(200, {})
 
       await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
     })
 
     it('should fail on authentication failure', async () => {
-      nock('https://integrations.survicate.com').get('/endpoint/segment/check').reply(401, {})
+      nock('https://hv.survicate.com').get('/integrations/partners/segment/check').reply(401, {})
 
       await expect(testDestination.testAuthentication(authData)).rejects.toThrowError()
     })

--- a/packages/destination-actions/src/destinations/survicate/identifyGroup/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/survicate/identifyGroup/__tests__/index.test.ts
@@ -50,7 +50,7 @@ describe('Survicate Cloud Mode - identifyGroup', () => {
       timestamp: '2023-10-01T00:00:00Z'
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/group', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/group', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('identifyGroup', {
       event,

--- a/packages/destination-actions/src/destinations/survicate/identifyGroup/index.ts
+++ b/packages/destination-actions/src/destinations/survicate/identifyGroup/index.ts
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError("'User ID' or 'Anonymous ID' is required")
     }
 
-    return request(`https://integrations.survicate.com/endpoint/segment/group`, {
+    return request(`https://hv.survicate.com/integrations/partners/segment/group`, {
       method: 'post',
       json: {
         ...(user_id ? { user_id } : {}),

--- a/packages/destination-actions/src/destinations/survicate/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/survicate/identifyUser/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe('Survicate Cloud Mode - identifyUser', () => {
       }
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/identify', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/identify', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('identifyUser', {
       event,
@@ -75,7 +75,7 @@ describe('Survicate Cloud Mode - identifyUser', () => {
       }
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/identify', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/identify', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('identifyUser', {
       event,
@@ -103,7 +103,7 @@ describe('Survicate Cloud Mode - identifyUser', () => {
       }
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/identify', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/identify', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('identifyUser', {
       event,

--- a/packages/destination-actions/src/destinations/survicate/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/survicate/identifyUser/index.ts
@@ -56,7 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError("'User ID' or 'Anonymous ID' is required")
     }
 
-    return request(`https://integrations.survicate.com/endpoint/segment/identify`, {
+    return request(`https://hv.survicate.com/integrations/partners/segment/identify`, {
       method: 'post',
       json: {
         ...(user_id ? { user_id } : {}),

--- a/packages/destination-actions/src/destinations/survicate/index.ts
+++ b/packages/destination-actions/src/destinations/survicate/index.ts
@@ -45,7 +45,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request, { settings }) => {
-      return request(`https://integrations.survicate.com/endpoint/segment/check`, {
+      return request(`https://hv.survicate.com/integrations/partners/segment/check`, {
         method: 'get',
         headers: {
           Authorization: `Bearer ${settings.apiKey}`,

--- a/packages/destination-actions/src/destinations/survicate/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/survicate/trackEvent/__tests__/index.test.ts
@@ -50,7 +50,7 @@ describe('Survicate Cloud Mode - trackEvent', () => {
       timestamp: '2023-10-01T00:00:00Z'
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/track', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/track', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('trackEvent', {
       event,
@@ -79,7 +79,7 @@ describe('Survicate Cloud Mode - trackEvent', () => {
       timestamp: '2023-10-01T00:00:00Z'
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/track', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/track', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('trackEvent', {
       event,
@@ -108,7 +108,7 @@ describe('Survicate Cloud Mode - trackEvent', () => {
       timestamp: '2023-10-01T00:00:00Z'
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/track', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/track', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('trackEvent', {
       event,
@@ -133,7 +133,7 @@ describe('Survicate Cloud Mode - trackEvent', () => {
       anonymous_id: 'anon123'
     }
 
-    nock('https://integrations.survicate.com').post('/endpoint/segment/track', expectedJson).reply(200, {})
+    nock('https://hv.survicate.com').post('/integrations/partners/segment/track', expectedJson).reply(200, {})
 
     const response = await testDestination.testAction('trackEvent', {
       event,

--- a/packages/destination-actions/src/destinations/survicate/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/survicate/trackEvent/index.ts
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
       throw new PayloadValidationError("'User ID' or 'Anonymous ID' is required")
     }
 
-    return request(`https://integrations.survicate.com/endpoint/segment/track`, {
+    return request(`https://hv.survicate.com/integrations/partners/segment/track`, {
       method: 'post',
       json: {
         name,


### PR DESCRIPTION
Point identify, track, group and auth check requests to the new hv.survicate.com/integrations/partners/segment/* endpoints.

<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

<img width="482" height="128" alt="image" src="https://github.com/user-attachments/assets/13bc578b-2344-4454-87e5-54fd49430327" />

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)

<img width="619" height="601" alt="group" src="https://github.com/user-attachments/assets/40741bf8-4385-4552-a2ba-2c866b0e2246" />

<img width="619" height="532" alt="identify" src="https://github.com/user-attachments/assets/8a271381-1bc5-4ce6-8b95-fcc739e1261e" />

<img width="615" height="442" alt="track" src="https://github.com/user-attachments/assets/6ff543e8-b4e5-4973-a64b-f5d3cd009a0b" />


