### PR TITLE
Fix SFMC Async Action Description

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -6,9 +6,7 @@ import { getDataExtensionFields, asyncUpsertRowsV2 } from '../sfmc-operations'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event asynchronously to Data Extension',
-  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.
-  
-    Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future`,
+  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud. Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future`,
   fields: {
     keys: { ...keys, required: true, dynamic: true },
     values: { ...values_dataExtensionFields, dynamic: true },

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
@@ -3219,7 +3219,7 @@
     },
     "asyncDataExtension": {
       "title": "Send Event asynchronously to Data Extension",
-      "description": "Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.\n  \n    Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future",
+      "description": "Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud. Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future",
       "platform": "cloud",
       "defaultSubscription": null,
       "hidden": false,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

This PR removes the extra new line characters from the SFMC async action description.

Before fix
<img width="1065" height="622" alt="image" src="https://github.com/user-attachments/assets/d1287b25-7060-4b80-b18c-d390bc875b09" />

After Fix
<img width="2559" height="1325" alt="image" src="https://github.com/user-attachments/assets/9c8dcab7-08cf-47cf-a621-ae391689cdbb" />

Linked Audience Create Activation flow
<img width="1679" height="1109" alt="image" src="https://github.com/user-attachments/assets/65194842-fdd3-4ec9-a7a5-f9723645a31b" />



## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
