### PR TITLE
feat: add Vibe (Actions) destination with Track Conversion Event

### DIFF
--- a/.claude/commands/generate-destination.md
+++ b/.claude/commands/generate-destination.md
@@ -12,11 +12,14 @@ You are a Segment Actions Destination code generator. Given a destination name a
 ## Reference
 
 **You MUST read existing destinations in `packages/destination-actions/src/destinations/` before generating code.** Browse 2-3 similar destinations to understand the current patterns for:
+
 - Root `index.ts` (DestinationDefinition) structure
 - Action `index.ts` (ActionDefinition) structure
 - `generated-types.ts` files
-- `__tests__/index.test.ts` patterns
+- `__tests__/index.test.ts` and `__tests__/snapshot.test.ts` patterns
 - How `extendRequest`, `authentication`, `presets`, and `actions` are wired up
+- **File organization**: hand-written `types.ts`, `constants.ts`, and `utils.ts` at the destination root (e.g. `braze/`, `klaviyo/`, `amazon-amc/`)
+- **Batching**: `performBatch` + `enable_batching` / `batch_size` / `batch_keys` field definitions (e.g. `klaviyo/removeProfileFromList/`, `klaviyo/properties.ts`)
 
 Use the actual repo code as your template — not hardcoded templates.
 
@@ -50,29 +53,55 @@ The destination goes in `packages/destination-actions/src/destinations/<destinat
 ```
 <destination-slug>/
 ├── index.ts                          # Main DestinationDefinition
-├── generated-types.ts                # Settings interface
+├── generated-types.ts                # Settings interface (auto-generated)
+├── constants.ts                      # Base URL, endpoint paths, enums, defaults
+├── types.ts                          # Hand-written request/response interfaces
+├── utils.ts                          # Send-event logic, transforms, batch builders
 ├── <action-kebab-case>/              # One folder per action
-│   ├── index.ts                      # ActionDefinition
-│   ├── generated-types.ts            # Payload interface
+│   ├── index.ts                      # ActionDefinition (perform + performBatch)
+│   ├── generated-types.ts            # Payload interface (auto-generated)
 │   └── __tests__/
 │       └── index.test.ts
 └── __tests__/
-    └── index.test.ts                 # Destination-level tests
+    ├── index.test.ts                 # Destination-level tests
+    └── snapshot.test.ts              # Snapshot tests (all actions, required + all fields)
 ```
+
+> **File-organization rule (do NOT inline everything into the action `index.ts`):**
+>
+> - `constants.ts` — the API base URL, endpoint path constants, and any fixed enums (e.g. allowed action values). Import these into the action instead of hardcoding string literals inline.
+> - `types.ts` — explicit TypeScript interfaces for **every request body and API response object** the destination sends or receives. Never send an untyped inline object or read an `any` response.
+> - `utils.ts` — the actual "send event" logic and payload transforms (single + batch). The action `index.ts` `perform`/`performBatch` should be thin wrappers that build the typed payload and delegate to a `utils.ts` function.
+>
+> For a genuinely trivial single-action destination you may keep `constants.ts`/`types.ts`/`utils.ts` minimal, but they should still exist and hold the endpoint constant, the request/response types, and the send logic respectively — do not collapse them back into the action file.
 
 ### Step 5: Generate Files
 
 Generate in this order:
-1. `generated-types.ts` (root Settings)
-2. `index.ts` (root DestinationDefinition)
-3. For each action: `generated-types.ts`, `index.ts`, `__tests__/index.test.ts`
-4. `__tests__/index.test.ts` (root)
+
+1. `constants.ts` (base URL, endpoint paths, enums, defaults)
+2. `types.ts` (request body + API response interfaces)
+3. `utils.ts` (send-event logic, transforms, batch payload builders — imports from `constants.ts`/`types.ts`)
+4. `generated-types.ts` (root Settings)
+5. `index.ts` (root DestinationDefinition)
+6. For each action: `generated-types.ts`, `index.ts` (thin `perform`/`performBatch` delegating to `utils.ts`), `__tests__/index.test.ts`
+7. `__tests__/index.test.ts` (root)
+8. `__tests__/snapshot.test.ts` (root) — see Snapshot Tests section
 
 Follow the patterns from the destinations you read in Step 1.
 
-### Step 6: Register the Destination
+### Step 6: Do NOT register a destination ID
 
-Add the new destination to `packages/destination-actions/src/index.ts`.
+**Do NOT add a `register('<id>', './<slug>')` line to `packages/destination-actions/src/destinations/index.ts`.**
+
+The metadata ID is a real MongoDB ObjectId assigned when the destination is created in Segment's production control plane, and IDs must match across environments (synced via `sprout`). Inventing a placeholder ID and committing it to the registry is incorrect — it pollutes the shared registry with a fake ID and can collide or break staging sync.
+
+Instead:
+
+- Leave `destinations/index.ts` untouched.
+- In the post-output summary and the PR description, add a clearly-marked **TODO**: "Register this destination in `destinations/index.ts` with the production-assigned metadata ID before merging" and explain that the ID comes from creating the destination in production.
+
+If the user explicitly says they already have a production metadata ID, register with that real ID — never a generated/random one.
 
 ### Step 7: Generate Types
 
@@ -80,7 +109,13 @@ Run `yarn types --path packages/destination-actions/src/destinations/<destinatio
 
 ### Step 8: Validate
 
-Run tests: `yarn cloud jest --testPathPattern="<destination-slug>"`
+Run tests. Note the repo has a Jest version quirk: the `yarn cloud jest` wrapper may resolve to an incompatible root Jest. If you hit a `Cannot read properties of undefined (reading 'bind')` error, run the package-local binary directly instead:
+
+```bash
+cd packages/destination-actions && TZ=UTC ./node_modules/.bin/jest --testPathPattern="<destination-slug>"
+```
+
+Run both the unit tests and the snapshot tests. On first snapshot run, snapshots are written; review the generated `__snapshots__/` output to confirm the request bodies look correct, then commit them.
 
 Print file listing and summary table of all actions with event types, endpoints, field counts.
 
@@ -88,52 +123,216 @@ Print file listing and summary table of all actions with event types, endpoints,
 
 ### Authentication
 
-| Spec Auth Type | Code Pattern |
-|---|---|
-| OAuth 2.0 | `scheme: 'oauth2'` with `refreshAccessToken` |
-| API Key | `scheme: 'custom'` with key in `fields` |
-| Basic Auth | `scheme: 'basic'` with username/password |
+| Spec Auth Type | Code Pattern                                 |
+| -------------- | -------------------------------------------- |
+| OAuth 2.0      | `scheme: 'oauth2'` with `refreshAccessToken` |
+| API Key        | `scheme: 'custom'` with key in `fields`      |
+| Basic Auth     | `scheme: 'basic'` with username/password     |
 
 ### Event Types
 
-| Spec Event | `defaultSubscription` |
-|---|---|
-| identify | `'type = "identify"'` |
-| track | `'type = "track"'` |
-| track + identify | `'type = "track" or type = "identify"'` |
+| Spec Event             | `defaultSubscription`                       |
+| ---------------------- | ------------------------------------------- |
+| identify               | `'type = "identify"'`                       |
+| track                  | `'type = "track"'`                          |
+| track + identify       | `'type = "track" or type = "identify"'`     |
 | track (specific event) | `'type = "track" and event = "Event Name"'` |
 
 ### Field Types
 
-| Spec Type | Actions Field Type |
-|---|---|
-| String / Email / Phone / URL / Select | `type: 'string'` |
-| Number / Integer | `type: 'number'` |
-| Boolean | `type: 'boolean'` |
-| Date / DateTime | `type: 'datetime'` |
-| Object / JSON | `type: 'object'` |
-| Array of objects | `type: 'object'` with `multiple: true` |
+| Spec Type                             | Actions Field Type                     |
+| ------------------------------------- | -------------------------------------- |
+| String / Email / Phone / URL / Select | `type: 'string'`                       |
+| Number / Integer                      | `type: 'number'`                       |
+| Boolean                               | `type: 'boolean'`                      |
+| Date / DateTime                       | `type: 'datetime'`                     |
+| Object / JSON                         | `type: 'object'`                       |
+| Array of objects                      | `type: 'object'` with `multiple: true` |
 
 ### Default Paths
 
