### PR TITLE
fix(core): filter audienceMembership to match schema-filtered payloads in executeBatch

### DIFF
--- a/packages/core/src/__tests__/audience-membership.test.ts
+++ b/packages/core/src/__tests__/audience-membership.test.ts
@@ -226,6 +226,36 @@ describe('retlAudienceMembership', () => {
   })
 })
 
+interface BatchCaptureRef {
+  payload?: JSONObject[]
+  audienceMembership?: (boolean | undefined)[]
+}
+
+function makeBatchDestination(captureRef: BatchCaptureRef): DestinationDefinition<JSONObject> {
+  return {
+    name: 'Test Batch Destination',
+    mode: 'cloud',
+    authentication: { scheme: 'custom', fields: {} },
+    actions: {
+      testAction: {
+        title: 'Test Action',
+        description: 'Test',
+        fields: {
+          userId: { label: 'User ID', description: 'The user ID', type: 'string', required: true },
+          count: { label: 'Count', description: 'A required number', type: 'number', required: true }
+        },
+        perform: (_request) => {
+          return
+        },
+        performBatch: (_request, data) => {
+          captureRef.payload = data.payload as JSONObject[]
+          captureRef.audienceMembership = data.audienceMembership as (boolean | undefined)[]
+        }
+      }
+    }
+  }
+}
+
 function makeDestination(
   captureRef: { data?: ExecuteInput<JSONObject, JSONObject> }
 ): DestinationDefinition<JSONObject> {
@@ -342,5 +372,61 @@ describe('audienceMembership on ExecuteInput in perform()', () => {
       }, undefined)
       expect(data?.audienceMembership).toBeUndefined()
     })
+  })
+})
+
+describe('audienceMembership on ExecuteInput in performBatch()', () => {
+  it('only processes valid payloads and aligns audienceMembership correctly when one event fails validation', async () => {
+    const captureRef: BatchCaptureRef = {}
+    const testDestination = createTestIntegration(makeBatchDestination(captureRef))
+
+    const events = [
+      {
+        type: 'identify',
+        userId: 'user-1',
+        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+        traits: { my_audience: true },
+        properties: { count: 1 }
+      },
+      {
+        type: 'identify',
+        userId: 'user-2',
+        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+        traits: { my_audience: false },
+        properties: { count: 2 }
+      },
+      {
+        type: 'identify',
+        userId: 'user-3',
+        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+        traits: { my_audience: true },
+        properties: { count: 'not-a-number' }
+      },
+      {
+        type: 'identify',
+        userId: 'user-4',
+        context: { personas: { computation_class: 'audience', computation_key: 'my_audience' } },
+        traits: { my_audience: false },
+        properties: { count: 4 }
+      }
+    ]
+
+    await testDestination.testBatchAction('testAction', {
+      events,
+      mapping: {
+        userId: { '@path': '$.userId' },
+        count: { '@path': '$.properties.count' }
+      }
+    })
+
+    expect(captureRef.payload).toHaveLength(3)
+    expect(captureRef.payload).toEqual([
+      { userId: 'user-1', count: 1 },
+      { userId: 'user-2', count: 2 },
+      { userId: 'user-4', count: 4 }
+    ])
+
+    expect(captureRef.audienceMembership).toHaveLength(3)
+    expect(captureRef.audienceMembership).toEqual([true, false, false])
   })
 })

--- a/packages/core/src/destination-kit/action.ts
+++ b/packages/core/src/destination-kit/action.ts
@@ -473,7 +473,9 @@ export class Action<Settings, Payload extends JSONLikeObject, AudienceSettings =
       const syncModeVal = this.definition.syncMode ? bundle.mapping?.['__segment_internal_sync_mode'] : undefined
       const syncMode = isSyncMode(syncModeVal) ? syncModeVal : undefined
       const matchingKey = bundle.mapping?.['__segment_internal_matching_key']
