### PR TITLE
Publish: OIDC single-package test (action-destinations 3.495.0)

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.494.0",
+  "version": "3.495.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",


### PR DESCRIPTION
Smoke test of keyless OIDC publishing. Bumps only @segment/action-destinations so from-package publishes exactly one package.