### PR TITLE
STRATCONN-6845 [Facebook Custom Audience]: stop a single invalid phone from failing the whole batch (feature-flagged)

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/constants.ts
@@ -6,4 +6,10 @@ export const CANARY_API_VERSION = FACEBOOK_CUSTOM_AUDIENCES_CANARY_API_VERSION
 
 export const FACEBOOK_CUSTOM_AUDIENCE_FLAGON = 'facebook-custom-audience-actions-canary-version'
 
+export const FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON = 'facebook-custom-audience-actions-journeys-support'
+
+// When enabled, a phone that normalizes to an empty string (e.g. '+0000000000') is
+// discarded to '' instead of throwing 'Cannot hash an empty string' and failing the whole batch.
+export const FLAGON_NAME_BATCH_DISCARD_FIX = 'fb-custom-audience-batch-discard-fix'
+
 export const BASE_URL = 'https://graph.facebook.com'

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
@@ -12,8 +12,12 @@ import {
   normalizeCountry
 } from '../functions'
 import { Payload } from '../generated-types'
+import { FLAGON_NAME_BATCH_DISCARD_FIX } from '../../constants'
 
 const sha256 = (value: string) => crypto.createHash('sha256').update(value).digest('hex')
+
+// The empty-phone discard fix is gated behind this flag; pass it to exercise the fixed behavior.
+const fixOn = { [FLAGON_NAME_BATCH_DISCARD_FIX]: true }
 
 const basePayload: Payload = {
   externalId: 'user-123',
@@ -138,25 +142,30 @@ describe('getData', () => {
     expect(row[14]).toBe('AB1234CD-E123-12FG-J123')
   })
 
-  it('returns empty string for phone when it normalizes to an empty string (e.g. "+0000000000")', () => {
+  it('with the fix flag ON, returns empty string for a phone that normalizes to an empty string (e.g. "+0000000000")', () => {
     const payload = { ...basePayload, phone: '+0000000000' }
-    const [row] = getData([payload])
+    const [row] = getData([payload], fixOn)
     expect(row[2]).toBe('')
   })
 
-  it('passes an already-hashed phone through unchanged', () => {
+  it('with the fix flag OFF (legacy), a phone that normalizes to an empty string throws', () => {
+    const payload = { ...basePayload, phone: '+0000000000' }
+    expect(() => getData([payload])).toThrow('Cannot hash an empty string')
+  })
+
+  it('with the fix flag ON, passes an already-hashed phone through unchanged', () => {
     const prehashed = sha256('+15551234567')
     const payload = { ...basePayload, phone: prehashed }
-    const [row] = getData([payload])
+    const [row] = getData([payload], fixOn)
     expect(row[2]).toBe(prehashed)
   })
 
-  it('passes an already-hashed phone with no digits through unchanged', () => {
+  it('with the fix flag ON, passes an already-hashed phone with no digits through unchanged', () => {
     // Pathological but valid sha256/hex value (only a-f). normalizePhone() would
     // reduce it to '', so it must be detected as pre-hashed BEFORE normalizing.
     const prehashed = 'abcdef'.repeat(11).slice(0, 64)
     const payload = { ...basePayload, phone: prehashed }
-    const [row] = getData([payload])
+    const [row] = getData([payload], fixOn)
     expect(row[2]).toBe(prehashed)
   })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
@@ -144,6 +144,22 @@ describe('getData', () => {
     expect(row[2]).toBe('')
   })
 
+  it('passes an already-hashed phone through unchanged', () => {
+    const prehashed = sha256('+15551234567')
+    const payload = { ...basePayload, phone: prehashed }
+    const [row] = getData([payload])
+    expect(row[2]).toBe(prehashed)
+  })
+
+  it('passes an already-hashed phone with no digits through unchanged', () => {
+    // Pathological but valid sha256/hex value (only a-f). normalizePhone() would
+    // reduce it to '', so it must be detected as pre-hashed BEFORE normalizing.
+    const prehashed = 'abcdef'.repeat(11).slice(0, 64)
+    const payload = { ...basePayload, phone: prehashed }
+    const [row] = getData([payload])
+    expect(row[2]).toBe(prehashed)
+  })
+
   it('returns one row per payload', () => {
     const payloads = [
       { ...basePayload, externalId: 'ext-001' },

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/functions.test.ts
@@ -138,6 +138,12 @@ describe('getData', () => {
     expect(row[14]).toBe('AB1234CD-E123-12FG-J123')
   })
 
+  it('returns empty string for phone when it normalizes to an empty string (e.g. "+0000000000")', () => {
+    const payload = { ...basePayload, phone: '+0000000000' }
+    const [row] = getData([payload])
+    expect(row[2]).toBe('')
+  })
+
   it('returns one row per payload', () => {
     const payloads = [
       { ...basePayload, externalId: 'ext-001' },
@@ -218,7 +224,7 @@ describe('normalizeName', () => {
     expect(normalizeName('  John  ')).toBe('john')
   })
 
-  it("removes apostrophes", () => {
+  it('removes apostrophes', () => {
     expect(normalizeName("O'Brien")).toBe('obrien')
   })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -215,7 +215,7 @@ export function getData(payloads: Payload[]): FacebookDataRow[] {
     const row: FacebookDataRow = [
       externalId ?? '',
       email ? processHashing(email.trim().toLowerCase(), 'sha256', 'hex') : '',
-      phone ? processHashing(phone, 'sha256', 'hex', normalizePhone) ?? '' : '',
+      phone ? (normalizePhone(phone) ? processHashing(phone, 'sha256', 'hex', normalizePhone) ?? '' : '') : '',
       year ? processHashing(year.trim(), 'sha256', 'hex') ?? '' : '',
       month ? processHashing(normalizeMonth(month), 'sha256', 'hex') ?? '' : '',
       day ? processHashing(day.trim(), 'sha256', 'hex') ?? '' : '',

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -11,8 +11,8 @@ import {
 import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { processHashing, isAlreadyHashed } from '../../../lib/hashing-utils'
-import { PayloadMap, AudienceJSON, FacebookDataRow, RawData } from './types'
-import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON, FLAGON_NAME_BATCH_DISCARD_FIX } from '../constants'
+import { PayloadMap, AudienceJSON, FacebookDataRow } from './types'
+import { BASE_URL, FLAGON_NAME_BATCH_DISCARD_FIX } from '../constants'
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -10,9 +10,9 @@ import {
 } from '@segment/actions-core'
 import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
-import { processHashing } from '../../../lib/hashing-utils'
-import { PayloadMap, AudienceJSON, FacebookDataRow } from './types'
-import { BASE_URL } from '../constants'
+import { processHashing, isAlreadyHashed } from '../../../lib/hashing-utils'
+import { PayloadMap, AudienceJSON, FacebookDataRow, RawData } from './types'
+import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON } from '../constants'
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 
@@ -215,7 +215,7 @@ export function getData(payloads: Payload[]): FacebookDataRow[] {
     const row: FacebookDataRow = [
       externalId ?? '',
       email ? processHashing(email.trim().toLowerCase(), 'sha256', 'hex') : '',
-      phone ? (normalizePhone(phone) ? processHashing(phone, 'sha256', 'hex', normalizePhone) ?? '' : '') : '',
+      hashPhone(phone),
       year ? processHashing(year.trim(), 'sha256', 'hex') ?? '' : '',
       month ? processHashing(normalizeMonth(month), 'sha256', 'hex') ?? '' : '',
       day ? processHashing(day.trim(), 'sha256', 'hex') ?? '' : '',
@@ -240,6 +240,20 @@ export function normalizePhone(value: string): string {
   const removedNonNumveric = value.replace(/\D/g, '')
 
   return removedNonNumveric.replace(/^0+/, '')
+}
+
+/**
+ * Hashes a phone number for Facebook Custom Audiences.
+ * - Pre-hashed values (valid sha256/hex) are passed through unchanged.
+ * - Otherwise the value is normalized; if normalization leaves an empty string
+ *   (e.g. '+0000000000'), it is treated as missing and returns '' rather than
+ *   letting SmartHashing.hash() throw 'Cannot hash an empty string'.
+ */
+export function hashPhone(phone?: string): string {
+  if (!phone) return ''
+  if (isAlreadyHashed(phone, 'sha256', 'hex')) return phone
+  const normalized = normalizePhone(phone)
+  return normalized ? processHashing(normalized, 'sha256', 'hex') : ''
 }
 
 export function normalizeGender(value: string): string {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -12,7 +12,7 @@ import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { processHashing, isAlreadyHashed } from '../../../lib/hashing-utils'
 import { PayloadMap, AudienceJSON, FacebookDataRow, RawData } from './types'
-import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON } from '../constants'
+import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON, FLAGON_NAME_BATCH_DISCARD_FIX } from '../constants'
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 
@@ -84,7 +84,7 @@ export async function sendRequest(
 ): Promise<void> {
   const indices = Array.from(map.keys())
   const payloads = Array.from(map.values())
-  const json = getJSON(payloads)
+  const json = getJSON(payloads, features)
 
   try {
     await request(`${BASE_URL}/${getApiVersion(features, statsContext)}/${audienceId}/users`, {
@@ -164,8 +164,8 @@ export function getAudienceId(
   return (hookAudienceId ?? payloadAudienceId) as string
 }
 
-export function getJSON(payloads: Payload[]): AudienceJSON {
-  const data = getData(payloads)
+export function getJSON(payloads: Payload[], features?: Features): AudienceJSON {
+  const data = getData(payloads, features)
   const app_ids: string[] = []
   const page_ids: string[] = []
   const ig_account_ids: string[] = []
@@ -194,7 +194,7 @@ export function validate(audienceId: unknown): string | undefined {
   }
 }
 
-export function getData(payloads: Payload[]): FacebookDataRow[] {
+export function getData(payloads: Payload[], features?: Features): FacebookDataRow[] {
   const data: FacebookDataRow[] = new Array(payloads.length)
 
   payloads.forEach((payload, index) => {
@@ -215,7 +215,7 @@ export function getData(payloads: Payload[]): FacebookDataRow[] {
     const row: FacebookDataRow = [
       externalId ?? '',
       email ? processHashing(email.trim().toLowerCase(), 'sha256', 'hex') : '',
-      hashPhone(phone),
+      getHashedPhone(phone, features),
       year ? processHashing(year.trim(), 'sha256', 'hex') ?? '' : '',
       month ? processHashing(normalizeMonth(month), 'sha256', 'hex') ?? '' : '',
       day ? processHashing(day.trim(), 'sha256', 'hex') ?? '' : '',
@@ -243,11 +243,25 @@ export function normalizePhone(value: string): string {
 }
 
 /**
- * Hashes a phone number for Facebook Custom Audiences.
+ * Resolves the hashed phone value for a row, choosing behavior based on the
+ * `fb-custom-audience-batch-discard-fix` feature flag.
+ * - Flag ON: hashPhone() discards a phone that normalizes to empty (e.g. '+0000000000') to '',
+ *   so one bad phone no longer fails the whole batch.
+ * - Flag OFF: the original behavior, which throws 'Cannot hash an empty string' for such values.
+ */
+export function getHashedPhone(phone: string | undefined, features?: Features): string {
+  if (features?.[FLAGON_NAME_BATCH_DISCARD_FIX]) {
+    return hashPhone(phone)
+  }
+  return phone ? processHashing(phone, 'sha256', 'hex', normalizePhone) ?? '' : ''
+}
+
+/**
+ * Hashes a phone number for Facebook Custom Audiences (fixed behavior).
  * - Pre-hashed values (valid sha256/hex) are passed through unchanged.
  * - Otherwise the value is normalized; if normalization leaves an empty string
- *   (e.g. '+0000000000'), it is treated as missing and returns '' rather than
- *   letting SmartHashing.hash() throw 'Cannot hash an empty string'.
+ *   (e.g. '+0000000000'), it is discarded to '' instead of letting SmartHashing.hash()
+ *   throw 'Cannot hash an empty string' and fail the whole batch.
  */
 export function hashPhone(phone?: string): string {
   if (!phone) return ''


### PR DESCRIPTION
## Summary

Facebook Custom Audiences failed an **entire batch** when a single row had a phone number that normalizes to an empty string (e.g. the placeholder `+0000000000`). `normalizePhone()` strips non-numeric characters and leading zeros, producing `''`, which reached `SmartHashing.hash('')` and threw `Cannot hash an empty string`. Because that throw escaped `getData()` before the request was built, **all** events in the batch were rejected instead of just the one bad row. Reported by Nestle (STRATCONN-6845 / STRATCONN-6848).

This PR routes phone hashing through a new `getHashedPhone(phone, features)` helper in `getData()`:

- **`hashPhone()`** (fixed behavior): pre-hashed sha256/hex values pass through unchanged; otherwise the value is normalized and, if normalization leaves an empty string, it is discarded to `''` instead of throwing — so one bad phone no longer fails the whole batch.
- **Feature-flag gated:** the fix is behind the `fb-custom-audience-batch-discard-fix` flag (`centrifuge-destinations` family, Workspace ID). **Flag OFF → original behavior (unchanged); Flag ON → fix.** This enables a controlled, per-workspace rollout for this high-volume destination.

### Behavior

| Input | Flag OFF (default) | Flag ON |
|---|---|---|
| `+0000000000` in a batch | throws → **whole batch fails** (today's behavior) | that row → `''`, rest of the batch succeeds |
| valid phone | hashed (unchanged) | hashed (unchanged) |
| pre-hashed sha256 phone | passed through | passed through |

## Testing

### Audience with faulty email
<img width="1511" height="942" alt="image" src="https://github.com/user-attachments/assets/f65fd7be-0ac0-4f6b-b123-9f9dd9e157bc" />


### Event Delivery
<img width="955" height="517" alt="image" src="https://github.com/user-attachments/assets/5d6bf9d6-d6fc-4b18-970d-33b2703101e0" />


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality — flag ON discards an empty-normalizing phone to `''`; flag OFF throws `Cannot hash an empty string`; pre-hashed passthrough (including a digit-free hash that would otherwise normalize away).
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) — `serve` + curl against the `sync` action with a mocked Graph API, confirming an all-good batch succeeds and a bad-phone batch behaves per flag state.
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change. — With the flag OFF the original code path runs verbatim; no new fields were added, and valid/pre-hashed phones hash identically in both states.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.



## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'` — no new fields added by this change. Phone (PII) continues to be SHA-256 hashed before it leaves Segment (Facebook's required format), and already-hashed values are still detected and not re-hashed.

## New Destination Checklist

N/A — this is a bug fix to an existing destination, not a new destination.
