### PR TITLE
[Pinterest CAPI] Accept phone as a valid identifier in reportConversionEvent

### DIFF
--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PinterestConversionApi ReportConversionEvent Should send an event to pinterest successfully when user data only has a phone number 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "action_source": "web",
+      "app_id": undefined,
+      "app_name": "InitechGlobal",
+      "app_version": "545",
+      "custom_data": Object {
+        "content_ids": undefined,
+        "contents": undefined,
+        "currency": undefined,
+        "num_items": undefined,
+        "opt_out_type": undefined,
+        "order_id": undefined,
+        "search_string": undefined,
+        "value": undefined,
+      },
+      "device_brand": undefined,
+      "device_carrier": undefined,
+      "device_model": "iPhone7,2",
+      "device_type": "ios",
+      "event_id": "test-message-rocnz07d5e8",
+      "event_name": "checkout",
+      "event_source_url": "https://segment.com/academy/",
+      "event_time": 1678694183,
+      "language": undefined,
+      "opt_out": true,
+      "os_version": "8.1.3",
+      "partner_name": "ss-segment",
+      "user_data": Object {
+        "click_id": undefined,
+        "client_ip_address": undefined,
+        "client_user_agent": undefined,
+        "country": undefined,
+        "ct": undefined,
+        "db": undefined,
+        "em": undefined,
+        "external_id": undefined,
+        "fn": undefined,
+        "ge": undefined,
+        "hashed_maids": undefined,
+        "ln": undefined,
+        "partner_id": undefined,
+        "ph": Array [
+          "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+        ],
+        "st": undefined,
+        "zp": undefined,
+      },
+      "wifi": undefined,
+    },
+  ],
+}
+`;
+
 exports[`PinterestConversionApi ReportConversionEvent Should send an event to pinterest successfully,if user data have either of email,hashed_maids or both client_ip_address and client_user_agent 1`] = `
 Object {
   "data": Array [

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/__tests__/index.test.ts
@@ -141,6 +141,28 @@ describe('PinterestConversionApi', () => {
       )
     })
 
+    it('Should send an event to pinterest successfully when user data only has a phone number', async () => {
+      nock(`https://api.pinterest.com`)
+        .post(`/${API_VERSION}/ad_accounts/${authData.ad_account_id}/events`)
+        .reply(200, {})
+
+      const responses = await testDestination.testAction('reportConversionEvent', {
+        event,
+        settings: authData,
+        useDefaultMappings: true,
+        mapping: {
+          event_name: 'checkout',
+          user_data: {
+            phone: ['123456789']
+          }
+        }
+      })
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(JSON.parse(responses[0]?.options?.body as string)?.data?.length).toBe(1)
+      expect(responses[0].options.json).toMatchSnapshot()
+    })
+
     it('Should send an signup event to pinterest successfully,if user data have either of email,hashed_maids or both client_ip_address and client_user_agent', async () => {
       nock(`https://api.pinterest.com`)
         .post(`/${API_VERSION}/ad_accounts/${authData.ad_account_id}/events`)

--- a/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/index.ts
+++ b/packages/destination-actions/src/destinations/pinterest-conversions/reportConversionEvent/index.ts
@@ -168,6 +168,7 @@ const action: ActionDefinition<Settings, Payload> = {
 async function processPayload(request: RequestClient, settings: Settings, payload: Payload) {
   if (
     isEmpty(payload.user_data?.email) &&
+    isEmpty(payload.user_data?.phone) &&
     isEmpty(payload.user_data?.hashed_maids) &&
     !(payload.user_data?.client_ip_address && payload.user_data?.client_user_agent)
   ) {


### PR DESCRIPTION
## What changed
The `processPayload` identifier guard in `reportConversionEvent/index.ts` rejected events whose only match key was `user_data.phone`, even though the error message it throws explicitly advertises "Phone Number" as an acceptable identifier — and phone is already hashed and sent downstream to Pinterest as `ph` (a first-class Pinterest CAPI match key).

This PR adds `isEmpty(payload.user_data?.phone)` to the accepted-identifier check (the recommended fix from the ticket), so validation behavior now matches the error message: an event with only a phone number is accepted and sent to Pinterest instead of being rejected with a misleading 400.

## Why
Customers relying on phone as their sole match key were getting an unexpected `Misconfigured required field` 400 error, despite the error message telling them phone alone was sufficient. Since Pinterest CAPI treats hashed phone (`ph`) as a first-class match key and the destination already transmits it, accepting phone as a standalone identifier is the correct fix (per the ticket's recommended approach).

## Subtasks addressed
- STRATCONN-6900: Add phone to reportConversionEvent identifier validation guard

(Parent: STRATCONN-6898)

## Testing
- Added a new unit test: "Should send an event to pinterest successfully when user data only has a phone number" — verifies a phone-only payload is accepted, hashed, and sent as `ph`.
- Updated snapshot confirms the hashed phone number is included in the outgoing `user_data.ph` field.
- Existing error-message test (no identifiers at all) remains green — message and behavior are now consistent.
- Ran `TZ=UTC jest --testPathPattern="pinterest-conversions"`: 2 suites, 10 tests, all passing.
- Ran lint against changed files: no errors.
- Ran `yarn types --path packages/destination-actions/src/destinations/pinterest-conversions/**`: no generated-type changes needed (only validation logic changed, no field schema changes).