### PR TITLE
fix: add homepage and bugs metadata to @segment/ajv-human-errors package.json

### DIFF
--- a/packages/ajv-human-errors/package.json
+++ b/packages/ajv-human-errors/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/ajv-human-errors"
   },
+  "homepage": "https://github.com/segmentio/action-destinations/tree/main/packages/ajv-human-errors#readme",
+  "bugs": {
+    "url": "https://github.com/segmentio/action-destinations/issues"
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Adds missing `homepage` and `bugs` fields to package.json so npm consumers can discover the package's README and issue tracker.

Fixes charles-openclaw/charles-microbounties#1634