### PR TITLE
chore(ajv-human-errors): add package support metadata

### DIFF
--- a/packages/ajv-human-errors/package.json
+++ b/packages/ajv-human-errors/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/ajv-human-errors"
   },
+  "homepage": "https://github.com/segmentio/action-destinations/tree/main/packages/ajv-human-errors#readme",
+  "bugs": {
+    "url": "https://github.com/segmentio/action-destinations/issues"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@segment/ajv-human-errors`
- add standard npm `bugs.url` metadata pointing to the repository issue URL
- leave runtime code, dependencies, package versioning, exports, and entry points unchanged

## Verification
- metadata assertion for `homepage` and `bugs.url`
- `git diff --check`
- `yarn install --ignore-scripts --frozen-lockfile`
- `yarn workspace @segment/ajv-human-errors typecheck`
- `yarn workspace @segment/ajv-human-errors build`
- `yarn workspace @segment/ajv-human-errors test --runInBand`
- `npm pack --dry-run --ignore-scripts --json ./packages/ajv-human-errors`