-      const audienceMembership = bundle.data.map((d) => resolveAudienceMembership(d, syncMode))
+      const audienceMembership = bundle.data
+        .map((d) => resolveAudienceMembership(d, syncMode))
+        .filter((_, i) => !invalidPayloadIndices.has(i))
 
       const data = {
         rawData: bundle.data,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -88,6 +88,20 @@ export class PayloadValidationError extends IntegrationError {
 }
 
 /**
+ * Error to indicate the payload has invalid audience membership.
+ * Should include a user-friendly message.
+ * These errors will not be retried and the user has to fix the payload.
+ */
+export class InvalidAudienceMembershipError extends IntegrationError {
+  /**
+   * @param message - a human-friendly message to display to users
+   */
+  constructor(message: string) {
+    super(message, ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP, 400)
+  }
+}
+
+/**
  * Error to indicate HTTP API call to destination failed.
  * Should include a user-friendly message and status code.
  * Errors will be retried based on status code.
@@ -207,6 +221,8 @@ export enum CustomErrorCodes {
   GET_AUDIENCE_FAILED = 'GET_AUDIENCE_FAILED',
   // When the RETL onMappingSave hook fails
   RETL_ON_MAPPING_SAVE_FAILED = 'RETL_ON_MAPPING_SAVE_FAILED',
+  // When Audience Membership cannot be resolved correctly
+  INVALID_AUDIENCE_MEMBERSHIP = 'INVALID_AUDIENCE_MEMBERSHIP',
   // Fallback error code if no other error code matches
   UNKNOWN_ERROR = 'UNKNOWN_ERROR'
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export {
   InvalidAuthenticationError,
   RetryableError,
   PayloadValidationError,
+  InvalidAudienceMembershipError,
   SelfTimeoutError,
   APIError,
   ErrorCodes,

--- a/packages/destination-actions/src/destinations/amplitude-cohorts/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amplitude-cohorts/syncAudience/__tests__/index.test.ts
@@ -58,8 +58,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.testAction('syncAudience', {
         event,
         settings,
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
@@ -110,8 +109,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.testAction('syncAudience', {
         event,
         settings,
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
@@ -164,8 +162,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
         useDefaultMappings: true,
         mapping: {
           amplitude_id: 'amp789'
-        },
-        features: { 'actions-core-audience-membership': true }
+        }
       })
 
       expect(responses.length).toBe(1)
@@ -193,8 +190,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
         testDestination.testAction('syncAudience', {
           event,
           settings,
-          useDefaultMappings: true,
-          features: { 'actions-core-audience-membership': true }
+          useDefaultMappings: true
         })
       ).rejects.toThrowError('ID Type must be specified in Audience Settings')
     })
@@ -225,8 +221,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           useDefaultMappings: true,
           mapping: {
             user_id: undefined
-          },
-          features: { 'actions-core-audience-membership': true }
+          }
         })
       ).rejects.toThrowError("No User Identifier of type User ID found in payload. Each payload must have a unique ID for the specified ID Type.")
     })
@@ -337,8 +332,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.testBatchAction('syncAudience', {
         events,
         settings,
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(2)
@@ -409,8 +403,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.testBatchAction('syncAudience', {
         events,
         settings,
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
@@ -464,8 +457,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           ...settings,
           endpoint: 'europe'
         },
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
@@ -507,8 +499,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.testAction('syncAudience', {
         event,
         settings,
-        useDefaultMappings: true,
-        features: { 'actions-core-audience-membership': true }
+        useDefaultMappings: true
       })
 
       expect(responses.length).toBe(1)
@@ -570,7 +561,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           memberships_result: [{ skipped_ids: [], operation: 'ADD' }]
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -636,7 +627,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           memberships_result: [{ skipped_ids: [], operation: 'REMOVE' }]
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -724,7 +715,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
         memberships_result: [{ skipped_ids: [], operation: 'REMOVE' }]
       })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(3)
       expect(responses[0]).toMatchObject({
@@ -804,7 +795,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           memberships_result: [{ skipped_ids: [], operation: 'ADD' }]
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping: ampMapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping: ampMapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -871,7 +862,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
         })
 
       const euSettings = { ...settings, endpoint: 'europe' }
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings: euSettings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings: euSettings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -937,7 +928,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           memberships_result: [{ skipped_ids: ['skipped_user'], operation: 'ADD' }]
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -1018,7 +1009,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           memberships_result: [{ skipped_ids: [], operation: 'ADD' }]
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(3)
       expect(responses[0]).toMatchObject({
@@ -1095,8 +1086,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
         settings,
-        mapping: traitsMappedMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: traitsMappedMapping
       })
 
       expect(responses.length).toBe(2)
@@ -1148,7 +1138,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
         })
       ]
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({
@@ -1218,7 +1208,7 @@ describe('Amplitude Cohorts - syncAudience', () => {
           }
         })
 
-      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping, features: { 'actions-core-audience-membership': true } })
+      const responses = await testDestination.executeBatch('syncAudience', { events, settings, mapping })
 
       expect(responses.length).toBe(2)
       expect(responses[0]).toMatchObject({

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/canary.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/canary.test.ts
@@ -68,7 +68,7 @@ describe('Facebook Custom Audiences - canary API version', () => {
         settings,
         auth,
         mapping: baseMapping,
-        features: { [FACEBOOK_CUSTOM_AUDIENCE_FLAGON]: false, 'actions-core-audience-membership': true }
+        features: { [FACEBOOK_CUSTOM_AUDIENCE_FLAGON]: false }
       })
 
       expect(responses[0].status).toBe(200)
@@ -84,7 +84,7 @@ describe('Facebook Custom Audiences - canary API version', () => {
         settings,
         auth,
         mapping: baseMapping,
-        features: { [FACEBOOK_CUSTOM_AUDIENCE_FLAGON]: true, 'actions-core-audience-membership': true }
+        features: { [FACEBOOK_CUSTOM_AUDIENCE_FLAGON]: true }
       })
 
       expect(responses[0].status).toBe(200)
@@ -101,8 +101,7 @@ describe('Facebook Custom Audiences - canary API version', () => {
         events,
         settings,
         auth,
-        mapping: baseMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: baseMapping
       })
 
       expect(responses[0].status).toBe(200)

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/delete.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/delete.test.ts
@@ -114,8 +114,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -207,8 +206,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -277,8 +275,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -328,8 +325,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping: engageMapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping: engageMapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -393,8 +389,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping: engageMapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping: engageMapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -451,8 +446,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping: engageMapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping: engageMapping
         })
 
         // --- Expected Segment MultiStatus Response ---
@@ -511,8 +505,7 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
           events,
           settings,
           auth,
-          mapping: engageMapping,
-          features: { 'actions-core-audience-membership': true }
+          mapping: engageMapping
         })
 
         // --- Expected Segment MultiStatus Response ---

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/delete.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/delete.test.ts
@@ -283,14 +283,14 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
 
         expect(responses[0]).toMatchObject({
           status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
           errormessage: 'Missing audience ID.',
           body: { externalId: 'user-1', email: 'user1@example.com', enable_batching: true, batch_size: 10000 }
         })
 
         expect(responses[1]).toMatchObject({
           status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
           errormessage: 'Missing audience ID.',
           body: { externalId: 'user-2', email: 'user2@example.com', enable_batching: true, batch_size: 10000 }
         })
@@ -513,14 +513,14 @@ describe('FacebookCustomAudiences.sync - syncMode: delete', () => {
 
         expect(responses[0]).toMatchObject({
           status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
           errormessage: 'Missing audience ID.',
           body: { externalId: 'rm-1', email: 'remove1@test.com' }
         })
 
         expect(responses[1]).toMatchObject({
           status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
           errormessage: 'Missing audience ID.',
           body: { externalId: 'rm-2', email: 'remove2@test.com' }
         })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/legacy.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/legacy.test.ts
@@ -100,7 +100,6 @@ describe('FacebookCustomAudiences.sync', () => {
         event,
         settings: retlSettings,
         auth,
-        features: { 'actions-core-audience-membership': true },
         mapping: {
           __segment_internal_sync_mode: 'upsert',
           email: { '@path': '$.properties.email' },
@@ -235,7 +234,6 @@ describe('FacebookCustomAudiences.sync', () => {
         event,
         settings: audienceSettings,
         auth,
-        features: { 'actions-core-audience-membership': true },
         mapping: {
           __segment_internal_sync_mode: 'mirror',
           email: { '@path': '$.properties.email' },

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/mirror.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/mirror.test.ts
@@ -172,8 +172,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: engageMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: engageMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -310,8 +309,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: engageMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: engageMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -444,8 +442,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: engageMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: engageMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -578,8 +575,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: retlMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: retlMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -692,8 +688,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: retlMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: retlMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -794,8 +789,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping: retlMapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping: retlMapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -861,8 +855,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -938,8 +931,7 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/mirror.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/mirror.test.ts
@@ -863,13 +863,13 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
 
       expect(responses[0]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Audience membership details missing'
       })
 
       expect(responses[1]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Audience membership details missing'
       })
     })
@@ -939,13 +939,13 @@ describe('FacebookCustomAudiences.sync - syncMode: mirror', () => {
 
       expect(responses[0]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Missing audience ID.'
       })
 
       expect(responses[1]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Missing audience ID.'
       })
     })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
@@ -401,43 +401,45 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
       })
     })
 
-    it('should not produce audience membership count mismatch when one event fails schema validation', async () => {
-      // Event at index 1 has no properties.externalId, so externalId resolves to undefined and
-      // is stripped by removeEmptyValues. externalId is required — that payload is filtered out
-      // by the schema validator before performBatch is called. The audienceMembership array is
-      // built from the already-filtered payloads array, so its length always matches and
-      // validate() does not return "Audience membership details count does not match batch payload count."
-      // context.personas is required so resolveAudienceMembership returns true (add) for each event.
-      const personas = {
-        computation_class: 'audience',
-        computation_key: 'my_audience'
-      }
-
+    it('should succeed for valid events when one event is filtered by schema validation', async () => {
+      // Event at index 1 has no userId, so externalId resolves to undefined and is stripped by
+      // removeEmptyValues. externalId is required — that payload is filtered out by the schema
+      // validator before performBatch is called. The audienceMembership array must also exclude
+      // the filtered event so its length matches the surviving payloads array.
       const events = [
         createTestEvent({
           type: 'track',
-          event: 'Audience Entered',
-          context: { personas },
-          properties: { externalId: 'user-1', email: 'user1@example.com', my_audience: true }
+          event: 'Test Audience Entered Event Name',
+          userId: 'user-1',
+          properties: { email: 'user1@example.com', test_audience: true },
+          context: { personas: { computation_class: 'audience', computation_key: 'test_audience' } }
         }),
         createTestEvent({
           type: 'track',
-          event: 'Audience Entered',
-          context: { personas },
-          properties: { email: 'user2@example.com', my_audience: true }
-          // no externalId — will fail required field schema validation
+          event: 'Test Audience Entered Event Name',
+          userId: undefined as unknown as string,
+          properties: { email: 'user2@example.com', test_audience: true },
+          context: { personas: { computation_class: 'audience', computation_key: 'test_audience' } }
         }),
         createTestEvent({
           type: 'track',
-          event: 'Audience Entered',
-          context: { personas },
-          properties: { externalId: 'user-3', email: 'user3@example.com', my_audience: true }
+          event: 'Test Audience Entered Event Name',
+          userId: 'user-3',
+          properties: { email: 'user3@example.com', test_audience: true },
+          context: { personas: { computation_class: 'audience', computation_key: 'test_audience' } }
+        }),
+        createTestEvent({
+          type: 'track',
+          event: 'Test Audience Exited Event Name',
+          userId: 'user-4',
+          properties: { email: 'user4@example.com', test_audience: false },
+          context: { personas: { computation_class: 'audience', computation_key: 'test_audience' } }
         })
       ]
 
       const mapping = {
         __segment_internal_sync_mode: 'upsert',
-        externalId: { '@path': '$.properties.externalId' },
+        externalId: { '@path': '$.userId' },
         email: { '@path': '$.properties.email' },
         retlOnMappingSave: {
           inputs: {},
@@ -450,7 +452,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         batch_size: 10000
       }
 
-      const facebookResponse = {
+      const facebookAddResponse = {
         audience_id: AUDIENCE_ID,
         session_id: '123456789',
         num_received: 2,
@@ -458,7 +460,16 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         invalid_entry_samples: {}
       }
 
-      nock(`${BASE_URL}/${API_VERSION}`).post(`/${AUDIENCE_ID}/users`).reply(200, facebookResponse)
+      const facebookDeleteResponse = {
+        audience_id: AUDIENCE_ID,
+        session_id: '987654321',
+        num_received: 1,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {}
+      }
+
+      nock(`${BASE_URL}/${API_VERSION}`).post(`/${AUDIENCE_ID}/users`).reply(200, facebookAddResponse)
+      nock(`${BASE_URL}/${API_VERSION}`).delete(`/${AUDIENCE_ID}/users`).reply(200, facebookDeleteResponse)
 
       const responses = await testDestination.executeBatch('sync', {
         events,
@@ -467,10 +478,9 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         mapping
       })
 
-      // Three responses: two successes (indices 0, 2) and one schema-validation error (index 1).
-      expect(responses.length).toBe(3)
+      expect(responses.length).toBe(4)
 
-      // Index 0 — valid event, upserted successfully
+      // Index 0 — valid event, added successfully
       expect(responses[0]).toMatchObject({
         status: 200,
         body: { externalId: 'user-1', email: 'user1@example.com' }
@@ -482,10 +492,17 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         errortype: 'PAYLOAD_VALIDATION_FAILED'
       })
 
-      // Index 2 — valid event, upserted successfully (no membership count mismatch error)
+      // Index 2 — valid event, added successfully
       expect(responses[2]).toMatchObject({
         status: 200,
         body: { externalId: 'user-3', email: 'user3@example.com' }
+      })
+
+      // Index 3 — valid event, removed from audience successfully
+      expect(responses[3]).toMatchObject({
+        status: 200,
+        body: { externalId: 'user-4', email: 'user4@example.com' },
+        sent: { audienceId: AUDIENCE_ID, method: 'DELETE' }
       })
     })
   })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
@@ -81,8 +81,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -225,8 +224,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -313,8 +311,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -383,8 +380,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // --- Expected Segment MultiStatus Response ---
@@ -468,8 +464,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         events,
         settings,
         auth,
-        mapping,
-        features: { 'actions-core-audience-membership': true }
+        mapping
       })
 
       // Three responses: two successes (indices 0, 2) and one schema-validation error (index 1).

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
@@ -388,14 +388,14 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
 
       expect(responses[0]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Missing audience ID.',
         body: { externalId: 'user-1', email: 'user1@example.com', enable_batching: true, batch_size: 10000 }
       })
 
       expect(responses[1]).toMatchObject({
         status: 400,
-        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errortype: 'INVALID_AUDIENCE_MEMBERSHIP',
         errormessage: 'Missing audience ID.',
         body: { externalId: 'user-2', email: 'user2@example.com', enable_batching: true, batch_size: 10000 }
       })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/upsert.test.ts
@@ -323,7 +323,7 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
       const expectedError = {
         status: 400,
         errortype: 'UNKNOWN_ERROR',
-        errormessage: "fbmessage: \"Invalid parameter\". message: \"Bad Request\". code: \"100\"",
+        errormessage: 'fbmessage: "Invalid parameter". message: "Bad Request". code: "100"',
         errorreporter: 'DESTINATION'
       }
 
@@ -402,6 +402,95 @@ describe('FacebookCustomAudiences.sync - syncMode: upsert', () => {
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: 'Missing audience ID.',
         body: { externalId: 'user-2', email: 'user2@example.com', enable_batching: true, batch_size: 10000 }
+      })
+    })
+
+    it('should not produce audience membership count mismatch when one event fails schema validation', async () => {
+      // Event at index 1 has no properties.externalId, so externalId resolves to undefined and
+      // is stripped by removeEmptyValues. externalId is required — that payload is filtered out
+      // by the schema validator before performBatch is called. The audienceMembership array is
+      // built from the already-filtered payloads array, so its length always matches and
+      // validate() does not return "Audience membership details count does not match batch payload count."
+      // context.personas is required so resolveAudienceMembership returns true (add) for each event.
+      const personas = {
+        computation_class: 'audience',
+        computation_key: 'my_audience'
+      }
+
+      const events = [
+        createTestEvent({
+          type: 'track',
+          event: 'Audience Entered',
+          context: { personas },
+          properties: { externalId: 'user-1', email: 'user1@example.com', my_audience: true }
+        }),
+        createTestEvent({
+          type: 'track',
+          event: 'Audience Entered',
+          context: { personas },
+          properties: { email: 'user2@example.com', my_audience: true }
+          // no externalId — will fail required field schema validation
+        }),
+        createTestEvent({
+          type: 'track',
+          event: 'Audience Entered',
+          context: { personas },
+          properties: { externalId: 'user-3', email: 'user3@example.com', my_audience: true }
+        })
+      ]
+
+      const mapping = {
+        __segment_internal_sync_mode: 'upsert',
+        externalId: { '@path': '$.properties.externalId' },
+        email: { '@path': '$.properties.email' },
+        retlOnMappingSave: {
+          inputs: {},
+          outputs: {
+            audienceName: 'test-audience',
+            audienceId: AUDIENCE_ID
+          }
+        },
+        enable_batching: true,
+        batch_size: 10000
+      }
+
+      const facebookResponse = {
+        audience_id: AUDIENCE_ID,
+        session_id: '123456789',
+        num_received: 2,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {}
+      }
+
+      nock(`${BASE_URL}/${API_VERSION}`).post(`/${AUDIENCE_ID}/users`).reply(200, facebookResponse)
+
+      const responses = await testDestination.executeBatch('sync', {
+        events,
+        settings,
+        auth,
+        mapping,
+        features: { 'actions-core-audience-membership': true }
+      })
+
+      // Three responses: two successes (indices 0, 2) and one schema-validation error (index 1).
+      expect(responses.length).toBe(3)
+
+      // Index 0 — valid event, upserted successfully
+      expect(responses[0]).toMatchObject({
+        status: 200,
+        body: { externalId: 'user-1', email: 'user1@example.com' }
+      })
+
+      // Index 1 — missing externalId, filtered at schema validation
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED'
+      })
+
+      // Index 2 — valid event, upserted successfully (no membership count mismatch error)
+      expect(responses[2]).toMatchObject({
+        status: 200,
+        body: { externalId: 'user-3', email: 'user3@example.com' }
       })
     })
   })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -65,11 +65,11 @@ export async function send(
         audienceMemberships = journeyMemberships
       }
     }
+  }
 
-    const errorMessage = validate(payloads, audienceId, audienceMemberships)
-    if (errorMessage) {
-      return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP)
-    }
+  const errorMessage = validate(payloads, audienceId, audienceMemberships)
+  if (errorMessage) {
+    return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP)
   }
 
   const addMap: PayloadMap = new Map<number, Payload>()

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -2,7 +2,7 @@ import { US_STATE_CODES, SCHEMA_PROPERTIES } from './constants'
 import { Payload } from './generated-types'
 import {
   RequestClient,
-  PayloadValidationError,
+  InvalidAudienceMembershipError,
   IntegrationError,
   MultiStatusResponse,
   ErrorCodes,
@@ -32,7 +32,7 @@ export function getJourneysMemberships(rawDatas: RawData[] | undefined): boolean
   const noneJourney = isJourneyStep.every((v) => !v)
 
   if (!allJourney && !noneJourney) {
-    throw new PayloadValidationError(
+    throw new InvalidAudienceMembershipError(
       'Batch contains a mix of journey_step and non-journey_step events. All events in a batch must be the same computation_class.'
     )
   }
@@ -68,7 +68,7 @@ export async function send(
 
     const errorMessage = validate(payloads, audienceId, audienceMemberships)
     if (errorMessage) {
-      return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED)
+      return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP)
     }
   }
 
@@ -89,7 +89,7 @@ export async function send(
         index,
         isBatch,
         'Audience membership details missing',
-        ErrorCodes.PAYLOAD_VALIDATION_FAILED
+        ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP
       )
     }
   })
@@ -167,8 +167,8 @@ export function setErrorResponse(
   sent?: JSONLikeObject
 ) {
   if (!isBatch) {
-    if (errortype === ErrorCodes.PAYLOAD_VALIDATION_FAILED) {
-      throw new PayloadValidationError(errormessage)
+    if (errortype === ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP) {
+      throw new InvalidAudienceMembershipError(errormessage)
     }
     throw new IntegrationError(errormessage, errortype, status)
   }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -56,7 +56,6 @@ export async function send(
 ): Promise<MultiStatusResponse | void> {
   const msResponse = new MultiStatusResponse()
 
-  const audienceId = getAudienceId(payloads[0], hookOutputs)
   if (features && features[FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]) {
     const journeyMemberships = getJourneysMemberships(rawData)
     if (Array.isArray(journeyMemberships) && journeyMemberships.length > 0) {
@@ -67,9 +66,11 @@ export async function send(
     }
   }
 
+  const audienceId = getAudienceId(payloads[0], hookOutputs)
   const errorMessage = validate(payloads, audienceId, audienceMemberships)
+
   if (errorMessage) {
-    return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.INVALID_AUDIENCE_MEMBERSHIP)
+    return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED)
   }
 
   const addMap: PayloadMap = new Map<number, Payload>()

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/functions.ts
@@ -1,6 +1,13 @@
 import { US_STATE_CODES, SCHEMA_PROPERTIES } from './constants'
 import { Payload } from './generated-types'
-import { RequestClient, PayloadValidationError, IntegrationError, MultiStatusResponse, ErrorCodes, Features } from '@segment/actions-core'
+import {
+  RequestClient,
+  PayloadValidationError,
+  IntegrationError,
+  MultiStatusResponse,
+  ErrorCodes,
+  Features
+} from '@segment/actions-core'
 import type { JSONLikeObject, AudienceMembership } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -9,15 +16,13 @@ import { BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON } from '../constants
 import { parseFacebookError, getApiVersion } from '../functions'
 import { FacebookResponseError } from '../types'
 
-/* 
+/*
  * Temporary function to handle audience membership when preset journeys_step_entered_track is in use.
- * All users will be added to the audience (no removals). 
- * This function will be removed once the Journeys team have migrated customers off of the  
- * journeys_step_entered_track preset. 
- */ 
-export function getJourneysMemberships(
-  rawDatas: RawData[] | undefined
-): boolean[] | undefined {
+ * All users will be added to the audience (no removals).
+ * This function will be removed once the Journeys team have migrated customers off of the
+ * journeys_step_entered_track preset.
+ */
+export function getJourneysMemberships(rawDatas: RawData[] | undefined): boolean[] | undefined {
   if (!rawDatas || (Array.isArray(rawDatas) && rawDatas.length === 0)) {
     return undefined
   }
@@ -27,7 +32,9 @@ export function getJourneysMemberships(
   const noneJourney = isJourneyStep.every((v) => !v)
 
   if (!allJourney && !noneJourney) {
-    throw new PayloadValidationError('Batch contains a mix of journey_step and non-journey_step events. All events in a batch must be the same computation_class.')
+    throw new PayloadValidationError(
+      'Batch contains a mix of journey_step and non-journey_step events. All events in a batch must be the same computation_class.'
+    )
   }
 
   if (noneJourney) {
@@ -48,22 +55,21 @@ export async function send(
   rawData?: RawData[]
 ): Promise<MultiStatusResponse | void> {
   const msResponse = new MultiStatusResponse()
-  
+
+  const audienceId = getAudienceId(payloads[0], hookOutputs)
   if (features && features[FACEBOOK_CUSTOM_AUDIENCE_JOURNEYS_FLAGON]) {
     const journeyMemberships = getJourneysMemberships(rawData)
     if (Array.isArray(journeyMemberships) && journeyMemberships.length > 0) {
       if (!audienceMemberships?.every((m) => typeof m === 'boolean')) {
-        // The above check is to ensure that the future JourneysVs preset will be able to add + remove users from the audience. 
+        // The above check is to ensure that the future JourneysVs preset will be able to add + remove users from the audience.
         audienceMemberships = journeyMemberships
       }
     }
-  }
 
-  const audienceId = getAudienceId(payloads[0], hookOutputs)
-  const errorMessage = validate(payloads, audienceId, audienceMemberships)
-
-  if (errorMessage) {
-    return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED)
+    const errorMessage = validate(payloads, audienceId, audienceMemberships)
+    if (errorMessage) {
+      return returnErrorResponse(msResponse, payloads, isBatch, errorMessage, ErrorCodes.PAYLOAD_VALIDATION_FAILED)
+    }
   }
 
   const addMap: PayloadMap = new Map<number, Payload>()
@@ -71,14 +77,20 @@ export async function send(
 
   payloads.forEach((payload, index) => {
     const audienceMembership = audienceMemberships?.[index]
-    if(audienceMembership === false){
+    if (audienceMembership === false) {
       deleteMap.set(index, payload)
-    } 
-    else if (audienceMembership === true){
+    } else if (audienceMembership === true) {
       addMap.set(index, payload)
-    } 
-    else if (audienceMembership === undefined){
-      setErrorResponse(msResponse, payload, 400, index, isBatch, "Audience membership details missing", ErrorCodes.PAYLOAD_VALIDATION_FAILED)
+    } else if (audienceMembership === undefined) {
+      setErrorResponse(
+        msResponse,
+        payload,
+        400,
+        index,
+        isBatch,
+        'Audience membership details missing',
+        ErrorCodes.PAYLOAD_VALIDATION_FAILED
+      )
     }
   })
 
@@ -99,7 +111,16 @@ export async function send(
   }
 }
 
-export async function sendRequest(request: RequestClient, audienceId: string, map: PayloadMap, msResponse: MultiStatusResponse, method: 'POST' | 'DELETE', isBatch: boolean, features?: Features, statsContext?: StatsContext): Promise<void> {
+export async function sendRequest(
+  request: RequestClient,
+  audienceId: string,
+  map: PayloadMap,
+  msResponse: MultiStatusResponse,
+  method: 'POST' | 'DELETE',
+  isBatch: boolean,
+  features?: Features,
+  statsContext?: StatsContext
+): Promise<void> {
   const indices = Array.from(map.keys())
   const payloads = Array.from(map.values())
   const json = getJSON(payloads)
@@ -121,8 +142,7 @@ export async function sendRequest(request: RequestClient, audienceId: string, ma
         }
       })
     }
-  } 
-  catch (error) {
+  } catch (error) {
     const { message, code, status } = parseFacebookError(error as FacebookResponseError)
 
     for (let i = 0; i < indices.length; i++) {
@@ -136,9 +156,18 @@ export async function sendRequest(request: RequestClient, audienceId: string, ma
   }
 }
 
-export function setErrorResponse(msResponse: MultiStatusResponse, payload: Payload, status: number, index: number, isBatch: boolean, errormessage: string, errortype: keyof typeof ErrorCodes | string, sent?: JSONLikeObject){
+export function setErrorResponse(
+  msResponse: MultiStatusResponse,
+  payload: Payload,
+  status: number,
+  index: number,
+  isBatch: boolean,
+  errormessage: string,
+  errortype: keyof typeof ErrorCodes | string,
+  sent?: JSONLikeObject
+) {
   if (!isBatch) {
-    if(errortype === ErrorCodes.PAYLOAD_VALIDATION_FAILED) {
+    if (errortype === ErrorCodes.PAYLOAD_VALIDATION_FAILED) {
       throw new PayloadValidationError(errormessage)
     }
     throw new IntegrationError(errormessage, errortype, status)
@@ -150,16 +179,25 @@ export function setErrorResponse(msResponse: MultiStatusResponse, payload: Paylo
     body: payload as unknown as JSONLikeObject,
     ...(sent ? { sent } : {})
   })
-} 
+}
 
-export function returnErrorResponse(msResponse: MultiStatusResponse, payloads: Payload[], isBatch: boolean, errormessage: string, errortype: keyof typeof ErrorCodes): MultiStatusResponse {
+export function returnErrorResponse(
+  msResponse: MultiStatusResponse,
+  payloads: Payload[],
+  isBatch: boolean,
+  errormessage: string,
+  errortype: keyof typeof ErrorCodes
+): MultiStatusResponse {
   payloads.forEach((payload, i) => {
     setErrorResponse(msResponse, payload, 400, i, isBatch, errormessage, errortype)
   })
   return msResponse
 }
 
-export function getAudienceId(payload: Payload, hookOutputs?: { retlOnMappingSave?: { outputs?: { audienceId?: string } } }): string {
+export function getAudienceId(
+  payload: Payload,
+  hookOutputs?: { retlOnMappingSave?: { outputs?: { audienceId?: string } } }
+): string {
   const { retlOnMappingSave: { outputs: { audienceId: hookAudienceId = undefined } = {} } = {} } = hookOutputs ?? {}
   const { external_audience_id: payloadAudienceId } = payload
   return (hookAudienceId ?? payloadAudienceId) as string
@@ -189,13 +227,16 @@ export function getJSON(payloads: Payload[]): AudienceJSON {
   }
 }
 
-export function validate(payloads: Payload[], audienceId: unknown, audienceMemberships?: AudienceMembership[]): string | undefined {
-  
-  if(!Array.isArray(audienceMemberships)){
+export function validate(
+  payloads: Payload[],
+  audienceId: unknown,
+  audienceMemberships?: AudienceMembership[]
+): string | undefined {
+  if (!Array.isArray(audienceMemberships)) {
     return 'Audience membership details for batch missing.'
   }
 
-  if(Array.isArray(audienceMemberships) && audienceMemberships.length !== payloads.length){
+  if (Array.isArray(audienceMemberships) && audienceMemberships.length !== payloads.length) {
     return 'Audience membership details count does not match batch payload count.'
   }
 


### PR DESCRIPTION
## Summary

- When one or more events in a batch fail schema validation, the invalid payloads are removed from the `payloads` array before `performBatch` is called
- The `audienceMembership` array was not trimmed to match, causing `validate()` inside `send()` to return `"Audience membership details count does not match batch payload count."` — failing **every** event in the batch instead of just the invalid one
- Fix: filter `audienceMembership` using the same `invalidPayloadIndices` set used to filter payloads, keeping the two arrays in sync

**Root cause** ([`action.ts#L476`](https://github.com/segmentio/action-destinations/blob/main/packages/core/src/destination-kit/action.ts#L476)):
```ts
// before
const audienceMembership = bundle.data.map((d) => resolveAudienceMembership(d, syncMode))

// after
const audienceMembership = bundle.data
  .map((d) => resolveAudienceMembership(d, syncMode))
  .filter((_, i) => !invalidPayloadIndices.has(i))
```

Also: updates error type for audience-related validation errors (missing audience ID, missing membership details) from `PAYLOAD_VALIDATION_FAILED` to `INVALID_AUDIENCE_MEMBERSHIP` to distinguish them from schema validation failures.

## Customer Impact

Any Facebook Custom Audiences sync batch containing even one schema-invalid event (e.g. a user record missing `externalId`) fails entirely — valid users in the same batch are not added to or removed from the audience. Customers see complete batch drops rather than single-event errors, leading to audience under-population and missed ad targeting.

## Unit tests updated
  - **upsert.test.ts**: Updated "missing audience ID" assertions to expect `INVALID_AUDIENCE_MEMBERSHIP` error type.
  - **mirror.test.ts**: Updated "missing audience membership details" and "missing audience ID" assertions to expect `INVALID_AUDIENCE_MEMBERSHIP` error type.
  - **delete.test.ts**: Updated "missing audience ID" assertions (RETL and Engage) to expect `INVALID_AUDIENCE_MEMBERSHIP` error type.

## Unit tests added
  - **upsert.test.ts**: "should succeed for valid events when one event is filtered by schema validation" — batch of 4 events (2 adds, 1 schema failure, 1 removal) verifying that the audienceMembership array is correctly filtered alongside payloads so
  valid events still succeed.
  - **audience-membership.test.ts** (core): Unit tests for `resolveAudienceMembership` logic.

## Staging test plan
  - [ ] Send a batch where one event has a missing required field (e.g. no `externalId`) — confirm valid events in the same batch succeed and the invalid one returns a 400.
  - [ ] Send a batch with no audience ID configured — confirm all events return `INVALID_AUDIENCE_MEMBERSHIP` errors (not `PAYLOAD_VALIDATION_FAILED`).
  - [ ] Send a mixed add/remove batch (Engage-style with `true`/`false` membership) — confirm adds hit POST and removes hit DELETE on Facebook's API.
  - [ ] Send a batch where all events are valid — confirm normal happy-path behavior is unaffected.


🤖 Generated with [Claude Code](https://claude.com/claude-code)