### PR TITLE
Domain name changes from VWO-> Wingify

### DIFF
--- a/packages/destination-actions/src/destinations/vwo/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/__tests__/index.test.ts
@@ -5,11 +5,11 @@ import { generateUUIDFor } from '../utility'
 
 const testDestination = createTestIntegration(Destination)
 
-describe('VWO AccountID Validation', () => {
+describe('Wingify AccountID Validation', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
       const settings: Settings = {
-        vwoAccountId: 654331,
+        wingifyAccountId: 654331,
         region: 'US'
       }
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
@@ -17,7 +17,7 @@ describe('VWO AccountID Validation', () => {
 
     it('should throw error for invalid AccountId', async () => {
       const settings: Settings = {
-        vwoAccountId: 65431231,
+        wingifyAccountId: 65431231,
         region: 'US'
       }
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()

--- a/packages/destination-actions/src/destinations/vwo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vwo/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Settings {
   /**
-   * Enter your VWO Account ID
+   * Enter your Wingify Account ID
    */
-  vwoAccountId: number
+  wingifyAccountId: number
   /**
-   * VWO Fullstack SDK Key. It is mandatory when using the VWO Fullstack suite.
+   * Wingify Fullstack SDK Key. It is mandatory when using the Wingify Fullstack suite.
    */
   apikey?: string
   /**
-   * VWO Region to sync data to. Default is US
+   * Wingify Region to sync data to. Default is US
    */
   region?: string
 }

--- a/packages/destination-actions/src/destinations/vwo/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/identifyUser/__tests__/index.test.ts
@@ -5,32 +5,32 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const BASE_ENDPOINT = 'https://dev.visualwebsiteoptimizer.com'
-const VWO_ACCOUNT_ID = 654331
-const VWO_UUID = 'ABC123'
+const accountId = 654331
+const wingifyUuid = 'ABC123'
 const SDK_KEY = 'sample-api-key'
 const SANITISED_USERID = '57CC1A3D57215E67824E461010E43F53'
 
-describe('VWO.identifyUser Web', () => {
+describe('Wingify.identifyUser Web', () => {
   describe('Only required parameters', () => {
-    it('should send segment traits as VWO attributes', async () => {
+    it('should send segment traits as Wingify attributes', async () => {
       const event = createTestEvent({
         traits: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           textProperty: 'Hello'
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=vwo_syncVisitorProp&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=wingify_syncVisitorProp&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('identifyUser', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               $visitor: {
@@ -38,13 +38,13 @@ describe('VWO.identifyUser Web', () => {
                   'segment.textProperty': 'Hello'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud'
               },
               page,
               isCustomEvent: true
             },
-            name: 'vwo_syncVisitorProp'
+            name: 'wingify_syncVisitorProp'
           },
           visitor: {
             props: {
@@ -71,10 +71,10 @@ describe('VWO.identifyUser Web', () => {
   })
 
   describe('All parameters', () => {
-    it('should send segment traits as VWO attributes', async () => {
+    it('should send segment traits as Wingify attributes', async () => {
       const event = createTestEvent({
         traits: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           textProperty: 'Hello'
         },
         context: {
@@ -86,18 +86,18 @@ describe('VWO.identifyUser Web', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=vwo_syncVisitorProp&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=wingify_syncVisitorProp&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('identifyUser', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               $visitor: {
@@ -105,13 +105,13 @@ describe('VWO.identifyUser Web', () => {
                   'segment.textProperty': 'Hello'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud'
               },
               page,
               isCustomEvent: true
             },
-            name: 'vwo_syncVisitorProp'
+            name: 'wingify_syncVisitorProp'
           },
           visitor: {
             props: {
@@ -138,21 +138,21 @@ describe('VWO.identifyUser Web', () => {
   })
 })
 
-describe('VWO.identifyUser Fullstack', () => {
+describe('Wingify.identifyUser Fullstack', () => {
   describe('Only required parameters', () => {
-    it('should send segment traits as VWO attributes', async () => {
+    it('should send segment traits as Wingify attributes', async () => {
       const event = createTestEvent({
         traits: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           textProperty: 'Hello'
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=vwo_syncVisitorProp&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=wingify_syncVisitorProp&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('identifyUser', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -165,21 +165,21 @@ describe('VWO.identifyUser Fullstack', () => {
               $visitor: {
                 props: {
                   'segment.textProperty': 'Hello',
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud'
               },
               page,
               isCustomEvent: true
             },
-            name: 'vwo_syncVisitorProp'
+            name: 'wingify_syncVisitorProp'
           },
           visitor: {
             props: {
               'segment.textProperty': 'Hello',
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }
@@ -202,10 +202,10 @@ describe('VWO.identifyUser Fullstack', () => {
   })
 
   describe('All parameters', () => {
-    it('should send segment traits as VWO attributes', async () => {
+    it('should send segment traits as Wingify attributes', async () => {
       const event = createTestEvent({
         traits: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           textProperty: 'Hello'
         },
         context: {
@@ -217,12 +217,12 @@ describe('VWO.identifyUser Fullstack', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=vwo_syncVisitorProp&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=wingify_syncVisitorProp&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('identifyUser', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -235,21 +235,21 @@ describe('VWO.identifyUser Fullstack', () => {
               $visitor: {
                 props: {
                   'segment.textProperty': 'Hello',
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud'
               },
               page,
               isCustomEvent: true
             },
-            name: 'vwo_syncVisitorProp'
+            name: 'wingify_syncVisitorProp'
           },
           visitor: {
             props: {
               'segment.textProperty': 'Hello',
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }

--- a/packages/destination-actions/src/destinations/vwo/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vwo/identifyUser/generated-types.ts
@@ -8,9 +8,9 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * VWO UUID
+   * Wingify UUID
    */
-  vwoUuid: string
+  wingifyUuid: string
   /**
    * Contains context information regarding a webpage
    */

--- a/packages/destination-actions/src/destinations/vwo/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/identifyUser/index.ts
@@ -5,7 +5,7 @@ import {formatPayload, formatAttributes, hosts} from '../utility'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Identify User',
-  description: "Maps Segment's visitor traits to the visitor attributes in VWO",
+  description: "Maps Segment's visitor traits to the visitor attributes in Wingify",
   defaultSubscription: 'type = "identify"',
   fields: {
     attributes: {
@@ -17,13 +17,13 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.traits'
       }
     },
-    vwoUuid: {
-      description: 'VWO UUID',
-      label: 'VWO UUID',
+    wingifyUuid: {
+      description: 'Wingify UUID',
+      label: 'Wingify UUID',
       required: true,
       type: 'string',
       default: {
-        '@path': '$.traits.vwo_uuid'
+        '@path': '$.traits.wingify_uuid'
       }
     },
     page: {
@@ -64,9 +64,9 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, { settings, payload }) => {
-    const eventName = 'vwo_syncVisitorProp'
+    const eventName = 'wingify_syncVisitorProp'
     const attributes = payload.attributes
-    delete attributes['vwo_uuid']
+    delete attributes['wingify_uuid']
     const formattedAttributes = formatAttributes(attributes)
     const visitor = { props: formattedAttributes }
     const { headers, structuredPayload } = formatPayload(
@@ -75,7 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
       true,
       false,
       settings.apikey,
-      settings.vwoAccountId
+      settings.wingifyAccountId
     )
     if (structuredPayload.d.visitor && structuredPayload.d.event.props.$visitor) {
       structuredPayload.d.visitor.props = {
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
     }
     const region = settings.region || "US"
     const host = hosts[region]
-    const endpoint = `${host}/events/t?en=${eventName}&a=${settings.vwoAccountId}`
+    const endpoint = `${host}/events/t?en=${eventName}&a=${settings.wingifyAccountId}`
     return request(endpoint, {
       method: 'POST',
       json: structuredPayload,

--- a/packages/destination-actions/src/destinations/vwo/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/index.ts
@@ -8,8 +8,8 @@ import identifyUser from './identifyUser'
 import syncAudience from './syncAudience'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'VWO Cloud Mode (Actions)',
-  slug: 'actions-vwo-cloud',
+  name: 'Wingify Cloud Mode (Actions)',
+  slug: 'actions-wingify-cloud',
   mode: 'cloud',
   presets: [
     {
@@ -45,20 +45,20 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'custom',
     fields: {
       vwoAccountId: {
-        label: 'Your VWO account ID',
-        description: 'Enter your VWO Account ID',
+        label: 'Your Wingify account ID',
+        description: 'Enter your Wingify Account ID',
         type: 'number',
         required: true
       },
       apikey: {
-        label: 'VWO SDK Key',
-        description: 'VWO Fullstack SDK Key. It is mandatory when using the VWO Fullstack suite.',
+        label: 'Wingify SDK Key',
+        description: 'Wingify Fullstack SDK Key. It is mandatory when using the Wingify Fullstack suite.',
         type: 'password',
         required: false
       },
       region: {
         label: 'Region',
-        description: 'VWO Region to sync data to. Default is US',
+        description: 'Wingify Region to sync data to. Default is US',
         type: 'string',
         choices: [
           { label: 'US', value: 'US' },
@@ -69,7 +69,7 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (_request, { settings }) => {
-      if (settings.vwoAccountId < 1 || settings.vwoAccountId.toString().length > 7) {
+      if (settings.wingifyAccountId < 1 || settings.wingifyAccountId.toString().length > 7) {
         throw new Error('Invalid AccountID. Please check your AccountID')
       } else {
         return true

--- a/packages/destination-actions/src/destinations/vwo/pageVisit/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/pageVisit/__tests__/index.test.ts
@@ -5,38 +5,38 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const BASE_ENDPOINT = 'https://dev.visualwebsiteoptimizer.com'
-const VWO_ACCOUNT_ID = 654331
-const VWO_UUID = 'ABC123'
+const accountId = 654331
+const wingifyUuid = 'ABC123'
 const EVENT_NAME = 'segment.pageView'
 const SDK_KEY = 'sample-api-key'
 const SANITISED_USERID = '57CC1A3D57215E67824E461010E43F53'
 
-describe('VWO.pageVisit Web', () => {
+describe('Wingify.pageVisit Web', () => {
   describe('Only required parameters', () => {
-    it('should send Page Visit event to VWO', async () => {
+    it('should send Page Visit event to Wingify', async () => {
       const event = createTestEvent({
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('pageVisit', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               url: page?.url,
               page,
               isCustomEvent: false,
-              vwoMeta: {
+              wingifyMeta: {
                 metric: {}
               }
             },
@@ -62,10 +62,10 @@ describe('VWO.pageVisit Web', () => {
   })
 
   describe('All Parameters', () => {
-    it('should send Page Visit event to VWO', async () => {
+    it('should send Page Visit event to Wingify', async () => {
       const event = createTestEvent({
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         },
         context: {
           page: {
@@ -76,24 +76,24 @@ describe('VWO.pageVisit Web', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('pageVisit', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               url: 'www.abc.com',
               page,
               isCustomEvent: false,
-              vwoMeta: {
+              wingifyMeta: {
                 metric: {}
               }
             },
@@ -119,20 +119,20 @@ describe('VWO.pageVisit Web', () => {
   })
 })
 
-describe('VWO.pageVisit Fullstack', () => {
+describe('Wingify.pageVisit Fullstack', () => {
   describe('Only required parameters', () => {
-    it('should send Page Visit event to VWO', async () => {
+    it('should send Page Visit event to Wingify', async () => {
       const event = createTestEvent({
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('pageVisit', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -147,10 +147,10 @@ describe('VWO.pageVisit Fullstack', () => {
               isCustomEvent: false,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 metric: {}
               }
             },
@@ -158,7 +158,7 @@ describe('VWO.pageVisit Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }
@@ -181,10 +181,10 @@ describe('VWO.pageVisit Fullstack', () => {
   })
 
   describe('All parameters', () => {
-    it('should send Page Visit event to VWO', async () => {
+    it('should send Page Visit event to Wingify', async () => {
       const event = createTestEvent({
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         },
         context: {
           page: {
@@ -195,12 +195,12 @@ describe('VWO.pageVisit Fullstack', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=${EVENT_NAME}&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('pageVisit', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -215,10 +215,10 @@ describe('VWO.pageVisit Fullstack', () => {
               isCustomEvent: false,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 metric: {}
               }
             },
@@ -226,7 +226,7 @@ describe('VWO.pageVisit Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }

--- a/packages/destination-actions/src/destinations/vwo/pageVisit/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vwo/pageVisit/generated-types.ts
@@ -6,9 +6,9 @@ export interface Payload {
    */
   url?: string
   /**
-   * VWO UUID
+   * Wingify UUID
    */
-  vwoUuid: string
+  wingifyUuid: string
   /**
    * Contains context information regarding a webpage
    */

--- a/packages/destination-actions/src/destinations/vwo/pageVisit/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/pageVisit/index.ts
@@ -5,7 +5,7 @@ import { formatPayload, hosts, sanitiseEventName } from '../utility'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page Visit',
-  description: `Sends Segment's page event to VWO`,
+  description: `Sends Segment's page event to Wingify`,
   fields: {
     url: {
       description: 'URL of the webpage',
@@ -16,13 +16,13 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.page.url'
       }
     },
-    vwoUuid: {
-      description: 'VWO UUID',
-      label: 'VWO UUID',
+    wingifyUuid: {
+      description: 'Wingify UUID',
+      label: 'Wingify UUID',
       required: true,
       type: 'string',
       default: {
-        '@path': '$.properties.vwo_uuid'
+        '@path': '$.properties.wingify_uuid'
       }
     },
     page: {
@@ -71,12 +71,12 @@ const action: ActionDefinition<Settings, Payload> = {
       false,
       false,
       settings.apikey,
-      settings.vwoAccountId
+      settings.wingifyAccountId
     )
     structuredPayload.d.event.props['url'] = payload.url
     const region = settings.region || 'US'
     const host = hosts[region]
-    const endpoint = `${host}/events/t?en=${eventName}&a=${settings.vwoAccountId}`
+    const endpoint = `${host}/events/t?en=${eventName}&a=${settings.wingifyAccountId}`
     return request(endpoint, {
       method: 'POST',
       json: structuredPayload,

--- a/packages/destination-actions/src/destinations/vwo/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/syncAudience/__tests__/index.test.ts
@@ -5,9 +5,9 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const BASE_ENDPOINT = 'https://dev.visualwebsiteoptimizer.com'
-const VWO_ACCOUNT_ID = 654331
+const accountId = 654331
 
-describe('VWO.syncAudience', () => {
+describe('Wingify.syncAudience', () => {
   it('should send the add audience call', async () => {
     const event = createTestEvent({
       event: 'Audience Entered',
@@ -16,19 +16,19 @@ describe('VWO.syncAudience', () => {
         audience_key: 'test_audience'
       }
     })
-    nock(BASE_ENDPOINT).post(`/events/t?en=vwo_integration&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+    nock(BASE_ENDPOINT).post(`/events/t?en=wingify_integration&a=${accountId}`).reply(200, {})
     const responses = await testDestination.testAction('syncAudience', {
       event,
       useDefaultMappings: true,
       settings: {
-        vwoAccountId: VWO_ACCOUNT_ID,
+        wingifyAccountId: accountId,
         apikey: ''
       }
     })
     const expectedRequest = {
       d: {
         event: {
-          name: 'vwo_integration',
+          name: 'wingify_integration',
           props: {
             action: 'audience_entered',
             audienceName: 'test_audience',
@@ -53,19 +53,19 @@ describe('VWO.syncAudience', () => {
         audience_key: 'test_audience'
       }
     })
-    nock(BASE_ENDPOINT).post(`/events/t?en=vwo_integration&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+    nock(BASE_ENDPOINT).post(`/events/t?en=wingify_integration&a=${accountId}`).reply(200, {})
     const responses = await testDestination.testAction('syncAudience', {
       event,
       useDefaultMappings: true,
       settings: {
-        vwoAccountId: VWO_ACCOUNT_ID,
+        wingifyAccountId: accountId,
         apikey: ''
       }
     })
     const expectedRequest = {
       d: {
         event: {
-          name: 'vwo_integration',
+          name: 'wingify_integration',
           props: {
             action: 'audience_entered',
             audienceName: 'test_audience',
@@ -89,19 +89,19 @@ describe('VWO.syncAudience', () => {
         audience_key: 'test_audience'
       }
     })
-    nock(BASE_ENDPOINT).post(`/events/t?en=vwo_integration&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+    nock(BASE_ENDPOINT).post(`/events/t?en=wingify_integration&a=${accountId}`).reply(200, {})
     const responses = await testDestination.testAction('syncAudience', {
       event,
       useDefaultMappings: true,
       settings: {
-        vwoAccountId: VWO_ACCOUNT_ID,
+        wingifyAccountId: accountId,
         apikey: ''
       }
     })
     const expectedRequest = {
       d: {
         event: {
-          name: 'vwo_integration',
+          name: 'wingify_integration',
           props: {
             action: 'audience_exited',
             audienceName: 'test_audience',

--- a/packages/destination-actions/src/destinations/vwo/syncAudience/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/syncAudience/index.ts
@@ -5,7 +5,7 @@ import {hosts} from "../utility";
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sync Audience',
-  description: 'Syncs Segment audiences to VWO',
+  description: 'Syncs Segment audiences to Wingify',
   defaultSubscription: 'event = "Audience Entered" or event = "Audience Exited"',
   fields: {
     name: {
@@ -52,17 +52,17 @@ const action: ActionDefinition<Settings, Payload> = {
     } else if (payload.name == 'Audience Exited') {
       action = 'audience_exited'
     }
-    const vwoPayload = {
+    const wingifyPayload = {
       d: {
         event: {
-          name: 'vwo_integration',
+          name: 'wingify_integration',
           time,
           props: {
             action,
             audienceName: payload.audienceId,
             audienceId: payload.audienceId,
             identifier: payload.userId || payload.anonymousId,
-            accountId: settings.vwoAccountId,
+            accountId: settings.wingifyAccountId,
             integration: 'segment'
           }
         }
@@ -70,11 +70,11 @@ const action: ActionDefinition<Settings, Payload> = {
     }
     const region = settings.region || "US"
     const host = hosts[region]
-    const endpoint = `${host}/events/t?en=vwo_integration&a=${settings.vwoAccountId}`
+    const endpoint = `${host}/events/t?en=wingify_integration&a=${settings.wingifyAccountId}`
 
     return request(endpoint, {
       method: 'POST',
-      json: vwoPayload
+      json: wingifyPayload
     })
   }
 }

--- a/packages/destination-actions/src/destinations/vwo/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vwo/trackEvent/__tests__/index.test.ts
@@ -5,38 +5,38 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const BASE_ENDPOINT = 'https://dev.visualwebsiteoptimizer.com'
-const VWO_ACCOUNT_ID = 654331
-const VWO_UUID = 'ABC123'
+const accountId = 654331
+const wingifyUuid = 'ABC123'
 const SDK_KEY = 'sample-api-key'
 const SANITISED_USERID = '57CC1A3D57215E67824E461010E43F53'
 
-describe('VWO.trackEvent Web', () => {
+describe('Wingify.trackEvent Web', () => {
   describe('Only required parameters', () => {
-    it('should send send event call to VWO', async () => {
+    it('should send send event call to Wingify', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: ''
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               page,
               isCustomEvent: true,
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -62,28 +62,28 @@ describe('VWO.trackEvent Web', () => {
       `)
     })
 
-    it('should send segment properties as VWO properties', async () => {
+    it('should send segment properties as Wingify properties', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           amount: 100,
           currency: 'INR',
           outbound: true
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               amount: 100,
@@ -91,7 +91,7 @@ describe('VWO.trackEvent Web', () => {
               outbound: true,
               page,
               isCustomEvent: true,
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -107,11 +107,11 @@ describe('VWO.trackEvent Web', () => {
   })
 
   describe('All parameters', () => {
-    it('should send send event call to VWO', async () => {
+    it('should send send event call to Wingify', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         },
         context: {
           page: {
@@ -122,24 +122,24 @@ describe('VWO.trackEvent Web', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: ''
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               page,
               isCustomEvent: true,
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -165,11 +165,11 @@ describe('VWO.trackEvent Web', () => {
       `)
     })
 
-    it('should send segment properties as VWO properties', async () => {
+    it('should send segment properties as Wingify properties', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           amount: 100,
           currency: 'INR',
           outbound: true
@@ -183,18 +183,18 @@ describe('VWO.trackEvent Web', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID
+          wingifyAccountId: accountId
         }
       })
       const page = event.context?.page
       const expectedRequest = {
         d: {
-          visId: VWO_UUID,
+          visId: wingifyUuid,
           event: {
             props: {
               amount: 100,
@@ -202,7 +202,7 @@ describe('VWO.trackEvent Web', () => {
               outbound: true,
               page,
               isCustomEvent: true,
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -218,21 +218,21 @@ describe('VWO.trackEvent Web', () => {
   })
 })
 
-describe('VWO.trackEvent Fullstack', () => {
+describe('Wingify.trackEvent Fullstack', () => {
   describe('Only required parameters', () => {
-    it('should send send event call to VWO', async () => {
+    it('should send send event call to Wingify', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -246,10 +246,10 @@ describe('VWO.trackEvent Fullstack', () => {
               isCustomEvent: true,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -259,7 +259,7 @@ describe('VWO.trackEvent Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }
@@ -280,22 +280,22 @@ describe('VWO.trackEvent Fullstack', () => {
       `)
     })
 
-    it('should send segment properties as VWO properties', async () => {
+    it('should send segment properties as Wingify properties', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           amount: 100,
           currency: 'INR',
           outbound: true
         }
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -312,10 +312,10 @@ describe('VWO.trackEvent Fullstack', () => {
               isCustomEvent: true,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -325,7 +325,7 @@ describe('VWO.trackEvent Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }
@@ -336,11 +336,11 @@ describe('VWO.trackEvent Fullstack', () => {
   })
 
   describe('All Parameters', () => {
-    it('should send send event call to VWO', async () => {
+    it('should send send event call to Wingify', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID
+          wingifyUuid: wingifyUuid
         },
         context: {
           page: {
@@ -351,12 +351,12 @@ describe('VWO.trackEvent Fullstack', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -370,10 +370,10 @@ describe('VWO.trackEvent Fullstack', () => {
               isCustomEvent: true,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -383,7 +383,7 @@ describe('VWO.trackEvent Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }
@@ -404,11 +404,11 @@ describe('VWO.trackEvent Fullstack', () => {
       `)
     })
 
-    it('should send segment properties as VWO properties', async () => {
+    it('should send segment properties as Wingify properties', async () => {
       const event = createTestEvent({
         event: 'testEvent',
         properties: {
-          vwo_uuid: VWO_UUID,
+          wingifyUuid: wingifyUuid,
           amount: 100,
           currency: 'INR',
           outbound: true
@@ -422,12 +422,12 @@ describe('VWO.trackEvent Fullstack', () => {
         },
         timestamp: '2023-05-09T13:12:44.924Z'
       })
-      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${VWO_ACCOUNT_ID}`).reply(200, {})
+      nock(BASE_ENDPOINT).post(`/events/t?en=segment.testEvent&a=${accountId}`).reply(200, {})
       const responses = await testDestination.testAction('trackEvent', {
         event,
         useDefaultMappings: true,
         settings: {
-          vwoAccountId: VWO_ACCOUNT_ID,
+          wingifyAccountId: accountId,
           apikey: SDK_KEY
         }
       })
@@ -444,10 +444,10 @@ describe('VWO.trackEvent Fullstack', () => {
               isCustomEvent: true,
               $visitor: {
                 props: {
-                  vwo_fs_environment: 'sample-api-key'
+                  wingify_fs_environment: 'sample-api-key'
                 }
               },
-              vwoMeta: {
+              wingifyMeta: {
                 source: 'segment.cloud',
                 ogName: 'testEvent',
                 metric: {}
@@ -457,7 +457,7 @@ describe('VWO.trackEvent Fullstack', () => {
           },
           visitor: {
             props: {
-              vwo_fs_environment: 'sample-api-key'
+              wingify_fs_environment: 'sample-api-key'
             }
           }
         }

--- a/packages/destination-actions/src/destinations/vwo/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vwo/trackEvent/generated-types.ts
@@ -12,9 +12,9 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * VWO UUID
+   * Wingify UUID
    */
-  vwoUuid: string
+  wingifyUuid: string
   /**
    * Contains context information regarding a webpage
    */

--- a/packages/destination-actions/src/destinations/vwo/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/vwo/trackEvent/index.ts
@@ -5,7 +5,7 @@ import { formatPayload, sanitiseEventName, hosts } from '../utility'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
-  description: `Sends Segment's track event to VWO`,
+  description: `Sends Segment's track event to Wingify`,
   defaultSubscription: 'type = "track"',
   fields: {
     name: {
@@ -26,13 +26,13 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.properties'
       }
     },
-    vwoUuid: {
-      description: 'VWO UUID',
-      label: 'VWO UUID',
+    wingifyUuid: {
+      description: 'Wingify UUID',
+      label: 'Wingify UUID',
       required: true,
       type: 'string',
       default: {
-        '@path': '$.properties.vwo_uuid'
+        '@path': '$.properties.wingify_uuid'
       }
     },
     page: {
@@ -80,12 +80,12 @@ const action: ActionDefinition<Settings, Payload> = {
       true,
       true,
       settings.apikey,
-      settings.vwoAccountId
+      settings.wingifyAccountId
     )
-    structuredPayload.d.event.props.vwoMeta['ogName'] = payload.name
+    structuredPayload.d.event.props.wingifyMeta['ogName'] = payload.name
     const region = settings.region || "US"
     const host = hosts[region]
-    const endpoint = `${host}/events/t?en=${sanitisedEventName}&a=${settings.vwoAccountId}`
+    const endpoint = `${host}/events/t?en=${sanitisedEventName}&a=${settings.wingifyAccountId}`
     return request(endpoint, {
       method: 'POST',
       headers,

--- a/packages/destination-actions/src/destinations/vwo/types.ts
+++ b/packages/destination-actions/src/destinations/vwo/types.ts
@@ -1,10 +1,10 @@
-export type vwoPayload = {
+export type wingifyPayload = {
   d: {
     msgId: string
     visId: string
     event: {
       props: {
-        vwo_og_event?: string
+        wingify_og_event?: string
         $visitor?: {
           props: {
             [k: string]: unknown
@@ -15,7 +15,7 @@ export type vwoPayload = {
         }
         [k: string]: unknown
         isCustomEvent?: boolean
-        vwoMeta: {
+        wingifyMeta: {
           source: string
           ogName?: string
           [k: string]: unknown
@@ -40,7 +40,7 @@ export type commonPayload = {
   attributes?: {
     [k: string]: unknown
   }
-  vwoUuid: string
+  wingifyUuid: string
   page?: {
     [k: string]: unknown
   }

--- a/packages/destination-actions/src/destinations/vwo/utility.ts
+++ b/packages/destination-actions/src/destinations/vwo/utility.ts
@@ -1,12 +1,12 @@
-import type { commonPayload, vwoPayload } from './types'
+import type { commonPayload, wingifyPayload } from './types'
 import * as crypto from 'crypto'
 
-const VWO_NAMESPACE = '11e13cd7-6c48-53ec-8679-7e9c752273c5'
+const namespace = '11e13cd7-6c48-53ec-8679-7e9c752273c5'
 
 export const hosts: { [key: string]: string } = {
-  US: 'https://dev.visualwebsiteoptimizer.com',
-  EU: 'https://dev.visualwebsiteoptimizer.com/eu01',
-  AS: 'https://dev.visualwebsiteoptimizer.com/as01'
+  US: 'https://eadge.wingify.com',
+  EU: 'https://eadge.wingify.com/eu01',
+  AS: 'https://eadge.wingify.com/as01'
 }
 
 function uuidv5(name: string, namespace: string): string {
@@ -43,10 +43,10 @@ export function formatPayload(
   accountId = 0
 ) {
   let formattedProperties: { [k: string]: unknown } = {}
-  const vwoUuid = apiKey.trim().length ? generateUUIDFor(payload.vwoUuid, accountId) : payload.vwoUuid
+  const wingifyUuid = apiKey.trim().length ? generateUUIDFor(payload.wingifyUuid, accountId) : payload.wingifyUuid
   if (isTrack) {
     formattedProperties = { ...payload.properties }
-    delete formattedProperties['vwo_uuid']
+    delete formattedProperties['wingify_uuid']
   }
   const epochTime = new Date().valueOf()
   const time = Math.floor(epochTime)
@@ -57,16 +57,16 @@ export function formatPayload(
         referrerUrl: payload.page['referrer']
       }
     : {}
-  const structuredPayload: vwoPayload = {
+  const structuredPayload: wingifyPayload = {
     d: {
-      msgId: `${vwoUuid}-${sessionId}`,
-      visId: vwoUuid,
+      msgId: `${wingifyUuid}-${sessionId}`,
+      visId: wingifyUuid,
       event: {
         props: {
           ...formattedProperties,
           page,
           isCustomEvent,
-          vwoMeta: {
+          wingifyMeta: {
             source: 'segment.cloud',
             metric: {}
           }
@@ -86,7 +86,7 @@ export function formatPayload(
   if (apiKey.trim().length) {
     const visitorObj = {
       props: {
-        vwo_fs_environment: apiKey
+        wingify_fs_environment: apiKey
       }
     }
     structuredPayload.d.event.props.$visitor = visitorObj
@@ -114,7 +114,7 @@ export function formatAttributes(attributes: { [k: string]: unknown } | undefine
 export function generateUUIDFor(userId: string | number, accountId: number) {
   userId = `${userId}` // type-cast
   const hash = `${accountId}`
-  const userIdNamespace = generate(hash, VWO_NAMESPACE)
+  const userIdNamespace = generate(hash, namespace)
   const uuidForUserIdAccountId = generate(userId, userIdNamespace)
   const desiredUuid = uuidForUserIdAccountId.replace(/-/gi, '').toUpperCase()
   return desiredUuid


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updates the VWO cloud-mode destination to use Wingify’s new API endpoints and naming conventions as part of Wingify’s domain migration.

Wingify is migrating its event ingestion infrastructure to the wingify.com domain and aligning API field/event naming with the Wingify brand. This keeps the Segment destination in sync with those backend changes so events continue to be delivered correctly.
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
