### PR TITLE
Fix partial-failure index misattribution on mixed add/remove userList batches

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
@@ -1490,6 +1490,174 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
+    it('correctly attributes a Google partialFailureError to the right original payload index on a mixed add/remove batch (STRATCONN-6862)', async () => {
+      // Batch layout:
+      //   index 0 - add (Audience Entered)      -> succeeds
+      //   index 1 - remove (Audience Exited)     -> succeeds
+      //   index 2 - remove (Audience Exited)     -> the one Google actually fails (removes-only call, failedIndex = 1)
+      //   index 3 - add (Audience Entered)       -> invalid email, fails client-side validation before any API call
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            email: 'test.add@example.com'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Exited',
+          properties: {
+            email: 'test.remove1@example.com'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Exited',
+          properties: {
+            email: 'test.remove2@example.com'
+          }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Audience Entered',
+          properties: {
+            email: 'invalid_email'
+          }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(200, { resourceName: 'customers/1234/userLists/1234' })
+
+      // adds-only call - single valid operation, succeeds with no partial failure
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/userLists/1234:addOperations`)
+        .post(/.*/, (body: Record<string, unknown>) => {
+          const operations = body.operations as Array<Record<string, unknown>>
+          return operations.every((op) => 'create' in op && !('remove' in op))
+        })
+        .reply(200, {})
+
+      // removes-only call - two operations, Google fails the 2nd one (failedIndex = 1 within THIS call),
+      // which corresponds to original payload index 2, NOT index 1.
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/userLists/1234:addOperations`)
+        .post(/.*/, (body: Record<string, unknown>) => {
+          const operations = body.operations as Array<Record<string, unknown>>
+          return operations.every((op) => 'remove' in op && !('create' in op))
+        })
+        .reply(200, {
+          partialFailureError: {
+            code: 3,
+            message: 'Mocking Partial Failure Error',
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.ads.googleads.v21.errors.GoogleAdsFailure',
+                errors: [
+                  {
+                    errorCode: {
+                      offlineUserDataJobError: 'INVALID_SHA256_FORMAT'
+                    },
+                    message: 'The SHA256 encoded value is malformed.',
+                    location: {
+                      fieldPathElements: [
+                        {
+                          fieldName: 'operations',
+                          index: 1
+                        },
+                        {
+                          fieldName: 'remove'
+                        },
+                        {
+                          fieldName: 'user_identifiers',
+                          index: 0
+                        },
+                        {
+                          fieldName: 'hashed_email'
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/userLists/1234:run`)
+        .post(/.*/)
+        .reply(200, { done: true })
+
+      const responses = await testDestination.executeBatch('userList', {
+        events,
+        mapping,
+        settings: {
+          customerId
+        }
+      })
+
+      // index 0 - add - succeeds
+      expect(responses[0]).toMatchObject({
+        status: 200,
+        sent: '/customers/1234/userLists/1234:run',
+        body: { done: true }
+      })
+
+      // index 1 - remove - succeeds (this is the payload the pre-fix bug would have incorrectly failed)
+      expect(responses[1]).toMatchObject({
+        status: 200,
+        sent: '/customers/1234/userLists/1234:run',
+        body: { done: true }
+      })
+
+      // index 2 - remove - the actual failing payload; must carry the partial failure error and its own sent/body
+      expect(responses[2]).toMatchObject({
+        status: 400,
+        errortype: 'BAD_REQUEST',
+        errormessage: 'The SHA256 encoded value is malformed.',
+        sent: {
+          remove: {
+            userIdentifiers: [
+              {
+                hashedEmail: '867cda0232be295cb81c3e98a175b80083e309d941295311bfde52720ea053e5'
+              }
+            ]
+          }
+        },
+        body: {
+          errorCode: { offlineUserDataJobError: 'INVALID_SHA256_FORMAT' },
+          message: 'The SHA256 encoded value is malformed.',
+          location: {
+            fieldPathElements: [
+              {
+                fieldName: 'operations',
+                index: 1
+              },
+              {
+                fieldName: 'remove'
+              },
+              {
+                fieldName: 'user_identifiers',
+                index: 0
+              },
+              {
+                fieldName: 'hashed_email'
+              }
+            ]
+          }
+        },
+        errorreporter: 'DESTINATION'
+      })
+
+      // index 3 - invalid email - client-side validation error, unaffected by the API partial failure path
+      expect(responses[3]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format.",
+        errorreporter: 'INTEGRATIONS'
+      })
+    })
+
     it('should successfully handle a batch of events where email is invalid or missing data for CONTACT_INFO', async () => {
       nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
         .post(/.*/)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -917,6 +917,12 @@ const extractBatchUserIdentifiers = (
   const removeUserIdentifiers: any[] = []
   const addUserIdentifiers: any[] = []
   const validPayloadIndicesBitmap: number[] = []
+  // Track each subset's position -> original payload index, so that a Google
+  // partialFailureError's failedIndex (relative to a single addOperations call)
+  // can be resolved back to the correct original payload index, even when a
+  // batch contains a mix of add and remove operations sent as separate calls.
+  const addPayloadIndices: number[] = []
+  const removePayloadIndices: number[] = []
 
   //Identify the user identifiers based on the idType
   const extractors = createIdentifierExtractors(features)
@@ -956,12 +962,20 @@ const extractBatchUserIdentifiers = (
     validPayloadIndicesBitmap.push(index)
     if (operationType === 'add') {
       addUserIdentifiers.push({ create: { userIdentifiers } })
+      addPayloadIndices.push(index)
     } else {
       removeUserIdentifiers.push({ remove: { userIdentifiers } })
+      removePayloadIndices.push(index)
     }
   })
 
-  return { addUserIdentifiers, removeUserIdentifiers, validPayloadIndicesBitmap }
+  return {
+    addUserIdentifiers,
+    removeUserIdentifiers,
+    validPayloadIndicesBitmap,
+    addPayloadIndices,
+    removePayloadIndices
+  }
 }
 
 // Helper function to determine operation type
@@ -1014,13 +1028,13 @@ export const processBatchPayload = async (
   const multiStatusResponse = new MultiStatusResponse()
   const id_type = hookListType ?? audienceSettings.external_id_type
   // Extract user identifiers and validPayloadIndicesBitmap from payloads
-  const { addUserIdentifiers, removeUserIdentifiers, validPayloadIndicesBitmap } = extractBatchUserIdentifiers(
-    payloads,
-    id_type,
-    multiStatusResponse,
-    syncMode,
-    features
-  )
+  const {
+    addUserIdentifiers,
+    removeUserIdentifiers,
+    validPayloadIndicesBitmap,
+    addPayloadIndices,
+    removePayloadIndices
+  } = extractBatchUserIdentifiers(payloads, id_type, multiStatusResponse, syncMode, features)
   // Create offline user data job payload
   const offlineUserJobPayload = createOfflineUserJobPayload(externalAudienceId, payloads[0], settings.customerId)
   // Step1 :- Create an Offline user data job
@@ -1045,7 +1059,7 @@ export const processBatchPayload = async (
       request,
       addUserIdentifiers,
       resourceName,
-      validPayloadIndicesBitmap,
+      addPayloadIndices,
       failedPayloadIndices,
       multiStatusResponse,
       features,
@@ -1058,7 +1072,7 @@ export const processBatchPayload = async (
       request,
       removeUserIdentifiers,
       resourceName,
-      validPayloadIndicesBitmap,
+      removePayloadIndices,
       failedPayloadIndices,
       multiStatusResponse,
       features,


### PR DESCRIPTION
## Summary
- Fixes STRATCONN-6862: on the Google Enhanced Conversions `userList` batch path, a mixed add+remove batch that received a Google-side `partialFailureError` (e.g. `INVALID_SHA256_FORMAT`) could misattribute the error to the wrong original payload index.
- Root cause: `extractBatchUserIdentifiers` split valid payloads into separate `addUserIdentifiers`/`removeUserIdentifiers` arrays sent as two independent `offlineUserDataJobs:addOperations` calls, but returned a single combined `validPayloadIndicesBitmap`. Google's `partialFailureError.failedIndex` is relative to each call's own `operations` array, not the combined bitmap, so `handlePartialFailureResponse`'s `validPayloadIndicesBitmap[failedIndex]` lookup resolved to the wrong original payload on mixed batches.
- Fix: track per-call index arrays (`addPayloadIndices`, `removePayloadIndices`) mapping each subset's position back to its original payload index, and pass the correct subset into each `processOperations` call.
- Adds a regression test (mixed add/remove/invalid batch, mocked partial failure on the removes-only call) asserting per-index status/sent/body outcomes.

## Subtasks addressed
- STRATCONN-6901: core fix
- STRATCONN-6902: regression test

## Test plan
- [x] `TZ=UTC yarn cloud jest --testPathPatterns="google-enhanced-conversions"` — 199/199 tests pass (10 suites)
- [x] New regression test passes and fails against the pre-fix code (index misattribution reproduced, then fixed)
- [x] `eslint` on changed files: 0 errors (only pre-existing warnings)
- [x] No new TypeScript errors introduced by the change
- [x] No field/type changes — no codegen regeneration needed