-| Segment Field | `@path` Expression |
-|---|---|
-| traits.* | `'$.traits.<field>'` |
-| properties.* | `'$.properties.<field>'` |
-| userId | `'$.userId'` |
-| anonymousId | `'$.anonymousId'` |
-| event | `'$.event'` |
-| timestamp | `'$.timestamp'` |
+| Segment Field | `@path` Expression       |
+| ------------- | ------------------------ |
+| traits.\*     | `'$.traits.<field>'`     |
+| properties.\* | `'$.properties.<field>'` |
+| userId        | `'$.userId'`             |
+| anonymousId   | `'$.anonymousId'`        |
+| event         | `'$.event'`              |
+| timestamp     | `'$.timestamp'`          |
 
 ### Action Pattern Detection
 
-| Spec Pattern | Code Pattern |
-|---|---|
-| "upsert" | Query API then create/update |
-| "batch" / "bulk" | `performBatch` with chunking |
-| "hash" / "SHA-256" | `crypto.createHash('sha256')` helper |
-| "archive" / "delete" | PATCH with `{archived: true}` or DELETE |
-| "create if not found" | try/catch with 404 fallback to POST |
+| Spec Pattern             | Code Pattern                                                       |
+| ------------------------ | ------------------------------------------------------------------ |
+| "upsert"                 | Query API then create/update                                       |
+| Any event-sending action | Implement BOTH `perform` and `performBatch` (see Batching section) |
+| "hash" / "SHA-256"       | `crypto.createHash('sha256')` helper                               |
+| "archive" / "delete"     | PATCH with `{archived: true}` or DELETE                            |
+| "create if not found"    | try/catch with 404 fallback to POST                                |
+
+## Batching (REQUIRED for event-sending actions)
+
+Every action that sends events/records to an API MUST implement batching unless the API genuinely has no way to accept more than one record per call (rare — confirm before skipping, and note it in the PR if you do).
+
+**Note:** Segment's platform does the actual chunking before calling `performBatch` — you do NOT implement chunking logic. You implement the field declarations and a `performBatch` handler that sends an array.
+
+**Field declarations** (add to the action's `fields`, mirroring `klaviyo/properties.ts`):
+
+```typescript
+enable_batching: {
+  type: 'boolean',
+  label: 'Batch Data',
+  description: 'When enabled, sends events to the API in batches.',
+  default: true
+},
+batch_size: {
+  label: 'Batch Size',
+  description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+  type: 'number',
+  required: false,
+  unsafe_hidden: true,
+  default: 1000
+  // add minimum/maximum only if the API documents record-count limits
+},
+batch_keys: {
+  label: 'Batch Keys',
+  description: 'The keys to use for batching the events.',
+  type: 'string',
+  unsafe_hidden: true,
+  required: false,
+  multiple: true,
+  default: ['<low-cardinality-grouping-field>']  // e.g. ['list_id'] — omit if not needed
+}
+```
+
+- `batch_keys` groups events that must be sent together (e.g. same list/audience). Use a **low-cardinality** field. Omit `batch_keys` entirely if the API endpoint has no per-group requirement.
+- Keep `batch_size` and `batch_keys` `unsafe_hidden: true` unless the customer genuinely needs control. Only expose `batch_size` with `minimum`/`maximum` when the API documents a records-per-request limit.
+
+**Handler shape** — `perform` and `performBatch` should both delegate to the same `utils.ts` builder so single and batch paths stay consistent:
+
+```typescript
+perform: (request, { payload, settings }) => {
+  return sendEvents(request, settings, [payload])
+},
+performBatch: (request, { payload, settings }) => {
+  // payload is an array here
+  return sendEvents(request, settings, payload)
+}
+```
+
+Where `sendEvents(request, settings, payloads: Payload[])` lives in `utils.ts`, maps each payload to the typed request body (from `types.ts`), and posts to the endpoint constant (from `constants.ts`).
+
+## Typed Requests and Responses (REQUIRED)
+
+Do NOT build inline untyped objects or read `any` responses. In `types.ts`, define an interface for **every** request body and API response shape, then use them:
+
+```typescript
+// types.ts
+export interface ConversionEventRequest {
+  eid: string
+  a: string
+  aid: string
+  ts: number
+  // ...
+}
+
+export interface ConversionEventResponse {
+  status: string
+  id?: string
+}
+```
+
+```typescript
+// utils.ts
+import type { ConversionEventRequest, ConversionEventResponse } from './types'
+
+export function sendEvents(request: RequestClient, settings: Settings, payloads: Payload[]) {
+  const body: ConversionEventRequest[] = payloads.map((p) => ({
+    /* typed mapping */
+  }))
+  return request<ConversionEventResponse>(ENDPOINT, { method: 'POST', json: body })
+}
+```
+
+- The request body variable must be annotated with the request interface.
+- Type the `request<ResponseType>(...)` call with the response interface so `response.data` is typed.
+
+## Snapshot Tests (REQUIRED)
+
+In addition to `__tests__/index.test.ts` (happy path + edge cases), generate `__tests__/snapshot.test.ts` following the repo convention (see `trackey`, `metronome`, `movable-ink`). It uses the shared `generateTestData` helper, loops over every action, and snapshots the request body for both "required fields" and "all fields":
+
+```typescript
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-<slug>'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({ properties: eventData })
+      const responses = await testDestination.testAction(actionSlug, {
+        event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({ properties: eventData })
+      const responses = await testDestination.testAction(actionSlug, {
+        event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})
+```
+
+Adjust the `destinationSlug` constant to match the destination's `slug`. Run the suite once to generate `__snapshots__/`, review it, and commit the snapshots.
 
 ## Code Style Rules
 
@@ -143,25 +342,34 @@ Print file listing and summary table of all actions with event types, endpoints,
 - Use `json` option on request (not `body: JSON.stringify(...)`)
 - Action names: `camelCase` in code, `kebab-case` for folders
 - Always `export default` for actions and destination
-- Shared helpers go in a root-level utility file
+- Endpoint URLs and fixed enums live in `constants.ts` — never hardcode string literals inline
+- Request bodies and API responses are typed via interfaces in `types.ts` — never inline untyped objects or `any` responses
+- Send/transform/batch logic lives in `utils.ts`; `perform`/`performBatch` are thin wrappers
 - Follow error handling patterns from `packages/core/src/errors.ts`
 
 ## Constraints
 
 - **DO NOT** use hardcoded templates — read the actual repo for patterns
 - **DO NOT** hardcode credentials or secrets
-- **DO NOT** skip tests — every action needs at least 2 tests (happy path + edge case)
-- **DO NOT** skip registering the destination in the index
+- **DO NOT** skip tests — every action needs at least 2 unit tests (happy path + edge case) PLUS snapshot tests
+- **DO NOT** register a destination ID in `destinations/index.ts` with a placeholder/generated ID — leave registration as a TODO for the production-assigned ID (see Step 6)
+- **DO NOT** collapse `constants.ts` / `types.ts` / `utils.ts` back into the action `index.ts`
+- **DO NOT** skip `performBatch` for event-sending actions unless the API cannot accept multiple records (and say so in the PR)
+- **DO NOT** send untyped request bodies or read untyped (`any`) responses
 
 ## Quality Checklist
 
 - [ ] All actions from the spec are implemented
 - [ ] Every action has fields with proper types and defaults
 - [ ] Every action has a `perform` function hitting the correct endpoint
-- [ ] Every action has at least 2 tests
+- [ ] Every event-sending action implements `performBatch` with `enable_batching` / `batch_size` (+ `batch_keys` if grouping is needed)
+- [ ] `constants.ts`, `types.ts`, and `utils.ts` exist; endpoint/enums, request+response interfaces, and send logic are separated out
+- [ ] All request bodies and API responses are typed (no inline untyped objects, no `any` responses)
+- [ ] Every action has at least 2 unit tests (happy path + edge case)
+- [ ] `__tests__/snapshot.test.ts` exists and snapshots are generated + reviewed
 - [ ] Root `index.ts` imports and registers all actions
 - [ ] `generated-types.ts` files match field definitions
-- [ ] Destination is registered in `packages/destination-actions/src/index.ts`
+- [ ] Destination is NOT registered with a placeholder ID in `destinations/index.ts` (registration left as a TODO for the production ID)
 - [ ] Tests pass
 - [ ] No hardcoded credentials or secrets
 
@@ -172,11 +380,13 @@ After generating all files, print a summary:
 ```
 Destination generated for <Destination Name>
    Location: packages/destination-actions/src/destinations/<slug>/
-   Actions: <count>
-   Tests: <count>
-   Registered in index: Yes
+   Actions: <count> (batching: <enabled/reason-if-not>)
+   Files: constants.ts, types.ts, utils.ts, index.ts + per-action folders
+   Unit tests: <count>   Snapshot tests: generated for <count> actions
+   Registered in index: NO — TODO: add register('<PROD_METADATA_ID>', './<slug>') once the
+                        destination is created in production (ID must match across environments)
 
 To verify:
    yarn types --path packages/destination-actions/src/destinations/<slug>
-   yarn cloud jest --testPathPattern="<slug>"
+   cd packages/destination-actions && TZ=UTC ./node_modules/.bin/jest --testPathPattern="<slug>"
 ```

--- a/.claude/skills/QUICK_START.md
+++ b/.claude/skills/QUICK_START.md
@@ -1,5 +1,21 @@
 # Quick Start Guide - Destination Generator Skills
 
+## Fastest path: `/orchestrate` (recommended)
+
+Run the whole pipeline with one command and just answer the prompts:
+
+```
+/orchestrate <destination-name>
+```
+
+You'll be asked for the **API source** (a docs URL, an OpenAPI spec path, or a PRD) and an **output directory** (default `/tmp/<slug>/`). The orchestrator then runs all 7 steps — refine → map → spec → generate → local e2e → deploy staging → staging e2e — pausing for your review between each.
+
+```
+refined-actions → endpoint-mapping → final-spec → code → local e2e → deploy → staging e2e
+```
+
+Use the step-by-step paths below if you'd rather drive each skill yourself.
+
 ## Choose Your Path
 
 ### Path A: I have an OpenAPI specification ✅
@@ -212,6 +228,11 @@ your-destination/
 
 | File                                                      | Purpose                          |
 | --------------------------------------------------------- | -------------------------------- |
+| `.claude/commands/orchestrate.md`                         | End-to-end pipeline orchestrator |
+| `.claude/commands/refined-actions.md`                     | Step 1 — PRD → refined actions   |
+| `.claude/commands/endpoint-mapping.md`                    | Step 2 — actions → endpoints     |
+| `.claude/commands/spec-generator.md`                      | Step 3 — mapping → spec doc      |
+| `.claude/commands/generate-destination.md`                | Step 4 — spec → code + tests     |
 | `.claude/skills/README.md`                                | Full documentation               |
 | `.claude/skills/QUICK_START.md`                           | This file                        |
 | `.claude/skills/openapi-analyze/SKILL.md`                 | OpenAPI analysis skill           |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,6 +1,43 @@
 # Destination Generator Skills
 
-This directory contains skills that automate the creation of Segment action-destinations from various sources (OpenAPI specs, website documentation, etc.).
+This directory contains skills that automate the creation of Segment action-destinations from various sources (OpenAPI specs, website documentation, PRDs, etc.).
+
+## 🚀 Start here: `/orchestrate` (the one-command pipeline)
+
+The fastest way to build a destination is the **`/orchestrate`** command. It runs the entire pipeline end-to-end — analysis → mapping → spec → code → tests → deploy → staging tests — pausing for your review between steps and passing outputs between skills for you.
+
+```
+/orchestrate <destination-name>
+```
+
+**Example:**
+
+```
+/orchestrate Vibe Actions
+```
+
+**What it does (7 steps):**
+
+| Step              | Skill                   | Output                                                          |
+| ----------------- | ----------------------- | --------------------------------------------------------------- |
+| 1. Refine         | `/refined-actions`      | `refined-actions.md` / `.json`                                  |
+| 2. Map            | `/endpoint-mapping`     | `endpoint-mapping.md` / `.json`                                 |
+| 3. Spec           | `/spec-generator`       | `final-spec.md`                                                 |
+| 4. Generate       | `/generate-destination` | code in `packages/destination-actions/src/destinations/<slug>/` |
+| 5. Test (local)   | `/test-destination-e2e` | local e2e results                                               |
+| 6. Deploy         | `/deploy-staging`       | staging deploy                                                  |
+| 7. Test (staging) | `/test-destination-e2e` | staging e2e results                                             |
+
+**How to use it:**
+
+1. Type `/orchestrate <destination-name>` in Claude Code.
+2. When asked, provide the **API source** — a docs URL, an OpenAPI spec path, or a PRD/markdown doc.
+3. Confirm (or change) the **output directory** for intermediate files (default `/tmp/<slug>/`).
+4. Review each step's output when the orchestrator pauses, and approve to continue.
+
+The orchestrator asks questions only a human can answer (scope, ambiguous mappings), answers what it can from prior outputs, and remembers where it left off if interrupted. Everything intermediate is written to the output directory so nothing is lost between steps.
+
+> Prefer running the pipeline yourself step-by-step, or only have an OpenAPI spec / website? The individual skills below still work standalone.
 
 ## Overview
 
@@ -15,8 +52,8 @@ Building a new Segment destination typically involves:
 
 These skills automate 70-80% of this process by:
 
-1. Analyzing API documentation (OpenAPI specs or websites) to identify suitable actions
-2. Generating TypeScript destination code with proper types and tests
+1. Analyzing API documentation (OpenAPI specs, websites, or PRDs) to identify suitable actions
+2. Generating TypeScript destination code with proper types, batching, and tests
 
 ## Skills
 
@@ -226,18 +263,29 @@ When prompted:
 ```
 packages/destination-actions/src/destinations/[slug]/
 ├── index.ts                       # Destination definition
-├── generated-types.ts             # Auto-generated TypeScript types
-├── IMPLEMENTATION_NOTES.md        # TODOs and next steps
+├── generated-types.ts             # Auto-generated Settings types
+├── constants.ts                   # Base URL, endpoint paths, enums
+├── types.ts                       # Hand-written request/response interfaces
+├── utils.ts                       # Send-event logic, transforms, batch builders
 ├── __tests__/
-│   └── index.test.ts             # Destination tests
+│   ├── index.test.ts             # Destination tests
+│   └── snapshot.test.ts          # Snapshot tests (loops all actions)
 ├── [action-1]/
-│   ├── index.ts                  # Action definition
-│   ├── generated-types.ts        # Action types
+│   ├── index.ts                  # Action definition (perform + performBatch)
+│   ├── generated-types.ts        # Action payload types
 │   └── __tests__/
 │       └── index.test.ts         # Action tests
 └── [action-2]/
     └── ... (same structure)
 ```
+
+> **Conventions enforced by `/generate-destination`:**
+>
+> - Endpoints/enums in `constants.ts`, request+response interfaces in `types.ts`, send logic in `utils.ts` — not inlined into the action.
+> - Event-sending actions implement **`performBatch`** with `enable_batching` / `batch_size` (+ `batch_keys` when grouping is needed).
+> - All request bodies and API responses are **typed** (no inline untyped objects, no `any` responses).
+> - **Snapshot tests** are generated alongside unit tests.
+> - The destination is **not** registered in `destinations/index.ts` with a placeholder ID — registration is left as a TODO for the production-assigned metadata ID (IDs must match across environments, created in production and synced via `sprout`).
 
 ## What Gets Automated
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For more detailed instruction, see the following READMEs:
 
 ## Table of Contents:
 
+- [Generate a Destination with Claude Code](#generate-a-destination-with-claude-code)
 - [Get Started](#get-started)
 - [Actions CLI](#actions-cli)
 - [Example Destination](#example-destination)
@@ -35,6 +36,31 @@ For more detailed instruction, see the following READMEs:
 - [Action Hooks](#action-hooks)
 - [HTTP Requests](#http-requests)
 - [Support](#support)
+
+## Generate a Destination with Claude Code
+
+If you use [Claude Code](https://claude.com/claude-code), this repo ships skills that scaffold a full destination for you — from API docs to working code and tests.
+
+The simplest way is the one-command pipeline. Just run:
+
+```
+/orchestrate <Destination Name>
+```
+
+Then provide your **API source** (a docs URL, an OpenAPI spec, or a PRD) when prompted. It walks through every step — analyzing the API, mapping actions to endpoints, writing the code, and generating tests — pausing for your review along the way.
+
+Prefer to run one step at a time? These skills also work on their own:
+
+| Command                 | What it does                                    |
+| ----------------------- | ----------------------------------------------- |
+| `/refined-actions`      | Turn a PRD or API docs into a list of actions   |
+| `/endpoint-mapping`     | Map those actions to API endpoints and fields   |
+| `/spec-generator`       | Produce a full destination spec document        |
+| `/generate-destination` | Generate the destination code, types, and tests |
+
+📖 See [`.claude/skills/README.md`](./.claude/skills/README.md) and [`.claude/skills/QUICK_START.md`](./.claude/skills/QUICK_START.md) for details.
+
+> These skills accelerate the boilerplate — always review the generated code and follow the [Contributing Guide](./CONTRIBUTING.md) before opening a PR.
 
 ## Get started
 

--- a/packages/destination-actions/src/destinations/index.ts
+++ b/packages/destination-actions/src/destinations/index.ts
@@ -237,6 +237,7 @@ register('69a6caedee3c3617ae42dde8', './pendo-audiences')
 register('69a6cb5fda60c0bec5994df4', './avo-v2')
 register('69b9249b38dabe2f2f1f528a', './youappi-audiences')
 register('69e75a7148bfabf0961fbe4d', './voiceops')
+register('6519e8f3e34b2736550b2fbb', './vibe-actions')
 
 function register(id: MetadataId, destinationPath: string) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/destination-actions/src/destinations/vibe-actions/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../index'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Vibe (Actions)', () => {
+  it('exposes the trackConversionEvent action', () => {
+    expect(testDestination.actions.trackConversionEvent).toBeDefined()
+  })
+
+  it('requires a pixelId setting', () => {
+    const pixelId = Destination.authentication?.fields?.pixelId
+    expect(pixelId).toBeDefined()
+    expect(pixelId?.required).toBe(true)
+  })
+})

--- a/packages/destination-actions/src/destinations/vibe-actions/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * The Vibe pixel identifier (aid) from your advertiser dashboard. Identifies your advertiser account for server-to-server conversion tracking.
+   */
+  pixelId: string
+}

--- a/packages/destination-actions/src/destinations/vibe-actions/index.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/index.ts
@@ -1,4 +1,5 @@
 import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import trackConversionEvent from './trackConversionEvent'
@@ -24,6 +25,39 @@ const destination: DestinationDefinition<Settings> = {
     // No testAuthentication: there is no credential to validate. The pixelId is
     // enforced as a required setting.
   },
+
+  presets: [
+    {
+      name: 'Order Completed',
+      subscribe: 'type = "track" and event = "Order Completed"',
+      partnerAction: 'trackConversionEvent',
+      mapping: {
+        ...defaultValues(trackConversionEvent.fields),
+        action: 'purchase'
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Page Viewed',
+      subscribe: 'type = "page"',
+      partnerAction: 'trackConversionEvent',
+      mapping: {
+        ...defaultValues(trackConversionEvent.fields),
+        action: 'page_view'
+      },
+      type: 'automatic'
+    },
+    {
+      name: 'Signed Up',
+      subscribe: 'type = "track" and event = "Signed Up"',
+      partnerAction: 'trackConversionEvent',
+      mapping: {
+        ...defaultValues(trackConversionEvent.fields),
+        action: 'signup'
+      },
+      type: 'automatic'
+    }
+  ],
 
   actions: {
     trackConversionEvent

--- a/packages/destination-actions/src/destinations/vibe-actions/index.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/index.ts
@@ -1,0 +1,33 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import trackConversionEvent from './trackConversionEvent'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Vibe (Actions)',
+  slug: 'actions-vibe',
+  mode: 'cloud',
+  description: 'Send server-to-server conversion events to Vibe.',
+  authentication: {
+    // The Vibe S2S conversion endpoint requires no credentials. The advertiser
+    // is identified solely by the pixelId (sent as `aid` in the request body).
+    scheme: 'custom',
+    fields: {
+      pixelId: {
+        label: 'Pixel ID',
+        description:
+          'The Vibe pixel identifier (aid) from your advertiser dashboard. Identifies your advertiser account for server-to-server conversion tracking.',
+        type: 'string',
+        required: true
+      }
+    }
+    // No testAuthentication: there is no credential to validate. The pixelId is
+    // enforced as a required setting.
+  },
+
+  actions: {
+    trackConversionEvent
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/vibe-actions/metadata.json
+++ b/packages/destination-actions/src/destinations/vibe-actions/metadata.json
@@ -1,0 +1,313 @@
+{
+  "slug": "actions-vibe",
+  "name": "Vibe (Actions)",
+  "mode": "cloud",
+  "description": "Send server-to-server conversion events to Vibe.",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "pixelId": {
+        "label": "Pixel ID",
+        "description": "The Vibe pixel identifier (aid) from your advertiser dashboard. Identifies your advertiser account for server-to-server conversion tracking.",
+        "type": "string",
+        "required": true,
+        "multiple": false,
+        "choices": null,
+        "default": null,
+        "depends_on": null
+      }
+    }
+  },
+  "audienceConfig": null,
+  "actions": {
+    "trackConversionEvent": {
+      "title": "Track Conversion Event",
+      "description": "Send a server-to-server conversion event to Vibe.",
+      "platform": "cloud",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": null,
+      "dynamicFields": null,
+      "fields": {
+        "eventId": {
+          "label": "Event ID",
+          "description": "Distinct event identifier (UUID recommended). Defaults to the Segment message ID. A UUID is generated automatically if left empty.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "action": {
+          "label": "Action",
+          "description": "The conversion action category performed.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": [
+            {
+              "label": "Install",
+              "value": "install"
+            },
+            {
+              "label": "Lead",
+              "value": "lead"
+            },
+            {
+              "label": "Page View",
+              "value": "page_view"
+            },
+            {
+              "label": "Purchase",
+              "value": "purchase"
+            },
+            {
+              "label": "Signup",
+              "value": "signup"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "timestamp": {
+          "label": "Timestamp",
+          "description": "Event timestamp. Converted to UNIX epoch milliseconds before sending.",
+          "type": "datetime",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.timestamp"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "ipAddress": {
+          "label": "IP Address",
+          "description": "The user's IP address.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.ip"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "priceUsd": {
+          "label": "Price (USD)",
+          "description": "The purchase price in USD. Included in the event data payload.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.price"
+              },
+              "then": {
+                "@path": "$.properties.price"
+              },
+              "else": {
+                "@path": "$.properties.revenue"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "purchaseId": {
+          "label": "Purchase ID",
+          "description": "The purchase or order identifier. Included in the event data payload.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.order_id"
+              },
+              "then": {
+                "@path": "$.properties.order_id"
+              },
+              "else": {
+                "@path": "$.properties.purchase_id"
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "googleAnalyticsId": {
+          "label": "Google Analytics ID",
+          "description": "Google Analytics identifier used for attribution.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties.gid"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "userAgent": {
+          "label": "User Agent",
+          "description": "The browser/device user agent string.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.userAgent"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "url": {
+          "label": "URL",
+          "description": "The URL of the page where the action occurred.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.page.url"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "presets": []
+}

--- a/packages/destination-actions/src/destinations/vibe-actions/metadata.json
+++ b/packages/destination-actions/src/destinations/vibe-actions/metadata.json
@@ -24,7 +24,7 @@
       "title": "Track Conversion Event",
       "description": "Send a server-to-server conversion event to Vibe.",
       "platform": "cloud",
-      "defaultSubscription": "type = \"track\"",
+      "defaultSubscription": "type = \"track\" or type = \"page\"",
       "hidden": false,
       "hasPerformBatch": false,
       "syncMode": null,
@@ -59,16 +59,18 @@
         },
         "action": {
           "label": "Action",
-          "description": "The conversion action category performed.",
+          "description": "The conversion action category performed. No default is applied; set explicitly or via a preset.",
           "type": "string",
           "required": true,
           "multiple": false,
           "allowNull": false,
           "dynamic": false,
-          "default": {
-            "@path": "$.event"
-          },
+          "default": null,
           "choices": [
+            {
+              "label": "Call",
+              "value": "call"
+            },
             {
               "label": "Install",
               "value": "install"
@@ -106,7 +108,7 @@
         },
         "timestamp": {
           "label": "Timestamp",
-          "description": "Event timestamp. Converted to UNIX epoch milliseconds before sending.",
+          "description": "Event timestamp. Converted to UNIX epoch milliseconds before sending. Must be within the last 7 days.",
           "type": "datetime",
           "required": true,
           "multiple": false,
@@ -130,9 +132,55 @@
           "format": null,
           "additionalProperties": false
         },
+        "email": {
+          "label": "Email",
+          "description": "The user's email address. Required if IP Address is not provided.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@if": {
+              "exists": {
+                "@path": "$.properties.email"
+              },
+              "then": {
+                "@path": "$.properties.email"
+              },
+              "else": {
+                "@if": {
+                  "exists": {
+                    "@path": "$.traits.email"
+                  },
+                  "then": {
+                    "@path": "$.traits.email"
+                  },
+                  "else": {
+                    "@path": "$.context.traits.email"
+                  }
+                }
+              }
+            }
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": "email",
+          "additionalProperties": false
+        },
         "ipAddress": {
           "label": "IP Address",
-          "description": "The user's IP address.",
+          "description": "The user's IP address (IPv4). Required if Email is not provided.",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -156,9 +204,35 @@
           "format": null,
           "additionalProperties": false
         },
+        "eventData": {
+          "label": "Event Data",
+          "description": "Additional event data sent as a stringified JSON object. Reserved keys `price_usd` (float) and `purchase_id` (string) can be set here or via their dedicated fields.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
         "priceUsd": {
           "label": "Price (USD)",
-          "description": "The purchase price in USD. Included in the event data payload.",
+          "description": "The purchase price in USD. Merged into the event data payload as `price_usd`.",
           "type": "number",
           "required": false,
           "multiple": false,
@@ -194,7 +268,7 @@
         },
         "purchaseId": {
           "label": "Purchase ID",
-          "description": "The purchase or order identifier. Included in the event data payload.",
+          "description": "The purchase or order identifier. Merged into the event data payload as `purchase_id`.",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -230,7 +304,7 @@
         },
         "googleAnalyticsId": {
           "label": "Google Analytics ID",
-          "description": "Google Analytics identifier used for attribution.",
+          "description": "Google Analytics identifier used for cross-platform attribution.",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -309,5 +383,246 @@
       }
     }
   },
-  "presets": []
+  "presets": [
+    {
+      "name": "Order Completed",
+      "type": "automatic",
+      "partnerAction": "trackConversionEvent",
+      "subscribe": "type = \"track\" and event = \"Order Completed\"",
+      "mapping": {
+        "eventId": {
+          "@path": "$.messageId"
+        },
+        "timestamp": {
+          "@path": "$.timestamp"
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.email"
+                },
+                "then": {
+                  "@path": "$.traits.email"
+                },
+                "else": {
+                  "@path": "$.context.traits.email"
+                }
+              }
+            }
+          }
+        },
+        "ipAddress": {
+          "@path": "$.context.ip"
+        },
+        "eventData": {
+          "@path": "$.properties"
+        },
+        "priceUsd": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.price"
+            },
+            "then": {
+              "@path": "$.properties.price"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "purchaseId": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.order_id"
+            },
+            "then": {
+              "@path": "$.properties.order_id"
+            },
+            "else": {
+              "@path": "$.properties.purchase_id"
+            }
+          }
+        },
+        "googleAnalyticsId": {
+          "@path": "$.properties.gid"
+        },
+        "userAgent": {
+          "@path": "$.context.userAgent"
+        },
+        "url": {
+          "@path": "$.context.page.url"
+        },
+        "action": "purchase"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Page Viewed",
+      "type": "automatic",
+      "partnerAction": "trackConversionEvent",
+      "subscribe": "type = \"page\"",
+      "mapping": {
+        "eventId": {
+          "@path": "$.messageId"
+        },
+        "timestamp": {
+          "@path": "$.timestamp"
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.email"
+                },
+                "then": {
+                  "@path": "$.traits.email"
+                },
+                "else": {
+                  "@path": "$.context.traits.email"
+                }
+              }
+            }
+          }
+        },
+        "ipAddress": {
+          "@path": "$.context.ip"
+        },
+        "eventData": {
+          "@path": "$.properties"
+        },
+        "priceUsd": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.price"
+            },
+            "then": {
+              "@path": "$.properties.price"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "purchaseId": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.order_id"
+            },
+            "then": {
+              "@path": "$.properties.order_id"
+            },
+            "else": {
+              "@path": "$.properties.purchase_id"
+            }
+          }
+        },
+        "googleAnalyticsId": {
+          "@path": "$.properties.gid"
+        },
+        "userAgent": {
+          "@path": "$.context.userAgent"
+        },
+        "url": {
+          "@path": "$.context.page.url"
+        },
+        "action": "page_view"
+      },
+      "eventSlug": null
+    },
+    {
+      "name": "Signed Up",
+      "type": "automatic",
+      "partnerAction": "trackConversionEvent",
+      "subscribe": "type = \"track\" and event = \"Signed Up\"",
+      "mapping": {
+        "eventId": {
+          "@path": "$.messageId"
+        },
+        "timestamp": {
+          "@path": "$.timestamp"
+        },
+        "email": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.email"
+            },
+            "then": {
+              "@path": "$.properties.email"
+            },
+            "else": {
+              "@if": {
+                "exists": {
+                  "@path": "$.traits.email"
+                },
+                "then": {
+                  "@path": "$.traits.email"
+                },
+                "else": {
+                  "@path": "$.context.traits.email"
+                }
+              }
+            }
+          }
+        },
+        "ipAddress": {
+          "@path": "$.context.ip"
+        },
+        "eventData": {
+          "@path": "$.properties"
+        },
+        "priceUsd": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.price"
+            },
+            "then": {
+              "@path": "$.properties.price"
+            },
+            "else": {
+              "@path": "$.properties.revenue"
+            }
+          }
+        },
+        "purchaseId": {
+          "@if": {
+            "exists": {
+              "@path": "$.properties.order_id"
+            },
+            "then": {
+              "@path": "$.properties.order_id"
+            },
+            "else": {
+              "@path": "$.properties.purchase_id"
+            }
+          }
+        },
+        "googleAnalyticsId": {
+          "@path": "$.properties.gid"
+        },
+        "userAgent": {
+          "@path": "$.context.userAgent"
+        },
+        "url": {
+          "@path": "$.context.page.url"
+        },
+        "action": "signup"
+      },
+      "eventSlug": null
+    }
+  ]
 }

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/__tests__/index.test.ts
@@ -1,0 +1,136 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const testDestination = createTestIntegration(Destination)
+
+const ENDPOINT = 'https://t.vibe.co'
+const PATH = '/s2s-conversion/events'
+
+const settings = { pixelId: 'pixel-abc-123' }
+
+describe('VibeActions.trackConversionEvent', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('sends a purchase conversion with default mappings', async () => {
+    let requestBody: Record<string, unknown> = {}
+    nock(ENDPOINT)
+      .post(PATH, (body) => {
+        requestBody = body
+        return true
+      })
+      .reply(200, {})
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'purchase',
+      messageId: 'msg-1',
+      timestamp: '2021-08-17T15:21:15.449Z',
+      context: {
+        ip: '8.8.8.8',
+        userAgent: 'Mozilla/5.0',
+        page: { url: 'https://example.com/checkout' }
+      },
+      properties: {
+        price: 75.5,
+        order_id: 'order-99',
+        gid: 'GA1.2.3'
+      }
+    })
+
+    const responses = await testDestination.testAction('trackConversionEvent', {
+      event,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].status).toBe(200)
+    expect(requestBody).toMatchObject({
+      eid: 'msg-1',
+      a: 'purchase',
+      aid: 'pixel-abc-123',
+      ts: new Date('2021-08-17T15:21:15.449Z').getTime(),
+      ip: '8.8.8.8',
+      ua: 'Mozilla/5.0',
+      url: 'https://example.com/checkout',
+      gid: 'GA1.2.3',
+      ed: JSON.stringify({ price_usd: 75.5, purchase_id: 'order-99' })
+    })
+  })
+
+  it('generates a UUID for eid when messageId is absent', async () => {
+    let requestBody: Record<string, unknown> = {}
+    nock(ENDPOINT)
+      .post(PATH, (body) => {
+        requestBody = body
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('trackConversionEvent', {
+      settings,
+      mapping: {
+        action: 'signup',
+        timestamp: '2021-08-17T15:21:15.449Z'
+      }
+    })
+
+    // UUID v4 format
+    expect(requestBody.eid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    expect(requestBody.a).toBe('signup')
+    // No event data keys -> ed omitted
+    expect(requestBody.ed).toBeUndefined()
+  })
+
+  it('omits ed when neither price nor purchaseId is present', async () => {
+    let requestBody: Record<string, unknown> = {}
+    nock(ENDPOINT)
+      .post(PATH, (body) => {
+        requestBody = body
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('trackConversionEvent', {
+      settings,
+      mapping: {
+        eventId: 'msg-2',
+        action: 'lead',
+        timestamp: '2021-08-17T15:21:15.449Z',
+        ipAddress: '1.1.1.1'
+      }
+    })
+
+    expect(requestBody.ed).toBeUndefined()
+    expect(requestBody.a).toBe('lead')
+  })
+
+  it('rejects an action value outside the allowed enum', async () => {
+    await expect(
+      testDestination.testAction('trackConversionEvent', {
+        settings,
+        mapping: {
+          eventId: 'msg-3',
+          action: 'not_a_real_action',
+          timestamp: '2021-08-17T15:21:15.449Z'
+        }
+      })
+    ).rejects.toThrow()
+  })
+
+  it('rejects an unparseable timestamp', async () => {
+    await expect(
+      testDestination.testAction('trackConversionEvent', {
+        settings,
+        mapping: {
+          eventId: 'msg-4',
+          action: 'install',
+          timestamp: 'not-a-date'
+        }
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/__tests__/index.test.ts
@@ -5,9 +5,12 @@ import Destination from '../../index'
 const testDestination = createTestIntegration(Destination)
 
 const ENDPOINT = 'https://t.vibe.co'
-const PATH = '/s2s-conversion/events'
+const PATH = '/s2s-conversion/events/segment'
 
 const settings = { pixelId: 'pixel-abc-123' }
+
+// Use a recent timestamp so the 7-day freshness check passes.
+const recentIso = new Date(Date.now() - 60 * 1000).toISOString()
 
 describe('VibeActions.trackConversionEvent', () => {
   afterEach(() => {
@@ -25,15 +28,16 @@ describe('VibeActions.trackConversionEvent', () => {
 
     const event = createTestEvent({
       type: 'track',
-      event: 'purchase',
+      event: 'Order Completed',
       messageId: 'msg-1',
-      timestamp: '2021-08-17T15:21:15.449Z',
+      timestamp: recentIso,
       context: {
         ip: '8.8.8.8',
         userAgent: 'Mozilla/5.0',
         page: { url: 'https://example.com/checkout' }
       },
       properties: {
+        email: 'joe@gmail.com',
         price: 75.5,
         order_id: 'order-99',
         gid: 'GA1.2.3'
@@ -43,6 +47,9 @@ describe('VibeActions.trackConversionEvent', () => {
     const responses = await testDestination.testAction('trackConversionEvent', {
       event,
       settings,
+      mapping: {
+        action: 'purchase'
+      },
       useDefaultMappings: true
     })
 
@@ -52,12 +59,21 @@ describe('VibeActions.trackConversionEvent', () => {
       eid: 'msg-1',
       a: 'purchase',
       aid: 'pixel-abc-123',
-      ts: new Date('2021-08-17T15:21:15.449Z').getTime(),
+      ts: new Date(recentIso).getTime(),
+      em: 'joe@gmail.com',
       ip: '8.8.8.8',
       ua: 'Mozilla/5.0',
       url: 'https://example.com/checkout',
+      gid: 'GA1.2.3'
+    })
+    // ed merges arbitrary properties with the reserved keys.
+    expect(JSON.parse(requestBody.ed as string)).toMatchObject({
+      email: 'joe@gmail.com',
+      price: 75.5,
+      order_id: 'order-99',
       gid: 'GA1.2.3',
-      ed: JSON.stringify({ price_usd: 75.5, purchase_id: 'order-99' })
+      price_usd: 75.5,
+      purchase_id: 'order-99'
     })
   })
 
@@ -74,18 +90,20 @@ describe('VibeActions.trackConversionEvent', () => {
       settings,
       mapping: {
         action: 'signup',
-        timestamp: '2021-08-17T15:21:15.449Z'
+        timestamp: recentIso,
+        email: 'jane@gmail.com'
       }
     })
 
     // UUID v4 format
     expect(requestBody.eid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
     expect(requestBody.a).toBe('signup')
-    // No event data keys -> ed omitted
+    expect(requestBody.em).toBe('jane@gmail.com')
+    // No event data -> ed omitted
     expect(requestBody.ed).toBeUndefined()
   })
 
-  it('omits ed when neither price nor purchaseId is present', async () => {
+  it('omits ed when no event data is present', async () => {
     let requestBody: Record<string, unknown> = {}
     nock(ENDPOINT)
       .post(PATH, (body) => {
@@ -99,13 +117,29 @@ describe('VibeActions.trackConversionEvent', () => {
       mapping: {
         eventId: 'msg-2',
         action: 'lead',
-        timestamp: '2021-08-17T15:21:15.449Z',
+        timestamp: recentIso,
         ipAddress: '1.1.1.1'
       }
     })
 
     expect(requestBody.ed).toBeUndefined()
     expect(requestBody.a).toBe('lead')
+    expect(requestBody.ip).toBe('1.1.1.1')
+  })
+
+  it('accepts the "call" action value', async () => {
+    nock(ENDPOINT).post(PATH).reply(200, {})
+
+    const responses = await testDestination.testAction('trackConversionEvent', {
+      settings,
+      mapping: {
+        action: 'call',
+        timestamp: recentIso,
+        email: 'joe@gmail.com'
+      }
+    })
+
+    expect(responses[0].status).toBe(200)
   })
 
   it('rejects an action value outside the allowed enum', async () => {
@@ -115,7 +149,8 @@ describe('VibeActions.trackConversionEvent', () => {
         mapping: {
           eventId: 'msg-3',
           action: 'not_a_real_action',
-          timestamp: '2021-08-17T15:21:15.449Z'
+          timestamp: recentIso,
+          email: 'joe@gmail.com'
         }
       })
     ).rejects.toThrow()
@@ -128,9 +163,49 @@ describe('VibeActions.trackConversionEvent', () => {
         mapping: {
           eventId: 'msg-4',
           action: 'install',
-          timestamp: 'not-a-date'
+          timestamp: 'not-a-date',
+          email: 'joe@gmail.com'
         }
       })
     ).rejects.toThrow()
+  })
+
+  it('rejects when neither email nor IP address is provided', async () => {
+    await expect(
+      testDestination.testAction('trackConversionEvent', {
+        settings,
+        mapping: {
+          action: 'purchase',
+          timestamp: recentIso
+        }
+      })
+    ).rejects.toThrow('Either Email or IP Address is required.')
+  })
+
+  it('rejects a non-IPv4 IP address', async () => {
+    await expect(
+      testDestination.testAction('trackConversionEvent', {
+        settings,
+        mapping: {
+          action: 'purchase',
+          timestamp: recentIso,
+          ipAddress: '2001:db8::1'
+        }
+      })
+    ).rejects.toThrow('is not a valid IPv4 address')
+  })
+
+  it('rejects a timestamp older than 7 days', async () => {
+    const staleIso = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    await expect(
+      testDestination.testAction('trackConversionEvent', {
+        settings,
+        mapping: {
+          action: 'purchase',
+          timestamp: staleIso,
+          email: 'joe@gmail.com'
+        }
+      })
+    ).rejects.toThrow('older than 7 days')
   })
 })

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/generated-types.ts
@@ -6,27 +6,37 @@ export interface Payload {
    */
   eventId?: string
   /**
-   * The conversion action category performed.
+   * The conversion action category performed. No default is applied; set explicitly or via a preset.
    */
   action: string
   /**
-   * Event timestamp. Converted to UNIX epoch milliseconds before sending.
+   * Event timestamp. Converted to UNIX epoch milliseconds before sending. Must be within the last 7 days.
    */
   timestamp: string | number
   /**
-   * The user's IP address.
+   * The user's email address. Required if IP Address is not provided.
+   */
+  email?: string
+  /**
+   * The user's IP address (IPv4). Required if Email is not provided.
    */
   ipAddress?: string
   /**
-   * The purchase price in USD. Included in the event data payload.
+   * Additional event data sent as a stringified JSON object. Reserved keys `price_usd` (float) and `purchase_id` (string) can be set here or via their dedicated fields.
+   */
+  eventData?: {
+    [k: string]: unknown
+  }
+  /**
+   * The purchase price in USD. Merged into the event data payload as `price_usd`.
    */
   priceUsd?: number
   /**
-   * The purchase or order identifier. Included in the event data payload.
+   * The purchase or order identifier. Merged into the event data payload as `purchase_id`.
    */
   purchaseId?: string
   /**
-   * Google Analytics identifier used for attribution.
+   * Google Analytics identifier used for cross-platform attribution.
    */
   googleAnalyticsId?: string
   /**

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/generated-types.ts
@@ -1,0 +1,40 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Distinct event identifier (UUID recommended). Defaults to the Segment message ID. A UUID is generated automatically if left empty.
+   */
+  eventId?: string
+  /**
+   * The conversion action category performed.
+   */
+  action: string
+  /**
+   * Event timestamp. Converted to UNIX epoch milliseconds before sending.
+   */
+  timestamp: string | number
+  /**
+   * The user's IP address.
+   */
+  ipAddress?: string
+  /**
+   * The purchase price in USD. Included in the event data payload.
+   */
+  priceUsd?: number
+  /**
+   * The purchase or order identifier. Included in the event data payload.
+   */
+  purchaseId?: string
+  /**
+   * Google Analytics identifier used for attribution.
+   */
+  googleAnalyticsId?: string
+  /**
+   * The browser/device user agent string.
+   */
+  userAgent?: string
+  /**
+   * The URL of the page where the action occurred.
+   */
+  url?: string
+}

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/index.ts
@@ -1,14 +1,23 @@
 import type { ActionDefinition } from '@segment/actions-core'
+import { PayloadValidationError } from '@segment/actions-core'
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
-const ENDPOINT = 'https://t.vibe.co/s2s-conversion/events'
+const ENDPOINT = 'https://t.vibe.co/s2s-conversion/events/segment'
+
+// Events older than this (relative to now) are rejected by Vibe.
+const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000
+// Allow a small amount of clock skew for timestamps slightly in the future.
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000
+
+// Standard dotted-quad IPv4 validation (0-255 per octet).
+const IPV4_REGEX = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Conversion Event',
   description: 'Send a server-to-server conversion event to Vibe.',
-  defaultSubscription: 'type = "track"',
+  defaultSubscription: 'type = "track" or type = "page"',
   fields: {
     eventId: {
       label: 'Event ID',
@@ -22,41 +31,70 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     action: {
       label: 'Action',
-      description: 'The conversion action category performed.',
+      description: 'The conversion action category performed. No default is applied; set explicitly or via a preset.',
       type: 'string',
       required: true,
       choices: [
+        { label: 'Call', value: 'call' },
         { label: 'Install', value: 'install' },
         { label: 'Lead', value: 'lead' },
         { label: 'Page View', value: 'page_view' },
         { label: 'Purchase', value: 'purchase' },
         { label: 'Signup', value: 'signup' }
-      ],
-      default: {
-        '@path': '$.event'
-      }
+      ]
     },
     timestamp: {
       label: 'Timestamp',
-      description: 'Event timestamp. Converted to UNIX epoch milliseconds before sending.',
+      description:
+        'Event timestamp. Converted to UNIX epoch milliseconds before sending. Must be within the last 7 days.',
       type: 'datetime',
       required: true,
       default: {
         '@path': '$.timestamp'
       }
     },
+    email: {
+      label: 'Email',
+      description: "The user's email address. Required if IP Address is not provided.",
+      type: 'string',
+      format: 'email',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.email' },
+          then: { '@path': '$.properties.email' },
+          else: {
+            '@if': {
+              exists: { '@path': '$.traits.email' },
+              then: { '@path': '$.traits.email' },
+              else: { '@path': '$.context.traits.email' }
+            }
+          }
+        }
+      }
+    },
     ipAddress: {
       label: 'IP Address',
-      description: "The user's IP address.",
+      description: "The user's IP address (IPv4). Required if Email is not provided.",
       type: 'string',
       required: false,
       default: {
         '@path': '$.context.ip'
       }
     },
+    eventData: {
+      label: 'Event Data',
+      description:
+        'Additional event data sent as a stringified JSON object. Reserved keys `price_usd` (float) and `purchase_id` (string) can be set here or via their dedicated fields.',
+      type: 'object',
+      required: false,
+      default: {
+        '@path': '$.properties'
+      }
+    },
     priceUsd: {
       label: 'Price (USD)',
-      description: 'The purchase price in USD. Included in the event data payload.',
+      description: 'The purchase price in USD. Merged into the event data payload as `price_usd`.',
       type: 'number',
       required: false,
       default: {
@@ -69,7 +107,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     purchaseId: {
       label: 'Purchase ID',
-      description: 'The purchase or order identifier. Included in the event data payload.',
+      description: 'The purchase or order identifier. Merged into the event data payload as `purchase_id`.',
       type: 'string',
       required: false,
       default: {
@@ -82,7 +120,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     googleAnalyticsId: {
       label: 'Google Analytics ID',
-      description: 'Google Analytics identifier used for attribution.',
+      description: 'Google Analytics identifier used for cross-platform attribution.',
       type: 'string',
       required: false,
       default: {
@@ -113,7 +151,9 @@ const action: ActionDefinition<Settings, Payload> = {
       eventId,
       action: conversionAction,
       timestamp,
+      email,
       ipAddress,
+      eventData,
       priceUsd,
       purchaseId,
       googleAnalyticsId,
@@ -121,29 +161,49 @@ const action: ActionDefinition<Settings, Payload> = {
       url
     } = payload
 
+    // Vibe requires at least one identifier: email or IP address.
+    if (!email && !ipAddress) {
+      throw new PayloadValidationError('Either Email or IP Address is required.')
+    }
+
+    // Validate IPv4 format when an IP is provided.
+    if (ipAddress && !IPV4_REGEX.test(ipAddress)) {
+      throw new PayloadValidationError(`IP Address "${ipAddress}" is not a valid IPv4 address.`)
+    }
+
     // The `action` enum and `timestamp` date format are validated by the
     // framework against the field definitions before `perform` runs.
     const ts = new Date(timestamp).getTime()
+    if (Number.isNaN(ts)) {
+      throw new PayloadValidationError('Timestamp could not be parsed into a valid date.')
+    }
 
-    // `ed` is a JSON string with recognized keys `price_usd` (float) and
-    // `purchase_id` (string). Only include it when at least one key is present.
-    let ed: string | undefined
-    const eventData: { price_usd?: number; purchase_id?: string } = {}
+    // Vibe rejects events older than 7 days (and implausible future timestamps).
+    const now = Date.now()
+    if (ts < now - MAX_EVENT_AGE_MS) {
+      throw new PayloadValidationError('Timestamp is older than 7 days; the event cannot be sent to Vibe.')
+    }
+    if (ts > now + MAX_FUTURE_SKEW_MS) {
+      throw new PayloadValidationError('Timestamp is too far in the future.')
+    }
+
+    // `ed` is a stringified JSON object. Start from the arbitrary event data
+    // object, then merge the reserved keys `price_usd` and `purchase_id`.
+    const data: Record<string, unknown> = { ...(eventData ?? {}) }
     if (priceUsd !== undefined && priceUsd !== null) {
-      eventData.price_usd = priceUsd
+      data.price_usd = priceUsd
     }
     if (purchaseId !== undefined && purchaseId !== null && purchaseId !== '') {
-      eventData.purchase_id = purchaseId
+      data.purchase_id = purchaseId
     }
-    if (Object.keys(eventData).length > 0) {
-      ed = JSON.stringify(eventData)
-    }
+    const ed = Object.keys(data).length > 0 ? JSON.stringify(data) : undefined
 
     const body = {
       eid: eventId || uuidv4(),
       a: conversionAction,
       aid: settings.pixelId,
       ts,
+      em: email,
       ip: ipAddress,
       ed,
       gid: googleAnalyticsId,

--- a/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/vibe-actions/trackConversionEvent/index.ts
@@ -1,0 +1,161 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import { v4 as uuidv4 } from '@lukeed/uuid'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const ENDPOINT = 'https://t.vibe.co/s2s-conversion/events'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Conversion Event',
+  description: 'Send a server-to-server conversion event to Vibe.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    eventId: {
+      label: 'Event ID',
+      description:
+        'Distinct event identifier (UUID recommended). Defaults to the Segment message ID. A UUID is generated automatically if left empty.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.messageId'
+      }
+    },
+    action: {
+      label: 'Action',
+      description: 'The conversion action category performed.',
+      type: 'string',
+      required: true,
+      choices: [
+        { label: 'Install', value: 'install' },
+        { label: 'Lead', value: 'lead' },
+        { label: 'Page View', value: 'page_view' },
+        { label: 'Purchase', value: 'purchase' },
+        { label: 'Signup', value: 'signup' }
+      ],
+      default: {
+        '@path': '$.event'
+      }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description: 'Event timestamp. Converted to UNIX epoch milliseconds before sending.',
+      type: 'datetime',
+      required: true,
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    ipAddress: {
+      label: 'IP Address',
+      description: "The user's IP address.",
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.context.ip'
+      }
+    },
+    priceUsd: {
+      label: 'Price (USD)',
+      description: 'The purchase price in USD. Included in the event data payload.',
+      type: 'number',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.price' },
+          then: { '@path': '$.properties.price' },
+          else: { '@path': '$.properties.revenue' }
+        }
+      }
+    },
+    purchaseId: {
+      label: 'Purchase ID',
+      description: 'The purchase or order identifier. Included in the event data payload.',
+      type: 'string',
+      required: false,
+      default: {
+        '@if': {
+          exists: { '@path': '$.properties.order_id' },
+          then: { '@path': '$.properties.order_id' },
+          else: { '@path': '$.properties.purchase_id' }
+        }
+      }
+    },
+    googleAnalyticsId: {
+      label: 'Google Analytics ID',
+      description: 'Google Analytics identifier used for attribution.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.properties.gid'
+      }
+    },
+    userAgent: {
+      label: 'User Agent',
+      description: 'The browser/device user agent string.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.context.userAgent'
+      }
+    },
+    url: {
+      label: 'URL',
+      description: 'The URL of the page where the action occurred.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.context.page.url'
+      }
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    const {
+      eventId,
+      action: conversionAction,
+      timestamp,
+      ipAddress,
+      priceUsd,
+      purchaseId,
+      googleAnalyticsId,
+      userAgent,
+      url
+    } = payload
+
+    // The `action` enum and `timestamp` date format are validated by the
+    // framework against the field definitions before `perform` runs.
+    const ts = new Date(timestamp).getTime()
+
+    // `ed` is a JSON string with recognized keys `price_usd` (float) and
+    // `purchase_id` (string). Only include it when at least one key is present.
+    let ed: string | undefined
+    const eventData: { price_usd?: number; purchase_id?: string } = {}
+    if (priceUsd !== undefined && priceUsd !== null) {
+      eventData.price_usd = priceUsd
+    }
+    if (purchaseId !== undefined && purchaseId !== null && purchaseId !== '') {
+      eventData.purchase_id = purchaseId
+    }
+    if (Object.keys(eventData).length > 0) {
+      ed = JSON.stringify(eventData)
+    }
+
+    const body = {
+      eid: eventId || uuidv4(),
+      a: conversionAction,
+      aid: settings.pixelId,
+      ts,
+      ip: ipAddress,
+      ed,
+      gid: googleAnalyticsId,
+      ua: userAgent,
+      url
+    }
+
+    return request(ENDPOINT, {
+      method: 'POST',
+      json: body
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
## Summary

Adds a new cloud-mode destination **Vibe (Actions)** (slug `actions-vibe`) for Vibe's server-to-server conversion tracking API.

- **Endpoint:** `POST https://t.vibe.co/s2s-conversion/events/segment`
- **Auth:** None — the advertiser is identified solely by the `pixelId` (`aid`) setting from the Vibe advertiser dashboard.
- **Action:** `trackConversionEvent` (default subscription `type = "track" or type = "page"`)

### Action behavior
- Maps the Segment event to Vibe's fixed action enum: `call`, `install`, `lead`, `page_view`, `purchase`, `signup` (required mapping field, **no default** — set explicitly or via a preset).
- Requires at least one identifier: **email (`em`)** or **IP address (`ip`)**; throws `PayloadValidationError` if both are missing. Email falls back through `properties → traits → context.traits`.
- Validates that `ip` is a well-formed **IPv4** address.
- Converts `timestamp` to epoch milliseconds (`ts`) and enforces the **7-day freshness window** (with a small future-skew tolerance).
- Composes the `ed` JSON string from an arbitrary `eventData` object merged with the reserved keys `price_usd` and `purchase_id` (omitted when empty).
- Defaults `eid` to `messageId`, falling back to a generated UUID.

### Presets
- **Order Completed** → `a = purchase`
- **Page Viewed** → `a = page_view`
- **Signed Up** → `a = signup`

## Test plan
- [x] Unit tests — **11/11 passing** (happy path, UUID fallback, `ed` merge/omission, `call` enum, invalid enum, missing/invalid identifiers, IPv4 validation, stale timestamp, destination-level checks)
- [x] Local e2e via `./bin/run serve` — verified the exact outbound wire body against the live Vibe endpoint (200), plus all client-side validation rejections
- [x] `metadata.json` regenerated (fields + presets)
- [x] ESLint clean

## ⚠️ Before merging to production
- **Replace the placeholder metadata ID** (`6519e8f3e34b2736550b2fbb`) in `packages/destination-actions/src/destinations/index.ts` with the production-assigned ObjectId (must be synced across environments via sprout).

## Open questions
1. Is there a lightweight endpoint to validate a `pixelId` for `testAuthentication`, or is presence-only sufficient? (Currently no `testAuthentication`.)
2. Rate limits / quotas for the S2S conversion endpoint?
3. `gid` (Google Analytics ID) field label/description — TBC by Maxime.
4. Destination display name — "Vibe Tracking Event" was mentioned as TBC; currently ships as "Vibe (Actions)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)