### PR TITLE
[Airship] - [PINT-2637] - Several new features

### DIFF
--- a/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "named_user_id": "Z8PnKI8*YgWA",
+      "Z8PnKI8*YgWA": "Z8PnKI8*YgWA",
     },
   },
 ]
@@ -31,7 +31,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "named_user_id": "Z8PnKI8*YgWA",
+      "channel": "Z8PnKI8*YgWA",
     },
   },
 ]
@@ -40,7 +40,7 @@ Array [
 exports[`Testing snapshot for actions-airship destination: manageTags action - all fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "XvmIpuaw",
+    "XvmIpuaw": "XvmIpuaw",
   },
 }
 `;
@@ -48,7 +48,7 @@ Object {
 exports[`Testing snapshot for actions-airship destination: manageTags action - required fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "XvmIpuaw",
+    "channel": "XvmIpuaw",
   },
 }
 `;
@@ -207,7 +207,7 @@ Object {
     },
   ],
   "audience": Object {
-    "named_user_id": "*N75*",
+    "*N75*": "*N75*",
   },
 }
 `;
@@ -216,7 +216,7 @@ exports[`Testing snapshot for actions-airship destination: setAttributes action 
 Object {
   "attributes": Array [],
   "audience": Object {
-    "named_user_id": "*N75*",
+    "channel": "*N75*",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "Z8PnKI8*YgWA": "Z8PnKI8*YgWA",
+      "channel": "Z8PnKI8*YgWA",
     },
   },
 ]
@@ -40,7 +40,7 @@ Array [
 exports[`Testing snapshot for actions-airship destination: manageTags action - all fields 1`] = `
 Object {
   "audience": Object {
-    "XvmIpuaw": "XvmIpuaw",
+    "channel": "XvmIpuaw",
   },
 }
 `;
@@ -207,7 +207,7 @@ Object {
     },
   ],
   "audience": Object {
-    "*N75*": "*N75*",
+    "channel": "*N75*",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
@@ -6,6 +6,30 @@ import { DecoratedResponse } from '@segment/actions-core'
 const testDestination = createTestIntegration(Airship)
 
 describe('Airship', () => {
+  describe('extendRequest headers', () => {
+    it('should set the Segment attribution User-Agent header with the app key', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({
+        userId: 'test-user-rzoj4u7gqw',
+        timestamp: now,
+        traits: { trait1: 1 }
+      })
+
+      nock('https://go.urbanairship.com').post('/api/channels/attributes').reply(200, {})
+
+      const responses = await testDestination.testAction('setAttributes', {
+        event,
+        useDefaultMappings: true,
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        }
+      })
+      expect(responses[0].options.headers?.get('user-agent')).toBe('PartnerIntegrations/Segment (bar)')
+    })
+  })
+
   describe('setAttribute', () => {
     it('should work for US', async () => {
       const now = new Date().toISOString()
@@ -97,6 +121,46 @@ describe('Airship', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
       expect(responses[0].data).toMatchObject({})
+    })
+
+    it('should batch events, building each user object independently', async () => {
+      const now = new Date().toISOString()
+
+      nock('https://go.urbanairship.com').post('/api/custom-events').reply(200, {})
+
+      const responses = await testDestination.testBatchAction('customEvents', {
+        settings: {
+          access_token: 'foo',
+          app_key: 'bar',
+          endpoint: 'US'
+        },
+        events: [
+          createTestEvent({ type: 'track', timestamp: now, event: 'Event A', userId: 'named-user-1' }),
+          createTestEvent({
+            type: 'track',
+            timestamp: now,
+            event: 'Event B',
+            userId: undefined,
+            properties: { channel_id: 'chan-xyz' },
+            context: { device: { type: 'ios' } }
+          })
+        ],
+        mapping: {
+          named_user_id: { '@path': '$.userId' },
+          channel_id: { '@path': '$.properties.channel_id' },
+          channel_type: { '@path': '$.context.device.type' },
+          name: { '@path': '$.event' },
+          occurred: { '@path': '$.timestamp' },
+          enable_batching: true
+        }
+      })
+
+      expect(responses[0].status).toBe(200)
+      const sent = JSON.parse(responses[0].options.body as string)
+      expect(sent).toHaveLength(2)
+      // Each event resolves its own audience: first a named user, second an iOS channel
+      expect(sent[0].user).toEqual({ named_user_id: 'named-user-1' })
+      expect(sent[1].user).toEqual({ ios_channel: 'chan-xyz' })
     })
   })
 

--- a/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/airship.test.ts
@@ -129,6 +129,72 @@ describe('Airship', () => {
     })
   })
 
+  describe('setAttribute with channel_id', () => {
+    it('should use channel audience', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({
+        timestamp: now,
+        traits: { trait1: 1 }
+      })
+
+      nock('https://go.urbanairship.com').post('/api/channels/attributes').reply(200, {})
+
+      const responses = await testDestination.testAction('setAttributes', {
+        event,
+        settings: { access_token: 'foo', app_key: 'bar', endpoint: 'US' },
+        mapping: {
+          channel_id: 'chan-abc',
+          channel_type: 'email',
+          occurred: now,
+          attributes: { trait1: 1 }
+        }
+      })
+      expect(responses[0].status).toBe(200)
+    })
+  })
+
+  describe('customEvents with channel_id', () => {
+    it('should use channel audience', async () => {
+      const now = new Date().toISOString()
+      const event = createTestEvent({ type: 'track', timestamp: now })
+
+      nock('https://go.urbanairship.com').post('/api/custom-events').reply(200, {})
+
+      const responses = await testDestination.testAction('customEvents', {
+        event,
+        settings: { access_token: 'foo', app_key: 'bar', endpoint: 'US' },
+        mapping: {
+          channel_id: 'chan-abc',
+          channel_type: 'email',
+          name: 'Test Event',
+          occurred: now,
+          enable_batching: false
+        }
+      })
+      expect(responses[0].status).toBe(200)
+    })
+  })
+
+  describe('manageTags with channel_id', () => {
+    it('should use channel audience', async () => {
+      const event = createTestEvent({ traits: { airship_tags: { tag1: true } } })
+
+      nock('https://go.urbanairship.com').post('/api/channels/tags').reply(200, {})
+
+      const responses = await testDestination.testAction('manageTags', {
+        event,
+        settings: { access_token: 'foo', app_key: 'bar', endpoint: 'US' },
+        mapping: {
+          channel_id: 'chan-abc',
+          channel_type: 'sms',
+          tags: { tag1: true },
+          tag_group: 'segment-integration'
+        }
+      })
+      expect(responses[0].status).toBe(200)
+    })
+  })
+
   describe('delete', () => {
     it('should support deletes', async () => {
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -270,30 +270,40 @@ describe('Testing _parse_and_format_date', () => {
   })
 })
 
+describe('Testing _channel_type_to_key', () => {
+  it('should map known platform types to platform-specific keys', () => {
+    expect(_private._channel_type_to_key('ios')).toBe('ios_channel')
+    expect(_private._channel_type_to_key('android')).toBe('android_channel')
+    expect(_private._channel_type_to_key('amazon')).toBe('amazon_channel')
+    expect(_private._channel_type_to_key('web')).toBe('web_channel')
+  })
+
+  it('should fall back to the generic channel key for unknown types', () => {
+    expect(_private._channel_type_to_key('email')).toBe('channel')
+    expect(_private._channel_type_to_key('sms')).toBe('channel')
+  })
+})
+
 describe('Testing _build_audience', () => {
   it('should return named_user_id audience when only named_user_id is provided', () => {
     expect(_private._build_audience({ named_user_id: 'user-123' })).toEqual({ named_user_id: 'user-123' })
   })
 
-  it('should return channel audience when channel_id and channel_type are provided', () => {
-    expect(_private._build_audience({ channel_id: 'chan-abc', channel_type: 'email' })).toEqual({
-      email: 'chan-abc'
-    })
+  it('should use the platform-specific key when channel_type maps to one', () => {
+    expect(_private._build_audience({ channel_id: 'chan-abc', channel_type: 'ios' })).toEqual({ ios_channel: 'chan-abc' })
   })
 
-  it('should use channel selector when all three fields are provided (channel_id takes precedence)', () => {
-    expect(_private._build_audience({ named_user_id: 'user-123', channel_id: 'chan-abc', channel_type: 'email' })).toEqual({
-      email: 'chan-abc'
-    })
+  it('should use the generic channel key when channel_type is not a known platform', () => {
+    expect(_private._build_audience({ channel_id: 'chan-abc', channel_type: 'email' })).toEqual({ channel: 'chan-abc' })
   })
 
-  it('should use generic channel audience when channel_id provided without channel_type', () => {
+  it('should use the generic channel key when channel_type is omitted', () => {
     expect(_private._build_audience({ channel_id: 'chan-abc' })).toEqual({ channel: 'chan-abc' })
   })
 
-  it('should use generic channel audience when channel_id provided without channel_type even if named_user_id is present', () => {
-    expect(_private._build_audience({ named_user_id: 'user-123', channel_id: 'chan-abc' })).toEqual({
-      channel: 'chan-abc'
+  it('should prefer channel_id over named_user_id when both provided', () => {
+    expect(_private._build_audience({ named_user_id: 'user-123', channel_id: 'chan-abc', channel_type: 'ios' })).toEqual({
+      ios_channel: 'chan-abc'
     })
   })
 
@@ -303,28 +313,49 @@ describe('Testing _build_audience', () => {
 })
 
 describe('Testing _build_custom_event_object with channel_id', () => {
-  it('should use channel audience when channel_id is provided', () => {
+  it('should use the platform-specific key for a known channel type', () => {
     const payload: CustomEventsPayload = {
-      channel_id: 'chan-abc',
-      channel_type: 'email',
+      channel_id: 'bddb6f5d-dcc3-4b0b-ba50-61b169077302',
+      channel_type: 'ios',
       name: 'Test Event',
       occurred: occurred.toISOString(),
       enable_batching: false
     }
     const result = _private._build_custom_event_object(payload) as any
-    expect(result.user).toEqual({ email: 'chan-abc' })
+    expect(result.user).toEqual({ ios_channel: 'bddb6f5d-dcc3-4b0b-ba50-61b169077302' })
+  })
+
+  it('should use the generic channel key when channel_type is omitted', () => {
+    const payload: CustomEventsPayload = {
+      channel_id: 'chan-abc',
+      name: 'Test Event',
+      occurred: occurred.toISOString(),
+      enable_batching: false
+    }
+    const result = _private._build_custom_event_object(payload) as any
+    expect(result.user).toEqual({ channel: 'chan-abc' })
   })
 })
 
 describe('Testing _build_tags_object with channel_id', () => {
-  it('should use channel audience when channel_id is provided', () => {
+  it('should use the platform-specific key for a known channel type', () => {
     const payload: ManageTagsPayload = {
-      channel_id: 'chan-abc',
-      channel_type: 'sms',
+      channel_id: 'bddb6f5d-dcc3-4b0b-ba50-61b169077302',
+      channel_type: 'ios',
       tag_group: 'segment-integration',
       tags: { trait3: true }
     }
     const result = _private._build_tags_object(payload) as any
-    expect(result.audience).toEqual({ sms: 'chan-abc' })
+    expect(result.audience).toEqual({ ios_channel: 'bddb6f5d-dcc3-4b0b-ba50-61b169077302' })
+  })
+
+  it('should use the generic channel key when channel_type is omitted', () => {
+    const payload: ManageTagsPayload = {
+      channel_id: 'chan-abc',
+      tag_group: 'segment-integration',
+      tags: { trait3: true }
+    }
+    const result = _private._build_tags_object(payload) as any
+    expect(result.audience).toEqual({ channel: 'chan-abc' })
   })
 })

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -269,3 +269,62 @@ describe('Testing _parse_and_format_date', () => {
     expect(_private._parse_and_format_date('foo')).toEqual('foo')
   })
 })
+
+describe('Testing _build_audience', () => {
+  it('should return named_user_id audience when only named_user_id is provided', () => {
+    expect(_private._build_audience({ named_user_id: 'user-123' })).toEqual({ named_user_id: 'user-123' })
+  })
+
+  it('should return channel audience when channel_id and channel_type are provided', () => {
+    expect(_private._build_audience({ channel_id: 'chan-abc', channel_type: 'email' })).toEqual({
+      email: 'chan-abc'
+    })
+  })
+
+  it('should use channel selector when all three fields are provided (channel_id takes precedence)', () => {
+    expect(_private._build_audience({ named_user_id: 'user-123', channel_id: 'chan-abc', channel_type: 'email' })).toEqual({
+      email: 'chan-abc'
+    })
+  })
+
+  it('should use generic channel audience when channel_id provided without channel_type', () => {
+    expect(_private._build_audience({ channel_id: 'chan-abc' })).toEqual({ channel: 'chan-abc' })
+  })
+
+  it('should use generic channel audience when channel_id provided without channel_type even if named_user_id is present', () => {
+    expect(_private._build_audience({ named_user_id: 'user-123', channel_id: 'chan-abc' })).toEqual({
+      channel: 'chan-abc'
+    })
+  })
+
+  it('should throw when neither named_user_id nor channel_id is provided', () => {
+    expect(() => _private._build_audience({})).toThrow('Either Named User ID or Channel ID must be provided')
+  })
+})
+
+describe('Testing _build_custom_event_object with channel_id', () => {
+  it('should use channel audience when channel_id is provided', () => {
+    const payload: CustomEventsPayload = {
+      channel_id: 'chan-abc',
+      channel_type: 'email',
+      name: 'Test Event',
+      occurred: occurred.toISOString(),
+      enable_batching: false
+    }
+    const result = _private._build_custom_event_object(payload) as any
+    expect(result.user).toEqual({ email: 'chan-abc' })
+  })
+})
+
+describe('Testing _build_tags_object with channel_id', () => {
+  it('should use channel audience when channel_id is provided', () => {
+    const payload: ManageTagsPayload = {
+      channel_id: 'chan-abc',
+      channel_type: 'sms',
+      tag_group: 'segment-integration',
+      tags: { trait3: true }
+    }
+    const result = _private._build_tags_object(payload) as any
+    expect(result.audience).toEqual({ sms: 'chan-abc' })
+  })
+})

--- a/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
+++ b/packages/destination-actions/src/destinations/airship/__tests__/utilities.test.ts
@@ -155,6 +155,63 @@ describe('Testing _build_attribute_object', () => {
   })
 })
 
+describe('Testing _build_attribute_object with JSON (array/object) values', () => {
+  it('should append #default to array attribute keys without an instance ID', () => {
+    const payload: AttributesPayload = {
+      named_user_id: 'test-user',
+      occurred: occurred.toISOString(),
+      attributes: {
+        favourite_teams: ['Team A', 'Team B', 'Team C']
+      }
+    }
+    const result = _private._build_attributes_object(payload)
+    const attr = result.find((a: any) => a.key === 'favourite_teams#default')
+    expect(attr?.action).toBe('set')
+    expect(attr?.value).toEqual(['Team A', 'Team B', 'Team C'])
+  })
+
+  it('should append #default to object attribute keys without an instance ID', () => {
+    const payload: AttributesPayload = {
+      named_user_id: 'test-user',
+      occurred: occurred.toISOString(),
+      attributes: {
+        preferences: { theme: 'dark', language: 'en' }
+      }
+    }
+    const result = _private._build_attributes_object(payload)
+    const attr = result.find((a: any) => a.key === 'preferences#default')
+    expect(attr?.action).toBe('set')
+    expect(attr?.value).toEqual({ theme: 'dark', language: 'en' })
+  })
+
+  it('should preserve a user-supplied instance ID in the key', () => {
+    const payload: AttributesPayload = {
+      named_user_id: 'test-user',
+      occurred: occurred.toISOString(),
+      attributes: {
+        'reservation#a001': { flight: 'UA123', seat: '12A' }
+      }
+    }
+    const result = _private._build_attributes_object(payload)
+    const attr = result.find((a: any) => a.key === 'reservation#a001')
+    expect(attr?.action).toBe('set')
+    expect(attr?.value).toEqual({ flight: 'UA123', seat: '12A' })
+  })
+
+  it('should set action to remove for null value', () => {
+    const payload: AttributesPayload = {
+      named_user_id: 'test-user',
+      occurred: occurred.toISOString(),
+      attributes: {
+        favourite_teams: null
+      }
+    }
+    const result = _private._build_attributes_object(payload)
+    const attr = result.find((a: any) => a.key === 'favourite_teams')
+    expect(attr?.action).toBe('remove')
+  })
+})
+
 describe('Testing _build_tags_object', () => {
   it('should correctly format a tag', () => {
     expect(_private._build_tags_object(valid_tags_payload)).toEqual(airship_tags_payload)

--- a/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/index.test.ts.snap
@@ -12,7 +12,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "named_user_id": "5C5XZ3fWrH)z48",
+      "channel": "5C5XZ3fWrH)z48",
     },
   },
 ]

--- a/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "named_user_id": "5C5XZ3fWrH)z48",
+      "5C5XZ3fWrH)z48": "5C5XZ3fWrH)z48",
     },
   },
 ]
@@ -31,7 +31,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "named_user_id": "5C5XZ3fWrH)z48",
+      "channel": "5C5XZ3fWrH)z48",
     },
   },
 ]

--- a/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/customEvents/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -13,7 +13,7 @@ Array [
     },
     "occurred": false,
     "user": Object {
-      "5C5XZ3fWrH)z48": "5C5XZ3fWrH)z48",
+      "channel": "5C5XZ3fWrH)z48",
     },
   },
 ]

--- a/packages/destination-actions/src/destinations/airship/customEvents/generated-types.ts
+++ b/packages/destination-actions/src/destinations/airship/customEvents/generated-types.ts
@@ -2,9 +2,17 @@
 
 export interface Payload {
   /**
-   * The identifier assigned in Airship as the Named User
+   * The identifier assigned in Airship as the Named User. Provide either this or Channel ID.
    */
-  named_user_id: string
+  named_user_id?: string
+  /**
+   * Airship Channel ID. Provide either this or Named User ID.
+   */
+  channel_id?: string
+  /**
+   * The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.
+   */
+  channel_type?: string
   /**
    * Event Name
    */

--- a/packages/destination-actions/src/destinations/airship/customEvents/index.ts
+++ b/packages/destination-actions/src/destinations/airship/customEvents/index.ts
@@ -10,12 +10,24 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     named_user_id: {
       label: 'Airship Named User ID',
-      description: 'The identifier assigned in Airship as the Named User',
+      description: 'The identifier assigned in Airship as the Named User. Provide either this or Channel ID.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.userId'
       }
+    },
+    channel_id: {
+      label: 'Channel ID',
+      description: 'Airship Channel ID. Provide either this or Named User ID.',
+      type: 'string',
+      required: false
+    },
+    channel_type: {
+      label: 'Channel Type',
+      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      type: 'string',
+      required: false
     },
     name: {
       label: 'Name',

--- a/packages/destination-actions/src/destinations/airship/customEvents/index.ts
+++ b/packages/destination-actions/src/destinations/airship/customEvents/index.ts
@@ -25,9 +25,13 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     channel_type: {
       label: 'Channel Type',
-      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      description:
+        'The device type for the Channel ID (e.g. ios, android, amazon, web). Defaults to the device type from the event. If omitted or unrecognized, the generic channel key is used and Airship resolves the type, which may introduce a slight delay.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.context.device.type'
+      }
     },
     name: {
       label: 'Name',

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -24,14 +24,14 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Access Token',
         description: 'Create in the Airship Go dashboard in Settings->Partner Integrations->Segment',
         type: 'password',
-        // default: process.env.DEFAULT_ACCESS_TOKEN,
+        default: process.env.DEFAULT_ACCESS_TOKEN,
         required: true
       },
       app_key: {
         label: 'App Key',
         description: 'The App Key identifies the Airship Project to which API requests are made.',
         type: 'password',
-        // default: process.env.DEFAULT_APP_KEY,
+        default: process.env.DEFAULT_APP_KEY,
         required: true
       },
       endpoint: {

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -24,14 +24,14 @@ const destination: DestinationDefinition<Settings> = {
         label: 'Access Token',
         description: 'Create in the Airship Go dashboard in Settings->Partner Integrations->Segment',
         type: 'password',
-        default: process.env.DEFAULT_ACCESS_TOKEN,
+        // default: process.env.DEFAULT_ACCESS_TOKEN,
         required: true
       },
       app_key: {
         label: 'App Key',
         description: 'The App Key identifies the Airship Project to which API requests are made.',
         type: 'password',
-        default: process.env.DEFAULT_APP_KEY,
+        // default: process.env.DEFAULT_APP_KEY,
         required: true
       },
       endpoint: {

--- a/packages/destination-actions/src/destinations/airship/index.ts
+++ b/packages/destination-actions/src/destinations/airship/index.ts
@@ -92,7 +92,8 @@ const destination: DestinationDefinition<Settings> = {
         Authorization: `Bearer ${settings.access_token}`,
         'X-UA-Appkey': `${settings.app_key}`,
         Accept: 'application/vnd.urbanairship+json; version=3',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': `PartnerIntegrations/Segment (${settings.app_key})`
       }
     }
   },

--- a/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/index.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for Airship's manageTags destination action: all fields 1`] = `
 Object {
   "audience": Object {
-    "s0s43LdN(JFJswcY3#g3": "s0s43LdN(JFJswcY3#g3",
+    "channel": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/index.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for Airship's manageTags destination action: all fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "s0s43LdN(JFJswcY3#g3",
+    "s0s43LdN(JFJswcY3#g3": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;
@@ -11,7 +11,7 @@ Object {
 exports[`Testing snapshot for Airship's manageTags destination action: required fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "s0s43LdN(JFJswcY3#g3",
+    "channel": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for Airship's manageTags destination action: all fields 1`] = `
 Object {
   "audience": Object {
-    "s0s43LdN(JFJswcY3#g3": "s0s43LdN(JFJswcY3#g3",
+    "channel": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/manageTags/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Testing snapshot for Airship's manageTags destination action: all fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "s0s43LdN(JFJswcY3#g3",
+    "s0s43LdN(JFJswcY3#g3": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;
@@ -11,7 +11,7 @@ Object {
 exports[`Testing snapshot for Airship's manageTags destination action: required fields 1`] = `
 Object {
   "audience": Object {
-    "named_user_id": "s0s43LdN(JFJswcY3#g3",
+    "channel": "s0s43LdN(JFJswcY3#g3",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/manageTags/generated-types.ts
+++ b/packages/destination-actions/src/destinations/airship/manageTags/generated-types.ts
@@ -2,9 +2,17 @@
 
 export interface Payload {
   /**
-   * The identifier assigned in Airship as the Named User
+   * The identifier assigned in Airship as the Named User. Provide either this or Channel ID.
    */
-  named_user_id: string
+  named_user_id?: string
+  /**
+   * Airship Channel ID. Provide either this or Named User ID.
+   */
+  channel_id?: string
+  /**
+   * The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.
+   */
+  channel_type?: string
   /**
    * Tag name to add or remove. Values for each tag should be boolean only. A true value creates a tag, a false value removes a tag. Non-boolean values will be ignored.
    */

--- a/packages/destination-actions/src/destinations/airship/manageTags/index.ts
+++ b/packages/destination-actions/src/destinations/airship/manageTags/index.ts
@@ -9,12 +9,24 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     named_user_id: {
       label: 'Airship Named User ID',
-      description: 'The identifier assigned in Airship as the Named User',
+      description: 'The identifier assigned in Airship as the Named User. Provide either this or Channel ID.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.userId'
       }
+    },
+    channel_id: {
+      label: 'Channel ID',
+      description: 'Airship Channel ID. Provide either this or Named User ID.',
+      type: 'string',
+      required: false
+    },
+    channel_type: {
+      label: 'Channel Type',
+      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      type: 'string',
+      required: false
     },
     tags: {
       label: 'Tag Name',

--- a/packages/destination-actions/src/destinations/airship/manageTags/index.ts
+++ b/packages/destination-actions/src/destinations/airship/manageTags/index.ts
@@ -24,9 +24,13 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     channel_type: {
       label: 'Channel Type',
-      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      description:
+        'The device type for the Channel ID (e.g. ios, android, amazon, web). Defaults to the device type from the event. If omitted or unrecognized, the generic channel key is used and Airship resolves the type, which may introduce a slight delay.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.context.device.type'
+      }
     },
     tags: {
       label: 'Tag Name',

--- a/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for Airship's setAttributes destination action: requir
 Object {
   "attributes": Array [],
   "audience": Object {
-    "named_user_id": "Tw4VW",
+    "channel": "Tw4VW",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -143,7 +143,7 @@ Object {
     },
   ],
   "audience": Object {
-    "named_user_id": "Tw4VW",
+    "Tw4VW": "Tw4VW",
   },
 }
 `;
@@ -152,7 +152,7 @@ exports[`Testing snapshot for Airship's setAttributes destination action: requir
 Object {
   "attributes": Array [],
   "audience": Object {
-    "named_user_id": "Tw4VW",
+    "channel": "Tw4VW",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -143,7 +143,7 @@ Object {
     },
   ],
   "audience": Object {
-    "Tw4VW": "Tw4VW",
+    "channel": "Tw4VW",
   },
 }
 `;

--- a/packages/destination-actions/src/destinations/airship/setAttributes/generated-types.ts
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/generated-types.ts
@@ -2,9 +2,17 @@
 
 export interface Payload {
   /**
-   * The identifier assigned in Airship as the Named User
+   * The identifier assigned in Airship as the Named User. Provide either this or Channel ID.
    */
-  named_user_id: string
+  named_user_id?: string
+  /**
+   * Airship Channel ID. Provide either this or Named User ID.
+   */
+  channel_id?: string
+  /**
+   * The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.
+   */
+  channel_type?: string
   /**
    * When the Trait was set
    */

--- a/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
@@ -26,9 +26,13 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     channel_type: {
       label: 'Channel Type',
-      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      description:
+        'The device type for the Channel ID (e.g. ios, android, amazon, web). Defaults to the device type from the event. If omitted or unrecognized, the generic channel key is used and Airship resolves the type, which may introduce a slight delay.',
       type: 'string',
-      required: false
+      required: false,
+      default: {
+        '@path': '$.context.device.type'
+      }
     },
     occurred: {
       label: 'Occurred',

--- a/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
+++ b/packages/destination-actions/src/destinations/airship/setAttributes/index.ts
@@ -11,12 +11,24 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     named_user_id: {
       label: 'Airship Named User ID',
-      description: 'The identifier assigned in Airship as the Named User',
+      description: 'The identifier assigned in Airship as the Named User. Provide either this or Channel ID.',
       type: 'string',
-      required: true,
+      required: false,
       default: {
         '@path': '$.userId'
       }
+    },
+    channel_id: {
+      label: 'Channel ID',
+      description: 'Airship Channel ID. Provide either this or Named User ID.',
+      type: 'string',
+      required: false
+    },
+    channel_type: {
+      label: 'Channel Type',
+      description: 'The Airship audience key for the channel type (e.g. android_channel, ios_channel, amazon_channel, web_channel). If omitted, the generic channel key is used and Airship will resolve the type, which may introduce a slight delay.',
+      type: 'string',
+      required: false
     },
     occurred: {
       label: 'Occurred',

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -232,9 +232,26 @@ export function map_endpoint(region: string) {
   }
 }
 
+function _channel_type_to_key(channel_type: string): string {
+  const map: Record<string, string> = {
+    ios: 'ios_channel',
+    android: 'android_channel',
+    amazon: 'amazon_channel',
+    web: 'web_channel'
+  }
+  return map[channel_type.toLowerCase()] ?? 'channel'
+}
+
+// Builds the audience identifier object used to target a user, shared across all actions.
+// - named_user_id -> { named_user_id }
+// - channel_id with channel_type -> platform-specific key, e.g. { ios_channel } (Airship resolves
+//   the channel directly)
+// - channel_id without channel_type -> generic { channel } (Airship resolves the type server-side)
+// Used as the `user` object for custom events and the `audience` object for attributes and tags.
 function _build_audience(payload: { named_user_id?: string; channel_id?: string; channel_type?: string }): object {
   if (payload.channel_id) {
-    return { [payload.channel_type ?? 'channel']: payload.channel_id }
+    const key = payload.channel_type ? _channel_type_to_key(payload.channel_type) : 'channel'
+    return { [key]: payload.channel_id }
   }
   if (payload.named_user_id) {
     return { named_user_id: payload.named_user_id }
@@ -433,6 +450,7 @@ function _extract_country_language(locale: string): string[] {
 
 export const _private = {
   _build_audience,
+  _channel_type_to_key,
   _build_custom_event_object,
   _build_attributes_object,
   _build_attribute,

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -279,6 +279,16 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   /*
   This function builds a single attribute from a key/value.
   */
+  // JSON attributes (object/array values) require a key in the format attribute_name#instance_id.
+  // If the user hasn't included an instance ID, append '#default'.
+  if (
+    attribute_value !== null &&
+    typeof attribute_value === 'object' &&
+    !attribute_key.includes('#')
+  ) {
+    attribute_key = `${attribute_key}#default`
+  }
+
   let adjustedDate = null
   if (typeof attribute_value == 'string') {
     adjustedDate = _parse_date(attribute_value)
@@ -291,7 +301,7 @@ function _build_attribute(attribute_key: string, attribute_value: any, occurred:
   const attribute: {
     action: string
     key: string
-    value?: string | number | boolean
+    value?: unknown
     timestamp: string | boolean
   } = {
     action: 'set',

--- a/packages/destination-actions/src/destinations/airship/utilities.ts
+++ b/packages/destination-actions/src/destinations/airship/utilities.ts
@@ -1,4 +1,4 @@
-import { RequestClient } from '@segment/actions-core'
+import { RequestClient, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import { Payload as CustomEventsPayload } from './customEvents/generated-types'
 import { Payload as AttributesPayload } from './setAttributes/generated-types'
@@ -194,12 +194,9 @@ export function setBatchCustomEvent(request: RequestClient, settings: Settings, 
 export function setAttribute(request: RequestClient, settings: Settings, payload: AttributesPayload) {
   const endpoint = map_endpoint(settings.endpoint)
   const uri = `${endpoint}/api/channels/attributes`
-  const attributes = _build_attributes_object(payload)
   const airship_payload = {
-    attributes: attributes,
-    audience: {
-      named_user_id: `${payload.named_user_id}`
-    }
+    attributes: _build_attributes_object(payload),
+    audience: _build_audience(payload)
   }
   return do_request(request, uri, airship_payload)
 }
@@ -214,7 +211,8 @@ export function getChannelId(request: RequestClient, settings: Settings, emailAd
 // exported Action function
 export function manageTags(request: RequestClient, settings: Settings, payload: TagsPayload) {
   const endpoint = map_endpoint(settings.endpoint)
-  const uri = `${endpoint}/api/named_users/tags`
+  const path = payload.channel_id ? '/api/channels/tags' : '/api/named_users/tags'
+  const uri = `${endpoint}${path}`
   const airship_payload = _build_tags_object(payload)
   return do_request(request, uri, airship_payload)
 }
@@ -234,6 +232,16 @@ export function map_endpoint(region: string) {
   }
 }
 
+function _build_audience(payload: { named_user_id?: string; channel_id?: string; channel_type?: string }): object {
+  if (payload.channel_id) {
+    return { [payload.channel_type ?? 'channel']: payload.channel_id }
+  }
+  if (payload.named_user_id) {
+    return { named_user_id: payload.named_user_id }
+  }
+  throw new PayloadValidationError('Either Named User ID or Channel ID must be provided')
+}
+
 function _build_custom_event_object(payload: CustomEventsPayload): object {
   /*
   This function takes a Track payload and builds a Custom Event payload.
@@ -249,9 +257,7 @@ function _build_custom_event_object(payload: CustomEventsPayload): object {
   }
   const airship_payload = {
     occurred: _validate_timestamp(payload.occurred),
-    user: {
-      named_user_id: payload.named_user_id
-    },
+    user: _build_audience(payload),
     body: {
       name: payload.name.toLowerCase(),
       interaction_type: 'cdp',
@@ -346,9 +352,7 @@ function _build_tags_object(payload: TagsPayload): object {
     }
   }
   const airship_payload: { audience: {}; add?: {}; remove?: {} } = { audience: {} }
-  airship_payload.audience = {
-    named_user_id: payload.named_user_id
-  }
+  airship_payload.audience = _build_audience(payload)
   if (tags_to_add.length > 0) {
     airship_payload.add = { [tag_group]: tags_to_add }
   }
@@ -428,6 +432,7 @@ function _extract_country_language(locale: string): string[] {
 }
 
 export const _private = {
+  _build_audience,
   _build_custom_event_object,
   _build_attributes_object,
   _build_attribute,


### PR DESCRIPTION
- Add channel_id + channel_type as optional audience selectors across customEvents, setAttributes, and manageTags; channel_type is optional and defaults to the generic channel key (Airship resolves the type server-side); also fixes endpoint routing so both selector types correctly use /api/channels/attributes and /api/channels/tags
- Support objects and arrays as attribute values in setAttributes; JSON attribute keys are automatically suffixed with #default as the instance ID when one isn't already supplied (Airship's required key format for JSON attributes)
- Customize User-Agent header to outgoing requests for attribution in Airship-side logging

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
