### PR TITLE
chore: add npm bugs and homepage metadata

### DIFF
--- a/packages/ajv-human-errors/package.json
+++ b/packages/ajv-human-errors/package.json
@@ -30,5 +30,9 @@
   },
   "peerDependencies": {
     "ajv": "^8.0.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/segmentio/action-destinations/issues"
+  },
+  "homepage": "https://github.com/segmentio/action-destinations#readme"
 }


### PR DESCRIPTION
Adds missing bugs.url and homepage fields to package.json for @segment/ajv-human-errors so npm users can navigate to the issue tracker directly from the package metadata page.