### PR TITLE
docs: harden destination-generator skill from PR feedback + document /orchestrate

### DIFF
--- a/.claude/commands/endpoint-mapping.md
+++ b/.claude/commands/endpoint-mapping.md
@@ -34,6 +34,7 @@ Parse the spec and index: base URL, API version, auth scheme, all endpoints (pat
 ### Phase 2: Action-to-Endpoint Matching
 
 For each action, find matching endpoint(s) using this priority:
+
 1. Exact operationId match
 2. Semantic match (description alignment)
 3. Path + Method match
@@ -41,6 +42,23 @@ For each action, find matching endpoint(s) using this priority:
 5. Composite match (multiple sequential calls)
 
 Verify: HTTP method aligns, path params can be sourced, request body accommodates fields, response has needed IDs.
+
+#### Prefer a batch/bulk endpoint when one exists
+
+For **every** action, look for a dedicated batch/bulk endpoint alongside the single-record endpoint. These are the endpoints that will back `performBatch` in code, so identifying them here is required.
+
+Signals that an endpoint is a batch endpoint:
+
+- Path or operationId contains `batch`, `bulk`, `import`, `collection`, `events`, or a plural resource (`/users` accepting an array vs `/users/{id}`).
+- Request body schema is an **array** (or an object wrapping an array, e.g. `{ "data": [...] }`, `{ "records": [...] }`, `{ "events": [...] }`).
+- Docs mention "up to N records per request", a batch/bulk limit, or bulk import semantics.
+
+For each action, record BOTH when available:
+
+- **Single endpoint** — sends one record (backs `perform`).
+- **Batch endpoint** — accepts many records (backs `performBatch`).
+
+**Preference rule:** when a batch endpoint exists, it is the preferred delivery path — flag it as such and capture its records-per-request limit and array wrapper key (if any). If the API only exposes a single-record endpoint that happens to accept an array of records at the same path/method, note that the same endpoint serves both paths. If no batch capability exists at all, say so explicitly (this tells the generator not to invent one).
 
 ### Phase 3: Field-Level Mapping
 
@@ -72,6 +90,7 @@ Generated: <current date>
 ---
 
 ## API Overview
+
 - **Base URL:** <url>
 - **API Version:** <version>
 - **Auth:** <scheme>
@@ -89,19 +108,23 @@ Generated: <current date>
 **API Operation:** `<operationId>` — `<HTTP METHOD>`
 **Endpoint URI:** `<full path>`
 
+**Batch Endpoint:** `<operationId>` — `<HTTP METHOD>` `<full path>` — records-per-request limit: `<N or "undocumented">`, array wrapper key: `<key or "root array">`
+_(If no batch endpoint exists, write: "None — API accepts one record per call." If the single endpoint itself accepts an array, write: "Same as single endpoint — accepts an array of records.")_
+
 #### Field Mapping Table
 
-| Source Field | Segment Path | Target Field (API) | Target Type | Transform | Required by API |
-|---|---|---|---|---|---|
-| `email` | `$.traits.email` | `$.properties.email` | string | Direct | Yes |
+| Source Field | Segment Path     | Target Field (API)   | Target Type | Transform | Required by API |
+| ------------ | ---------------- | -------------------- | ----------- | --------- | --------------- |
+| `email`      | `$.traits.email` | `$.properties.email` | string      | Direct    | Yes             |
 
 #### Mandatory API Parameters (not in action fields)
 
-| Parameter | Location | Source | Value |
-|---|---|---|---|
-| `projectId` | path | settings | `settings.projectId` |
+| Parameter   | Location | Source   | Value                |
+| ----------- | -------- | -------- | -------------------- |
+| `projectId` | path     | settings | `settings.projectId` |
 
 #### Response Handling
+
 - **Success (200/201):** <what to extract>
 - **Error (4xx/5xx):** <handling>
 
@@ -110,6 +133,7 @@ Generated: <current date>
 ## Gap Reconciliations
 
 ### Gap: <Action Name>
+
 **Reason:** ...
 **Nearest Proxy:** ...
 **Composite Sequence:** ...
@@ -118,9 +142,9 @@ Generated: <current date>
 
 ## Coverage Summary
 
-| Action | Endpoint Match | Match Type | Gaps |
-|---|---|---|---|
-| `actionOne` | `POST /resource` | Direct | None |
+| Action      | Endpoint Match   | Match Type | Gaps |
+| ----------- | ---------------- | ---------- | ---- |
+| `actionOne` | `POST /resource` | Direct     | None |
 ```
 
 ### `endpoint-mapping.json`
@@ -134,9 +158,7 @@ Machine-readable format:
   "configuration": {
     "authType": "<auth method>",
     "authDetails": "<description>",
-    "settings": [
-      { "name": "setting_name", "type": "string", "required": true, "description": "Description" }
-    ]
+    "settings": [{ "name": "setting_name", "type": "string", "required": true, "description": "Description" }]
   },
   "apiOverview": {
     "baseUrl": "<url>",
@@ -161,6 +183,16 @@ Machine-readable format:
       "httpMethod": "POST",
       "endpointUri": "/resource/{id}",
       "matchType": "direct",
+      "batchEndpoint": {
+        "supported": true,
+        "apiOperation": "batchOperationId",
+        "httpMethod": "POST",
+        "endpointUri": "/resource/batch",
+        "sameAsSingle": false,
+        "arrayWrapperKey": "records",
+        "maxRecordsPerRequest": 1000,
+        "notes": "Preferred delivery path; backs performBatch"
+      },
       "fieldMappings": [
         {
           "sourceField": "email",
@@ -179,9 +211,7 @@ Machine-readable format:
     }
   ],
   "gapReconciliations": [],
-  "coverageSummary": [
-    { "action": "actionName", "endpoint": "POST /resource", "matchType": "direct", "hasGap": false }
-  ]
+  "coverageSummary": [{ "action": "actionName", "endpoint": "POST /resource", "matchType": "direct", "hasGap": false }]
 }
 ```
 
@@ -189,10 +219,11 @@ Machine-readable format:
 
 - **ZERO-DROP RULE**: Every action MUST appear in output — no exceptions.
 - **DO NOT** generate TypeScript code — only the mapping analysis.
-- **DO NOT** invent API endpoints not in the spec — flag as a gap.
+- **DO NOT** invent API endpoints not in the spec — flag as a gap. This includes batch endpoints: only record a batch endpoint that actually exists in the spec; if none exists, set `"supported": false`.
 - **DO NOT** skip required API fields.
 - Every field mapping MUST have a transformation type (even if "Direct").
 - Every path parameter MUST have a defined source.
+- Every action MUST have a `batchEndpoint` object. When a real batch/bulk endpoint exists, it is the preferred delivery path and MUST be captured with its array wrapper key and records-per-request limit.
 
 ## Validation Checklist
 
@@ -202,6 +233,7 @@ Machine-readable format:
 - [ ] Every gap has a reconciliation report
 - [ ] Every path parameter has a source
 - [ ] Response handling is defined for each mapping
+- [ ] Every action records a batch endpoint (or explicitly states none exists); when one exists it is flagged as the preferred delivery path with its array wrapper key and record limit
 
 ## Post-Output
 

--- a/.claude/commands/generate-destination.md
+++ b/.claude/commands/generate-destination.md
@@ -69,7 +69,7 @@ The destination goes in `packages/destination-actions/src/destinations/<destinat
 
 > **File-organization rule (do NOT inline everything into the action `index.ts`):**
 >
-> - `constants.ts` — the API base URL, endpoint path constants, and any fixed enums (e.g. allowed action values). Import these into the action instead of hardcoding string literals inline.
+> - `constants.ts` — the API base URL, endpoint path constants (include BOTH the single and batch endpoint paths when a batch endpoint exists), and any fixed enums (e.g. allowed action values). Import these into the action instead of hardcoding string literals inline.
 > - `types.ts` — explicit TypeScript interfaces for **every request body and API response object** the destination sends or receives. Never send an untyped inline object or read an `any` response.
 > - `utils.ts` — the actual "send event" logic and payload transforms (single + batch). The action `index.ts` `perform`/`performBatch` should be thin wrappers that build the typed payload and delegate to a `utils.ts` function.
 >
@@ -162,13 +162,15 @@ Print file listing and summary table of all actions with event types, endpoints,
 
 ### Action Pattern Detection
 
-| Spec Pattern             | Code Pattern                                                       |
-| ------------------------ | ------------------------------------------------------------------ |
-| "upsert"                 | Query API then create/update                                       |
-| Any event-sending action | Implement BOTH `perform` and `performBatch` (see Batching section) |
-| "hash" / "SHA-256"       | `crypto.createHash('sha256')` helper                               |
-| "archive" / "delete"     | PATCH with `{archived: true}` or DELETE                            |
-| "create if not found"    | try/catch with 404 fallback to POST                                |
+| Spec Pattern                         | Code Pattern                                                                                   |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| "upsert"                             | Query API then create/update                                                                   |
+| Any event-sending action             | Implement BOTH `perform` and `performBatch` (see Batching section)                             |
+| Action has a batch/bulk endpoint     | `performBatch` posts the array to the **batch endpoint** (not a loop over the single endpoint) |
+| Single & batch body shapes identical | `perform`/`performBatch` reuse ONE `utils.ts` builder (see "When can they reuse")              |
+| "hash" / "SHA-256"                   | `crypto.createHash('sha256')` helper                                                           |
+| "archive" / "delete"                 | PATCH with `{archived: true}` or DELETE                                                        |
+| "create if not found"                | try/catch with 404 fallback to POST                                                            |
 
 ## Batching (REQUIRED for event-sending actions)
 
@@ -208,7 +210,21 @@ batch_keys: {
 - `batch_keys` groups events that must be sent together (e.g. same list/audience). Use a **low-cardinality** field. Omit `batch_keys` entirely if the API endpoint has no per-group requirement.
 - Keep `batch_size` and `batch_keys` `unsafe_hidden: true` unless the customer genuinely needs control. Only expose `batch_size` with `minimum`/`maximum` when the API documents a records-per-request limit.
 
-**Handler shape** — `perform` and `performBatch` should both delegate to the same `utils.ts` builder so single and batch paths stay consistent:
+### Prefer the batch endpoint for `performBatch`
+
+If the endpoint-mapping / spec identifies a dedicated **batch/bulk endpoint** for an action (see the `batchEndpoint` object in `endpoint-mapping.json`), `performBatch` MUST target that endpoint — not loop the single-record endpoint. Use the mapping's `arrayWrapperKey` to shape the body (root array vs `{ "<key>": [...] }`) and honor `maxRecordsPerRequest` when setting `batch_size` limits.
+
+Decision order for `performBatch`:
+
+1. **Dedicated batch endpoint exists** → post the array (wrapped per `arrayWrapperKey`) to the batch endpoint in a single request. Preferred.
+2. **Single endpoint accepts an array** (`sameAsSingle: true`) → post the array to that same endpoint.
+3. **Only a single-record endpoint exists** → fan out with `Promise.all` over the single endpoint as a fallback, and note in the PR that the API has no native batch endpoint.
+
+Never send a batch to the single-record endpoint when a batch endpoint is available.
+
+### Handler shape — reuse ONE builder when the payloads are identical
+
+`perform` and `performBatch` should delegate to the same `utils.ts` builder **whenever the single and batch request bodies are the same shape** (i.e. the single path is just a batch of one). This is the common case and keeps the two paths from drifting:
 
 ```typescript
 perform: (request, { payload, settings }) => {
@@ -220,7 +236,24 @@ performBatch: (request, { payload, settings }) => {
 }
 ```
 
-Where `sendEvents(request, settings, payloads: Payload[])` lives in `utils.ts`, maps each payload to the typed request body (from `types.ts`), and posts to the endpoint constant (from `constants.ts`).
+Where `sendEvents(request, settings, payloads: Payload[])` lives in `utils.ts`, maps each payload to the typed request body (from `types.ts`), and posts to the batch endpoint constant (from `constants.ts`).
+
+**When can `perform` and `performBatch` reuse the same function?** Reuse a single `payloads: Payload[]` builder when ALL of these hold:
+
+- The single and batch endpoints share the **same request body element shape** (each record serializes identically whether alone or in a batch).
+- The batch endpoint accepts an **array of those same records** (root array or a simple `{ "<key>": [...] }` wrapper) — no per-record fan-out, no different envelope.
+- The single call is semantically "a batch of one" — same auth, same path params (or params derived per-record inside the builder), same response handling.
+
+When these hold, write ONE `sendEvents(request, settings, payloads)` function and have both handlers call it (`perform` with `[payload]`, `performBatch` with `payload`).
+
+**Do NOT force reuse — split into separate functions — when any of these differ:**
+
+- The single endpoint and batch endpoint have **different body shapes or envelopes** that aren't just "wrap the array" (e.g. single is `{ user: {...} }` but batch is `{ operations: [{ method, body }] }`).
+- The batch path requires **per-record metadata** (per-record method/op, per-record path) that the single path doesn't.
+- **No batch endpoint exists** and `performBatch` must fan out over the single endpoint (`Promise.all`) — keep the single-record builder shared and let `performBatch` map over it, rather than pretending it's one call.
+- Response handling or error semantics differ between the two (e.g. batch returns per-record status; single throws directly).
+
+In those cases, still keep both builders in `utils.ts` (e.g. `buildSingleRequest` and `buildBatchRequest`), and have each handler delegate to its own. The goal is: reuse when the shapes are genuinely the same, split cleanly when they aren't — never inline the logic into the action `index.ts`, and never duplicate identical mapping logic across the two handlers.
 
 ## Typed Requests and Responses (REQUIRED)
 
@@ -355,6 +388,8 @@ Adjust the `destinationSlug` constant to match the destination's `slug`. Run the
 - **DO NOT** register a destination ID in `destinations/index.ts` with a placeholder/generated ID — leave registration as a TODO for the production-assigned ID (see Step 6)
 - **DO NOT** collapse `constants.ts` / `types.ts` / `utils.ts` back into the action `index.ts`
 - **DO NOT** skip `performBatch` for event-sending actions unless the API cannot accept multiple records (and say so in the PR)
+- **DO NOT** loop the single-record endpoint in `performBatch` when a dedicated batch endpoint exists — target the batch endpoint
+- **DO NOT** duplicate identical single/batch mapping logic across `perform` and `performBatch` — share ONE `utils.ts` builder when the request shapes match; split into separate builders only when they genuinely differ
 - **DO NOT** send untyped request bodies or read untyped (`any`) responses
 
 ## Quality Checklist
@@ -363,6 +398,8 @@ Adjust the `destinationSlug` constant to match the destination's `slug`. Run the
 - [ ] Every action has fields with proper types and defaults
 - [ ] Every action has a `perform` function hitting the correct endpoint
 - [ ] Every event-sending action implements `performBatch` with `enable_batching` / `batch_size` (+ `batch_keys` if grouping is needed)
+- [ ] `performBatch` targets the dedicated batch endpoint when one exists (single-endpoint fan-out only as a documented fallback)
+- [ ] `perform` and `performBatch` share ONE `utils.ts` builder when request shapes match; split into separate builders only where they genuinely differ (no duplicated mapping logic)
 - [ ] `constants.ts`, `types.ts`, and `utils.ts` exist; endpoint/enums, request+response interfaces, and send logic are separated out
 - [ ] All request bodies and API responses are typed (no inline untyped objects, no `any` responses)
 - [ ] Every action has at least 2 unit tests (happy path + edge case)

--- a/.claude/commands/generate-destination.md
+++ b/.claude/commands/generate-destination.md
@@ -12,11 +12,14 @@ You are a Segment Actions Destination code generator. Given a destination name a
 ## Reference
 
 **You MUST read existing destinations in `packages/destination-actions/src/destinations/` before generating code.** Browse 2-3 similar destinations to understand the current patterns for:
+
 - Root `index.ts` (DestinationDefinition) structure
 - Action `index.ts` (ActionDefinition) structure
 - `generated-types.ts` files
-- `__tests__/index.test.ts` patterns
+- `__tests__/index.test.ts` and `__tests__/snapshot.test.ts` patterns
 - How `extendRequest`, `authentication`, `presets`, and `actions` are wired up
+- **File organization**: hand-written `types.ts`, `constants.ts`, and `utils.ts` at the destination root (e.g. `braze/`, `klaviyo/`, `amazon-amc/`)
+- **Batching**: `performBatch` + `enable_batching` / `batch_size` / `batch_keys` field definitions (e.g. `klaviyo/removeProfileFromList/`, `klaviyo/properties.ts`)
 
 Use the actual repo code as your template — not hardcoded templates.
 
@@ -50,29 +53,55 @@ The destination goes in `packages/destination-actions/src/destinations/<destinat
 ```
 <destination-slug>/
 ├── index.ts                          # Main DestinationDefinition
-├── generated-types.ts                # Settings interface
+├── generated-types.ts                # Settings interface (auto-generated)
+├── constants.ts                      # Base URL, endpoint paths, enums, defaults
+├── types.ts                          # Hand-written request/response interfaces
+├── utils.ts                          # Send-event logic, transforms, batch builders
 ├── <action-kebab-case>/              # One folder per action
-│   ├── index.ts                      # ActionDefinition
-│   ├── generated-types.ts            # Payload interface
+│   ├── index.ts                      # ActionDefinition (perform + performBatch)
+│   ├── generated-types.ts            # Payload interface (auto-generated)
 │   └── __tests__/
 │       └── index.test.ts
 └── __tests__/
-    └── index.test.ts                 # Destination-level tests
+    ├── index.test.ts                 # Destination-level tests
+    └── snapshot.test.ts              # Snapshot tests (all actions, required + all fields)
 ```
+
+> **File-organization rule (do NOT inline everything into the action `index.ts`):**
+>
+> - `constants.ts` — the API base URL, endpoint path constants, and any fixed enums (e.g. allowed action values). Import these into the action instead of hardcoding string literals inline.
+> - `types.ts` — explicit TypeScript interfaces for **every request body and API response object** the destination sends or receives. Never send an untyped inline object or read an `any` response.
+> - `utils.ts` — the actual "send event" logic and payload transforms (single + batch). The action `index.ts` `perform`/`performBatch` should be thin wrappers that build the typed payload and delegate to a `utils.ts` function.
+>
+> For a genuinely trivial single-action destination you may keep `constants.ts`/`types.ts`/`utils.ts` minimal, but they should still exist and hold the endpoint constant, the request/response types, and the send logic respectively — do not collapse them back into the action file.
 
 ### Step 5: Generate Files
 
 Generate in this order:
-1. `generated-types.ts` (root Settings)
-2. `index.ts` (root DestinationDefinition)
-3. For each action: `generated-types.ts`, `index.ts`, `__tests__/index.test.ts`
-4. `__tests__/index.test.ts` (root)
+
+1. `constants.ts` (base URL, endpoint paths, enums, defaults)
+2. `types.ts` (request body + API response interfaces)
+3. `utils.ts` (send-event logic, transforms, batch payload builders — imports from `constants.ts`/`types.ts`)
+4. `generated-types.ts` (root Settings)
+5. `index.ts` (root DestinationDefinition)
+6. For each action: `generated-types.ts`, `index.ts` (thin `perform`/`performBatch` delegating to `utils.ts`), `__tests__/index.test.ts`
+7. `__tests__/index.test.ts` (root)
+8. `__tests__/snapshot.test.ts` (root) — see Snapshot Tests section
 
 Follow the patterns from the destinations you read in Step 1.
 
-### Step 6: Register the Destination
+### Step 6: Do NOT register a destination ID
 
-Add the new destination to `packages/destination-actions/src/index.ts`.
+**Do NOT add a `register('<id>', './<slug>')` line to `packages/destination-actions/src/destinations/index.ts`.**
+
+The metadata ID is a real MongoDB ObjectId assigned when the destination is created in Segment's production control plane, and IDs must match across environments (synced via `sprout`). Inventing a placeholder ID and committing it to the registry is incorrect — it pollutes the shared registry with a fake ID and can collide or break staging sync.
+
+Instead:
+
+- Leave `destinations/index.ts` untouched.
+- In the post-output summary and the PR description, add a clearly-marked **TODO**: "Register this destination in `destinations/index.ts` with the production-assigned metadata ID before merging" and explain that the ID comes from creating the destination in production.
+
+If the user explicitly says they already have a production metadata ID, register with that real ID — never a generated/random one.
 
 ### Step 7: Generate Types
 
@@ -80,7 +109,13 @@ Run `yarn types --path packages/destination-actions/src/destinations/<destinatio
 
 ### Step 8: Validate
 
-Run tests: `yarn cloud jest --testPathPattern="<destination-slug>"`
+Run tests. Note the repo has a Jest version quirk: the `yarn cloud jest` wrapper may resolve to an incompatible root Jest. If you hit a `Cannot read properties of undefined (reading 'bind')` error, run the package-local binary directly instead:
+
+```bash
+cd packages/destination-actions && TZ=UTC ./node_modules/.bin/jest --testPathPattern="<destination-slug>"
+```
+
+Run both the unit tests and the snapshot tests. On first snapshot run, snapshots are written; review the generated `__snapshots__/` output to confirm the request bodies look correct, then commit them.
 
 Print file listing and summary table of all actions with event types, endpoints, field counts.
 
@@ -88,52 +123,216 @@ Print file listing and summary table of all actions with event types, endpoints,
 
 ### Authentication
 
-| Spec Auth Type | Code Pattern |
-|---|---|
-| OAuth 2.0 | `scheme: 'oauth2'` with `refreshAccessToken` |
-| API Key | `scheme: 'custom'` with key in `fields` |
-| Basic Auth | `scheme: 'basic'` with username/password |
+| Spec Auth Type | Code Pattern                                 |
+| -------------- | -------------------------------------------- |
+| OAuth 2.0      | `scheme: 'oauth2'` with `refreshAccessToken` |
+| API Key        | `scheme: 'custom'` with key in `fields`      |
+| Basic Auth     | `scheme: 'basic'` with username/password     |
 
 ### Event Types
 
-| Spec Event | `defaultSubscription` |
-|---|---|
-| identify | `'type = "identify"'` |
-| track | `'type = "track"'` |
-| track + identify | `'type = "track" or type = "identify"'` |
+| Spec Event             | `defaultSubscription`                       |
+| ---------------------- | ------------------------------------------- |
+| identify               | `'type = "identify"'`                       |
+| track                  | `'type = "track"'`                          |
+| track + identify       | `'type = "track" or type = "identify"'`     |
 | track (specific event) | `'type = "track" and event = "Event Name"'` |
 
 ### Field Types
 
-| Spec Type | Actions Field Type |
-|---|---|
-| String / Email / Phone / URL / Select | `type: 'string'` |
-| Number / Integer | `type: 'number'` |
-| Boolean | `type: 'boolean'` |
-| Date / DateTime | `type: 'datetime'` |
-| Object / JSON | `type: 'object'` |
-| Array of objects | `type: 'object'` with `multiple: true` |
+| Spec Type                             | Actions Field Type                     |
+| ------------------------------------- | -------------------------------------- |
+| String / Email / Phone / URL / Select | `type: 'string'`                       |
+| Number / Integer                      | `type: 'number'`                       |
+| Boolean                               | `type: 'boolean'`                      |
+| Date / DateTime                       | `type: 'datetime'`                     |
+| Object / JSON                         | `type: 'object'`                       |
+| Array of objects                      | `type: 'object'` with `multiple: true` |
 
 ### Default Paths
 
-| Segment Field | `@path` Expression |
-|---|---|
-| traits.* | `'$.traits.<field>'` |
-| properties.* | `'$.properties.<field>'` |
-| userId | `'$.userId'` |
-| anonymousId | `'$.anonymousId'` |
-| event | `'$.event'` |
-| timestamp | `'$.timestamp'` |
+| Segment Field | `@path` Expression       |
+| ------------- | ------------------------ |
+| traits.\*     | `'$.traits.<field>'`     |
+| properties.\* | `'$.properties.<field>'` |
+| userId        | `'$.userId'`             |
+| anonymousId   | `'$.anonymousId'`        |
+| event         | `'$.event'`              |
+| timestamp     | `'$.timestamp'`          |
 
 ### Action Pattern Detection
 
-| Spec Pattern | Code Pattern |
-|---|---|
-| "upsert" | Query API then create/update |
-| "batch" / "bulk" | `performBatch` with chunking |
-| "hash" / "SHA-256" | `crypto.createHash('sha256')` helper |
-| "archive" / "delete" | PATCH with `{archived: true}` or DELETE |
-| "create if not found" | try/catch with 404 fallback to POST |
+| Spec Pattern             | Code Pattern                                                       |
+| ------------------------ | ------------------------------------------------------------------ |
+| "upsert"                 | Query API then create/update                                       |
+| Any event-sending action | Implement BOTH `perform` and `performBatch` (see Batching section) |
+| "hash" / "SHA-256"       | `crypto.createHash('sha256')` helper                               |
+| "archive" / "delete"     | PATCH with `{archived: true}` or DELETE                            |
+| "create if not found"    | try/catch with 404 fallback to POST                                |
+
+## Batching (REQUIRED for event-sending actions)
+
+Every action that sends events/records to an API MUST implement batching unless the API genuinely has no way to accept more than one record per call (rare — confirm before skipping, and note it in the PR if you do).
+
+**Note:** Segment's platform does the actual chunking before calling `performBatch` — you do NOT implement chunking logic. You implement the field declarations and a `performBatch` handler that sends an array.
+
+**Field declarations** (add to the action's `fields`, mirroring `klaviyo/properties.ts`):
+
+```typescript
+enable_batching: {
+  type: 'boolean',
+  label: 'Batch Data',
+  description: 'When enabled, sends events to the API in batches.',
+  default: true
+},
+batch_size: {
+  label: 'Batch Size',
+  description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+  type: 'number',
+  required: false,
+  unsafe_hidden: true,
+  default: 1000
+  // add minimum/maximum only if the API documents record-count limits
+},
+batch_keys: {
+  label: 'Batch Keys',
+  description: 'The keys to use for batching the events.',
+  type: 'string',
+  unsafe_hidden: true,
+  required: false,
+  multiple: true,
+  default: ['<low-cardinality-grouping-field>']  // e.g. ['list_id'] — omit if not needed
+}
+```
+
+- `batch_keys` groups events that must be sent together (e.g. same list/audience). Use a **low-cardinality** field. Omit `batch_keys` entirely if the API endpoint has no per-group requirement.
+- Keep `batch_size` and `batch_keys` `unsafe_hidden: true` unless the customer genuinely needs control. Only expose `batch_size` with `minimum`/`maximum` when the API documents a records-per-request limit.
+
+**Handler shape** — `perform` and `performBatch` should both delegate to the same `utils.ts` builder so single and batch paths stay consistent:
+
+```typescript
+perform: (request, { payload, settings }) => {
+  return sendEvents(request, settings, [payload])
+},
+performBatch: (request, { payload, settings }) => {
+  // payload is an array here
+  return sendEvents(request, settings, payload)
+}
+```
+
+Where `sendEvents(request, settings, payloads: Payload[])` lives in `utils.ts`, maps each payload to the typed request body (from `types.ts`), and posts to the endpoint constant (from `constants.ts`).
+
+## Typed Requests and Responses (REQUIRED)
+
+Do NOT build inline untyped objects or read `any` responses. In `types.ts`, define an interface for **every** request body and API response shape, then use them:
+
+```typescript
+// types.ts
+export interface ConversionEventRequest {
+  eid: string
+  a: string
+  aid: string
+  ts: number
+  // ...
+}
+
+export interface ConversionEventResponse {
+  status: string
+  id?: string
+}
+```
+
+```typescript
+// utils.ts
+import type { ConversionEventRequest, ConversionEventResponse } from './types'
+
+export function sendEvents(request: RequestClient, settings: Settings, payloads: Payload[]) {
+  const body: ConversionEventRequest[] = payloads.map((p) => ({
+    /* typed mapping */
+  }))
+  return request<ConversionEventResponse>(ENDPOINT, { method: 'POST', json: body })
+}
+```
+
+- The request body variable must be annotated with the request interface.
+- Type the `request<ResponseType>(...)` call with the response interface so `response.data` is typed.
+
+## Snapshot Tests (REQUIRED)
+
+In addition to `__tests__/index.test.ts` (happy path + edge cases), generate `__tests__/snapshot.test.ts` following the repo convention (see `trackey`, `metronome`, `movable-ink`). It uses the shared `generateTestData` helper, loops over every action, and snapshots the request body for both "required fields" and "all fields":
+
+```typescript
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-<slug>'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({ properties: eventData })
+      const responses = await testDestination.testAction(actionSlug, {
+        event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({ properties: eventData })
+      const responses = await testDestination.testAction(actionSlug, {
+        event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})
+```
+
+Adjust the `destinationSlug` constant to match the destination's `slug`. Run the suite once to generate `__snapshots__/`, review it, and commit the snapshots.
 
 ## Code Style Rules
 
@@ -143,25 +342,34 @@ Print file listing and summary table of all actions with event types, endpoints,
 - Use `json` option on request (not `body: JSON.stringify(...)`)
 - Action names: `camelCase` in code, `kebab-case` for folders
 - Always `export default` for actions and destination
-- Shared helpers go in a root-level utility file
+- Endpoint URLs and fixed enums live in `constants.ts` — never hardcode string literals inline
+- Request bodies and API responses are typed via interfaces in `types.ts` — never inline untyped objects or `any` responses
+- Send/transform/batch logic lives in `utils.ts`; `perform`/`performBatch` are thin wrappers
 - Follow error handling patterns from `packages/core/src/errors.ts`
 
 ## Constraints
 
 - **DO NOT** use hardcoded templates — read the actual repo for patterns
 - **DO NOT** hardcode credentials or secrets
-- **DO NOT** skip tests — every action needs at least 2 tests (happy path + edge case)
-- **DO NOT** skip registering the destination in the index
+- **DO NOT** skip tests — every action needs at least 2 unit tests (happy path + edge case) PLUS snapshot tests
+- **DO NOT** register a destination ID in `destinations/index.ts` with a placeholder/generated ID — leave registration as a TODO for the production-assigned ID (see Step 6)
+- **DO NOT** collapse `constants.ts` / `types.ts` / `utils.ts` back into the action `index.ts`
+- **DO NOT** skip `performBatch` for event-sending actions unless the API cannot accept multiple records (and say so in the PR)
+- **DO NOT** send untyped request bodies or read untyped (`any`) responses
 
 ## Quality Checklist
 
 - [ ] All actions from the spec are implemented
 - [ ] Every action has fields with proper types and defaults
 - [ ] Every action has a `perform` function hitting the correct endpoint
-- [ ] Every action has at least 2 tests
+- [ ] Every event-sending action implements `performBatch` with `enable_batching` / `batch_size` (+ `batch_keys` if grouping is needed)
+- [ ] `constants.ts`, `types.ts`, and `utils.ts` exist; endpoint/enums, request+response interfaces, and send logic are separated out
+- [ ] All request bodies and API responses are typed (no inline untyped objects, no `any` responses)
+- [ ] Every action has at least 2 unit tests (happy path + edge case)
+- [ ] `__tests__/snapshot.test.ts` exists and snapshots are generated + reviewed
 - [ ] Root `index.ts` imports and registers all actions
 - [ ] `generated-types.ts` files match field definitions
-- [ ] Destination is registered in `packages/destination-actions/src/index.ts`
+- [ ] Destination is NOT registered with a placeholder ID in `destinations/index.ts` (registration left as a TODO for the production ID)
 - [ ] Tests pass
 - [ ] No hardcoded credentials or secrets
 
@@ -172,11 +380,13 @@ After generating all files, print a summary:
 ```
 Destination generated for <Destination Name>
    Location: packages/destination-actions/src/destinations/<slug>/
-   Actions: <count>
-   Tests: <count>
-   Registered in index: Yes
+   Actions: <count> (batching: <enabled/reason-if-not>)
+   Files: constants.ts, types.ts, utils.ts, index.ts + per-action folders
+   Unit tests: <count>   Snapshot tests: generated for <count> actions
+   Registered in index: NO — TODO: add register('<PROD_METADATA_ID>', './<slug>') once the
+                        destination is created in production (ID must match across environments)
 
 To verify:
    yarn types --path packages/destination-actions/src/destinations/<slug>
-   yarn cloud jest --testPathPattern="<slug>"
+   cd packages/destination-actions && TZ=UTC ./node_modules/.bin/jest --testPathPattern="<slug>"
 ```

--- a/.claude/skills/QUICK_START.md
+++ b/.claude/skills/QUICK_START.md
@@ -1,5 +1,21 @@
 # Quick Start Guide - Destination Generator Skills
 
+## Fastest path: `/orchestrate` (recommended)
+
+Run the whole pipeline with one command and just answer the prompts:
+
+```
+/orchestrate <destination-name>
+```
+
+You'll be asked for the **API source** (a docs URL, an OpenAPI spec path, or a PRD) and an **output directory** (default `/tmp/<slug>/`). The orchestrator then runs all 7 steps — refine → map → spec → generate → local e2e → deploy staging → staging e2e — pausing for your review between each.
+
+```
+refined-actions → endpoint-mapping → final-spec → code → local e2e → deploy → staging e2e
+```
+
+Use the step-by-step paths below if you'd rather drive each skill yourself.
+
 ## Choose Your Path
 
 ### Path A: I have an OpenAPI specification ✅
@@ -212,6 +228,11 @@ your-destination/
 
 | File                                                      | Purpose                          |
 | --------------------------------------------------------- | -------------------------------- |
+| `.claude/commands/orchestrate.md`                         | End-to-end pipeline orchestrator |
+| `.claude/commands/refined-actions.md`                     | Step 1 — PRD → refined actions   |
+| `.claude/commands/endpoint-mapping.md`                    | Step 2 — actions → endpoints     |
+| `.claude/commands/spec-generator.md`                      | Step 3 — mapping → spec doc      |
+| `.claude/commands/generate-destination.md`                | Step 4 — spec → code + tests     |
 | `.claude/skills/README.md`                                | Full documentation               |
 | `.claude/skills/QUICK_START.md`                           | This file                        |
 | `.claude/skills/openapi-analyze/SKILL.md`                 | OpenAPI analysis skill           |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,6 +1,43 @@
 # Destination Generator Skills
 
-This directory contains skills that automate the creation of Segment action-destinations from various sources (OpenAPI specs, website documentation, etc.).
+This directory contains skills that automate the creation of Segment action-destinations from various sources (OpenAPI specs, website documentation, PRDs, etc.).
+
+## 🚀 Start here: `/orchestrate` (the one-command pipeline)
+
+The fastest way to build a destination is the **`/orchestrate`** command. It runs the entire pipeline end-to-end — analysis → mapping → spec → code → tests → deploy → staging tests — pausing for your review between steps and passing outputs between skills for you.
+
+```
+/orchestrate <destination-name>
+```
+
+**Example:**
+
+```
+/orchestrate Vibe Actions
+```
+
+**What it does (7 steps):**
+
+| Step              | Skill                   | Output                                                          |
+| ----------------- | ----------------------- | --------------------------------------------------------------- |
+| 1. Refine         | `/refined-actions`      | `refined-actions.md` / `.json`                                  |
+| 2. Map            | `/endpoint-mapping`     | `endpoint-mapping.md` / `.json`                                 |
+| 3. Spec           | `/spec-generator`       | `final-spec.md`                                                 |
+| 4. Generate       | `/generate-destination` | code in `packages/destination-actions/src/destinations/<slug>/` |
+| 5. Test (local)   | `/test-destination-e2e` | local e2e results                                               |
+| 6. Deploy         | `/deploy-staging`       | staging deploy                                                  |
+| 7. Test (staging) | `/test-destination-e2e` | staging e2e results                                             |
+
+**How to use it:**
+
+1. Type `/orchestrate <destination-name>` in Claude Code.
+2. When asked, provide the **API source** — a docs URL, an OpenAPI spec path, or a PRD/markdown doc.
+3. Confirm (or change) the **output directory** for intermediate files (default `/tmp/<slug>/`).
+4. Review each step's output when the orchestrator pauses, and approve to continue.
+
+The orchestrator asks questions only a human can answer (scope, ambiguous mappings), answers what it can from prior outputs, and remembers where it left off if interrupted. Everything intermediate is written to the output directory so nothing is lost between steps.
+
+> Prefer running the pipeline yourself step-by-step, or only have an OpenAPI spec / website? The individual skills below still work standalone.
 
 ## Overview
 
@@ -15,8 +52,8 @@ Building a new Segment destination typically involves:
 
 These skills automate 70-80% of this process by:
 
-1. Analyzing API documentation (OpenAPI specs or websites) to identify suitable actions
-2. Generating TypeScript destination code with proper types and tests
+1. Analyzing API documentation (OpenAPI specs, websites, or PRDs) to identify suitable actions
+2. Generating TypeScript destination code with proper types, batching, and tests
 
 ## Skills
 
@@ -226,18 +263,29 @@ When prompted:
 ```
 packages/destination-actions/src/destinations/[slug]/
 ├── index.ts                       # Destination definition
-├── generated-types.ts             # Auto-generated TypeScript types
-├── IMPLEMENTATION_NOTES.md        # TODOs and next steps
+├── generated-types.ts             # Auto-generated Settings types
+├── constants.ts                   # Base URL, endpoint paths, enums
+├── types.ts                       # Hand-written request/response interfaces
+├── utils.ts                       # Send-event logic, transforms, batch builders
 ├── __tests__/
-│   └── index.test.ts             # Destination tests
+│   ├── index.test.ts             # Destination tests
+│   └── snapshot.test.ts          # Snapshot tests (loops all actions)
 ├── [action-1]/
-│   ├── index.ts                  # Action definition
-│   ├── generated-types.ts        # Action types
+│   ├── index.ts                  # Action definition (perform + performBatch)
+│   ├── generated-types.ts        # Action payload types
 │   └── __tests__/
 │       └── index.test.ts         # Action tests
 └── [action-2]/
     └── ... (same structure)
 ```
+
+> **Conventions enforced by `/generate-destination`:**
+>
+> - Endpoints/enums in `constants.ts`, request+response interfaces in `types.ts`, send logic in `utils.ts` — not inlined into the action.
+> - Event-sending actions implement **`performBatch`** with `enable_batching` / `batch_size` (+ `batch_keys` when grouping is needed).
+> - All request bodies and API responses are **typed** (no inline untyped objects, no `any` responses).
+> - **Snapshot tests** are generated alongside unit tests.
+> - The destination is **not** registered in `destinations/index.ts` with a placeholder ID — registration is left as a TODO for the production-assigned metadata ID (IDs must match across environments, created in production and synced via `sprout`).
 
 ## What Gets Automated
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For more detailed instruction, see the following READMEs:
 
 ## Table of Contents:
 
+- [Generate a Destination with Claude Code](#generate-a-destination-with-claude-code)
 - [Get Started](#get-started)
 - [Actions CLI](#actions-cli)
 - [Example Destination](#example-destination)
@@ -35,6 +36,31 @@ For more detailed instruction, see the following READMEs:
 - [Action Hooks](#action-hooks)
 - [HTTP Requests](#http-requests)
 - [Support](#support)
+
+## Generate a Destination with Claude Code
+
+If you use [Claude Code](https://claude.com/claude-code), this repo ships skills that scaffold a full destination for you — from API docs to working code and tests.
+
+The simplest way is the one-command pipeline. Just run:
+
+```
+/orchestrate <Destination Name>
+```
+
+Then provide your **API source** (a docs URL, an OpenAPI spec, or a PRD) when prompted. It walks through every step — analyzing the API, mapping actions to endpoints, writing the code, and generating tests — pausing for your review along the way.
+
+Prefer to run one step at a time? These skills also work on their own:
+
+| Command                 | What it does                                    |
+| ----------------------- | ----------------------------------------------- |
+| `/refined-actions`      | Turn a PRD or API docs into a list of actions   |
+| `/endpoint-mapping`     | Map those actions to API endpoints and fields   |
+| `/spec-generator`       | Produce a full destination spec document        |
+| `/generate-destination` | Generate the destination code, types, and tests |
+
+📖 See [`.claude/skills/README.md`](./.claude/skills/README.md) and [`.claude/skills/QUICK_START.md`](./.claude/skills/QUICK_START.md) for details.
+
+> These skills accelerate the boilerplate — always review the generated code and follow the [Contributing Guide](./CONTRIBUTING.md) before opening a PR.
 
 ## Get started
 


### PR DESCRIPTION
## Summary

Updates the Claude Code destination-generator **skills** and their docs. No product/destination code changes — this is tooling + documentation only (`.claude/` skills and READMEs).

Three things:

1. **Encodes real PR-review feedback into the `/generate-destination` skill** so future generated destinations follow repo conventions by default.
2. **Adds batch-endpoint awareness across `/endpoint-mapping` and `/generate-destination`** — the mapping now identifies a dedicated batch/bulk endpoint per action, and code generation prefers it for `performBatch` and reuses one builder when single/batch shapes match.
3. **Documents the `/orchestrate` one-command pipeline** for end users (root README + skills README/QUICK_START).

All patterns were verified against existing destinations in the repo (`klaviyo`, `reddit-conversions-api`, `iterable`, `ms-bing-capi`, `s3`, `trackey`) before being written into the skill.

## Feedback incorporated into `generate-destination.md`

| # | Feedback | Change |
|---|----------|--------|
| 1 | Enable batching with `batch_keys` + implement `performBatch` | New **Batching (REQUIRED)** section: `enable_batching` / `batch_size` / `batch_keys` field defs + `perform`/`performBatch` delegating to a shared `utils.ts` helper. Added to constraints & checklist. |
| 2 | Avoid registering the destination ID in `destinations/index.ts` | **Step 6** rewritten to "Do NOT register a destination ID" — leave the registry untouched and record it as a PR TODO for the production-assigned metadata ID (IDs must match across environments, synced via `sprout`). |
| 3 | Every request/response object should be typed | New **Typed Requests and Responses (REQUIRED)** section: interfaces in `types.ts`, annotated request bodies, `request<ResponseType>(...)`. |
| 4 | Separate `types.ts`, `constants.ts`, `utils.ts` for send logic | Updated folder structure + file-generation order + a file-organization rule (endpoints/enums → `constants.ts`, interfaces → `types.ts`, send logic → `utils.ts`; actions are thin wrappers). |
| 5 | Snapshot tests were missing | New **Snapshot Tests (REQUIRED)** section with the shared `generateTestData` boilerplate; `snapshot.test.ts` added to structure & checklist. |

Also fixed the documented test command to use the package-local Jest binary (avoids the root Jest 30 `bind` crash).

## Batch-endpoint awareness (new)

### `endpoint-mapping.md` — identify and prefer batch endpoints
- **Phase 2** gains a "Prefer a batch/bulk endpoint when one exists" subsection: signals for detecting batch endpoints (`batch`/`bulk`/`import` in path, array request bodies, wrapper keys like `{ "records": [...] }`, documented per-request limits), and a preference rule to record both single and batch endpoints per action.
- Markdown output template gains a **Batch Endpoint** line per action; JSON schema gains a `batchEndpoint` object (`supported`, operation, method, uri, `sameAsSingle`, `arrayWrapperKey`, `maxRecordsPerRequest`, notes).
- Constraints + validation checklist require every action to record a batch endpoint (or explicitly state none exists), and forbid inventing one not in the spec.

### `generate-destination.md` — prefer the batch endpoint + detect `perform`/`performBatch` reuse
- New **"Prefer the batch endpoint for `performBatch`"** section: 3-step decision order (dedicated batch endpoint → single endpoint accepting an array → single-endpoint `Promise.all` fallback, documented in the PR). Never batch to the single-record endpoint when a batch endpoint exists.
- New **"When can `perform` and `performBatch` reuse the same function?"** guidance: reuse ONE `utils.ts` builder when the single/batch body shapes match and the single call is "a batch of one"; split into separate builders when envelopes differ, per-record metadata is needed, fan-out is required, or response semantics differ.
- Action Pattern Detection table, Constraints, Quality Checklist, and `constants.ts` guidance all updated to reinforce both rules.

## `/orchestrate` documentation

- **Root `README.md`** — new concise, end-user-facing "Generate a Destination with Claude Code" section (+ TOC entry).
- **`.claude/skills/README.md`** — "🚀 Start here: `/orchestrate`" section with the 7-step pipeline and conventions callout.
- **`.claude/skills/QUICK_START.md`** — `/orchestrate` fastest-path at the top + pipeline commands in the file-locations table.

## Files changed

- `.claude/commands/endpoint-mapping.md`
- `.claude/commands/generate-destination.md`
- `.claude/skills/README.md`
- `.claude/skills/QUICK_START.md`
- `README.md`

## Testing

Docs/skill-definition changes only — no runtime code affected. All patterns cross-checked against existing destinations for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
