### PR TITLE
fix: align audienceMembership and rawData with schema-filtered payloads in executeBatch

### DIFF
--- a/packages/core/src/__tests__/audience-membership.test.ts
+++ b/packages/core/src/__tests__/audience-membership.test.ts
@@ -1,8 +1,10 @@
 import { createTestIntegration } from '../create-test-integration'
+import { Destination } from '../destination-kit'
 import { engageAudienceMembership, retlAudienceMembership } from '../audience-membership'
 import { DestinationDefinition } from '../destination-kit'
 import { ExecuteInput } from '../destination-kit/types'
 import { JSONObject } from '../json-object'
+import { createTestEvent } from '../create-test-event'
 
 describe('engageAudienceMembership', () => {
   describe('identify events', () => {
@@ -226,9 +228,9 @@ describe('retlAudienceMembership', () => {
   })
 })
 
-function makeDestination(
-  captureRef: { data?: ExecuteInput<JSONObject, JSONObject> }
-): DestinationDefinition<JSONObject> {
+function makeDestination(captureRef: {
+  data?: ExecuteInput<JSONObject, JSONObject>
+}): DestinationDefinition<JSONObject> {
   return {
     name: 'Test Destination',
     mode: 'cloud',
@@ -272,45 +274,56 @@ async function runAction(
 }
 
 describe('audienceMembership on ExecuteInput in perform()', () => {
-
   describe('Engage payloads', () => {
     it('is true for identify event with membership in traits', async () => {
-      const data = await runAction({
-        type: 'identify',
-        userId: 'user-1',
-        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
-        traits: { my_audience: true }
-      }, undefined)
+      const data = await runAction(
+        {
+          type: 'identify',
+          userId: 'user-1',
+          context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+          traits: { my_audience: true }
+        },
+        undefined
+      )
       expect(data?.audienceMembership).toBe(true)
     })
 
     it('is false for identify event with membership in traits', async () => {
-      const data = await runAction({
-        type: 'identify',
-        userId: 'user-1',
-        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
-        traits: { my_audience: false }
-      }, undefined)
+      const data = await runAction(
+        {
+          type: 'identify',
+          userId: 'user-1',
+          context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+          traits: { my_audience: false }
+        },
+        undefined
+      )
       expect(data?.audienceMembership).toBe(false)
     })
 
     it('is true for track event with membership in properties', async () => {
-      const data = await runAction({
-        type: 'track',
-        userId: 'user-1',
-        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
-        properties: { my_audience: true }
-      }, undefined)
+      const data = await runAction(
+        {
+          type: 'track',
+          userId: 'user-1',
+          context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+          properties: { my_audience: true }
+        },
+        undefined
+      )
       expect(data?.audienceMembership).toBe(true)
     })
 
     it('is false for track event with membership in properties', async () => {
-      const data = await runAction({
-        type: 'track',
-        userId: 'user-1',
-        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
-        properties: { my_audience: false }
-      }, undefined)
+      const data = await runAction(
+        {
+          type: 'track',
+          userId: 'user-1',
+          context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+          properties: { my_audience: false }
+        },
+        undefined
+      )
       expect(data?.audienceMembership).toBe(false)
     })
   })
@@ -335,12 +348,98 @@ describe('audienceMembership on ExecuteInput in perform()', () => {
 
   describe('non-audience events', () => {
     it('is undefined for a non-audience event', async () => {
-      const data = await runAction({
-        type: 'track',
-        userId: 'user-1',
-        properties: { foo: 'bar' }
-      }, undefined)
+      const data = await runAction(
+        {
+          type: 'track',
+          userId: 'user-1',
+          properties: { foo: 'bar' }
+        },
+        undefined
+      )
       expect(data?.audienceMembership).toBeUndefined()
     })
+  })
+})
+
+describe('audienceMembership on ExecuteInput in performBatch() when some events fail schema validation', () => {
+  const batchDestination: DestinationDefinition<JSONObject> = {
+    name: 'Batch Test Destination',
+    mode: 'cloud',
+    authentication: { scheme: 'custom', fields: {} },
+    actions: {
+      batchAction: {
+        title: 'Batch Action',
+        description: 'Batch Action',
+        fields: {
+          userId: { label: 'User ID', description: 'The user ID', type: 'string', required: true }
+        },
+        syncMode: {
+          default: 'mirror',
+          label: 'Sync Mode',
+          description: 'Sync mode',
+          choices: [
+            { label: 'Mirror', value: 'mirror' },
+            { label: 'Delete', value: 'delete' }
+          ]
+        },
+        perform: (_request) => 'ok',
+        performBatch: (_request, data) => {
+          capturedBatchData = data as ExecuteInput<JSONObject, JSONObject[]>
+          return 'batch ok'
+        }
+      }
+    }
+  }
+
+  let capturedBatchData: ExecuteInput<JSONObject, JSONObject[]> | undefined
+
+  beforeEach(() => {
+    capturedBatchData = undefined
+  })
+
+  it('audienceMembership length matches payload length when an invalid event is filtered out', async () => {
+    const destination = new Destination(batchDestination)
+
+    const validEvent1 = createTestEvent({ type: 'track', userId: 'user-1', event: 'new' })
+    const validEvent2 = createTestEvent({ type: 'track', userId: 'user-2', event: 'new' })
+    const invalidEvent = createTestEvent({ type: 'track', userId: undefined, event: 'new' })
+
+    await destination.onBatch([validEvent1, invalidEvent, validEvent2], {
+      subscription: {
+        subscribe: 'type = "track"',
+        partnerAction: 'batchAction',
+        mapping: {
+          userId: { '@path': '$.userId' },
+          __segment_internal_sync_mode: 'mirror'
+        }
+      }
+    })
+
+    expect(capturedBatchData).toBeDefined()
+    expect(capturedBatchData!.payload.length).toBe(2)
+    expect(capturedBatchData!.audienceMembership!.length).toBe(2)
+  })
+
+  it('rawData length matches payload length when an invalid event is filtered out', async () => {
+    const destination = new Destination(batchDestination)
+
+    const validEvent1 = createTestEvent({ type: 'track', userId: 'user-1', event: 'new' })
+    const validEvent2 = createTestEvent({ type: 'track', userId: 'user-2', event: 'new' })
+    const invalidEvent = createTestEvent({ type: 'track', userId: undefined, event: 'new' })
+
+    await destination.onBatch([validEvent1, invalidEvent, validEvent2], {
+      subscription: {
+        subscribe: 'type = "track"',
+        partnerAction: 'batchAction',
+        mapping: {
+          userId: { '@path': '$.userId' },
+          __segment_internal_sync_mode: 'mirror'
+        }
+      }
+    })
+
+    expect(capturedBatchData).toBeDefined()
+    expect(capturedBatchData!.payload.length).toBe(2)
+    expect((capturedBatchData!.rawData as JSONObject[]).length).toBe(2)
   })
 })

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -473,10 +473,11 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
       const syncModeVal = this.definition.syncMode ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
       const syncMode = isSyncMode(syncModeVal) ? syncModeVal : undefined
       const matchingKey = bundle.mapping?.['__segment_internal_matching_key']
-      const audienceMembership = bundle.data.map((d) => resolveAudienceMembership(d, syncMode))
+      const filteredBundleData = bundle.data.filter((_, i) => !invalidPayloadIndices.has(i))
+      const audienceMembership = filteredBundleData.map((d) => resolveAudienceMembership(d, syncMode))
 
       const data = {
-        rawData: bundle.data,
+        rawData: filteredBundleData,
         rawMapping: bundle.mapping,
         settings: bundle.settings,
         audienceSettings: bundle.audienceSettings,


### PR DESCRIPTION
[`action.ts#L421-L454`](https://github.com/segmentio/action-destinations/blob/main/packages/core/src/destination-kit/action.ts#L421-L454) filters out schema-invalid payloads before calling `performBatch`, leaving M events. But [`action.ts#L476`](https://github.com/segmentio/action-destinations/blob/main/packages/core/src/destination-kit/action.ts#L476) was building `audienceMembership` and `rawData` from the original unfiltered `bundle.data` (N events), causing an N≠M mismatch that throws `Audience membership details count does not match batch payload count` in Facebook Custom Audiences ([`sync/functions.ts#L198-L199`](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts#L198-L199)).

Fix filters `bundle.data` through `invalidPayloadIndices` before mapping to `audienceMembership` and `rawData` so all three stay in sync with the filtered payloads.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)