### PR TITLE
refactor: remove @segment/action-emitters dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -84,7 +84,6 @@
   },
   "dependencies": {
     "@lukeed/uuid": "^2.0.0",
-    "@segment/action-emitters": "^1.3.6",
     "@segment/ajv-human-errors": "^2.16.0",
     "@segment/destination-subscriptions": "^3.37.0",
     "@types/node": "^22.13.1",

--- a/packages/core/src/destination-kit/event-emitter-types.ts
+++ b/packages/core/src/destination-kit/event-emitter-types.ts
@@ -1,0 +1,9 @@
+export type EventEmitterSlug =
+  | 'warehouse_entity_added_track'
+  | 'warehouse_entity_removed_track'
+  | 'warehouse_audience_entered_track'
+  | 'warehouse_audience_exited_track'
+  | 'warehouse_audience_membership_changed_identify'
+  | 'warehouse_entity_values_changed_track'
+  | 'warehouse_all_events_track'
+  | 'journeys_step_entered_track'

--- a/packages/core/src/destination-kit/index.ts
+++ b/packages/core/src/destination-kit/index.ts
@@ -1,5 +1,5 @@
 import { validate, parseFql, ErrorCondition } from '@segment/destination-subscriptions'
-import { EventEmitterSlug } from '@segment/action-emitters'
+import { EventEmitterSlug } from './event-emitter-types'
 import type { JSONSchema4 } from 'json-schema'
 import {
   Action,


### PR DESCRIPTION
## Summary
- Removes the `@segment/action-emitters` package dependency from `@segment/actions-core`
- Hardcodes the `EventEmitterSlug` type locally in `packages/core/src/destination-kit/event-emitter-types.ts`

## Test plan
- [x] Typecheck passes (`yarn typecheck` in core)
- [x] All destination-kit tests pass (56/56)
- [x] Local `yarn install` passes
- [x] Local `yarn build` passes
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)