### PR TITLE
Updated repository.url for provenance support

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -25,5 +25,9 @@
       "cache": true
     }
   },
-  "defaultBase": "main"
+  "defaultBase": "main",
+  "analytics": false,
+  "tui": {
+    "enabled": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "action-destinations",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations"
+  },
   "private": true,
   "license": "MIT",
   "workspaces": {

--- a/packages/browser-destination-runtime/package.json
+++ b/packages/browser-destination-runtime/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/browser-destination-runtime",
   "version": "1.97.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destination-runtime"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/1flow/package.json
+++ b/packages/browser-destinations/destinations/1flow/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-1flow",
   "version": "1.81.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/1flow"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/adobe-target/package.json
+++ b/packages/browser-destinations/destinations/adobe-target/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-adobe-target",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/adobe-target"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/algolia-plugins/package.json
+++ b/packages/browser-destinations/destinations/algolia-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-algolia-plugins",
   "version": "1.75.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/algolia-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/amplitude-plugins/package.json
+++ b/packages/browser-destinations/destinations/amplitude-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-amplitude-plugins",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/amplitude-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/appcues-web/package.json
+++ b/packages/browser-destinations/destinations/appcues-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-appcues-web-actions",
   "version": "1.6.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/appcues-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
+++ b/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-braze-cloud-plugins",
   "version": "1.113.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/braze-cloud-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/braze/package.json
+++ b/packages/browser-destinations/destinations/braze/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-braze",
   "version": "1.113.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/braze"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/bucket/package.json
+++ b/packages/browser-destinations/destinations/bucket/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-bucket",
   "version": "1.79.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/bucket"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/cdpresolution/package.json
+++ b/packages/browser-destinations/destinations/cdpresolution/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-cdpresolution",
   "version": "1.85.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/cdpresolution"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/cj/package.json
+++ b/packages/browser-destinations/destinations/cj/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-cj",
   "version": "1.12.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/cj"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/commandbar/package.json
+++ b/packages/browser-destinations/destinations/commandbar/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-commandbar",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/commandbar"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/contentstack-web/package.json
+++ b/packages/browser-destinations/destinations/contentstack-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-contentstack-web",
   "version": "1.41.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/contentstack-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/devrev/package.json
+++ b/packages/browser-destinations/destinations/devrev/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-devrev",
   "version": "1.85.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/devrev"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/dub-plugins/package.json
+++ b/packages/browser-destinations/destinations/dub-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-dub-plugins",
   "version": "1.14.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/dub-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/friendbuy/package.json
+++ b/packages/browser-destinations/destinations/friendbuy/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-friendbuy",
   "version": "1.104.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/friendbuy"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/fullsession/package.json
+++ b/packages/browser-destinations/destinations/fullsession/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-fullsession",
   "version": "1.10.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/fullsession"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/fullstory/package.json
+++ b/packages/browser-destinations/destinations/fullstory/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-fullstory",
   "version": "1.100.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/fullstory"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/google-analytics-4-web/package.json
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-google-analytics-4",
   "version": "1.109.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/google-analytics-4-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/google-campaign-manager/package.json
+++ b/packages/browser-destinations/destinations/google-campaign-manager/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-google-campaign-manager",
   "version": "1.89.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/google-campaign-manager"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/google-ec-plugins/package.json
+++ b/packages/browser-destinations/destinations/google-ec-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-google-ec-plugins",
   "version": "1.7.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/google-ec-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/heap/package.json
+++ b/packages/browser-destinations/destinations/heap/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-heap",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/heap"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/hubble-web/package.json
+++ b/packages/browser-destinations/destinations/hubble-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-hubble-web",
   "version": "1.84.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/hubble-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/hubspot-web/package.json
+++ b/packages/browser-destinations/destinations/hubspot-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-hubspot",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/hubspot-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/intercom/package.json
+++ b/packages/browser-destinations/destinations/intercom/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-intercom",
   "version": "1.109.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/intercom"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/iterate/package.json
+++ b/packages/browser-destinations/destinations/iterate/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-iterate",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/iterate"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/jimo/package.json
+++ b/packages/browser-destinations/destinations/jimo/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-jimo",
   "version": "1.89.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/jimo"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/koala/package.json
+++ b/packages/browser-destinations/destinations/koala/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-koala",
   "version": "1.100.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/koala"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/logrocket/package.json
+++ b/packages/browser-destinations/destinations/logrocket/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-logrocket",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/logrocket"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/mixpanel-web/package.json
+++ b/packages/browser-destinations/destinations/mixpanel-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-mixpanel-web-actions",
   "version": "1.10.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/mixpanel-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/ms-bing-capi/package.json
+++ b/packages/browser-destinations/destinations/ms-bing-capi/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-ms-bing-capi",
   "version": "1.12.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/ms-bing-capi"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/pendo-web-actions/package.json
+++ b/packages/browser-destinations/destinations/pendo-web-actions/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-pendo-web-actions",
   "version": "1.89.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/pendo-web-actions"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/playerzero-web/package.json
+++ b/packages/browser-destinations/destinations/playerzero-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-playerzero",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/playerzero-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/reddit-pixel/package.json
+++ b/packages/browser-destinations/destinations/reddit-pixel/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-reddit-pixel",
   "version": "1.16.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/reddit-pixel"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/replaybird/package.json
+++ b/packages/browser-destinations/destinations/replaybird/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-replaybird",
   "version": "1.80.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/replaybird"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/rokt-plugins/package.json
+++ b/packages/browser-destinations/destinations/rokt-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-rokt-plugins",
   "version": "1.6.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/rokt-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/rupt/package.json
+++ b/packages/browser-destinations/destinations/rupt/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-rupt",
   "version": "1.87.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/rupt"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/screeb/package.json
+++ b/packages/browser-destinations/destinations/screeb/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-screeb",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/screeb"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/segment-utilities-web/package.json
+++ b/packages/browser-destinations/destinations/segment-utilities-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-utils",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/segment-utilities-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/snap-plugins/package.json
+++ b/packages/browser-destinations/destinations/snap-plugins/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-snap-plugins",
   "version": "1.80.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/snap-plugins"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/sprig-web/package.json
+++ b/packages/browser-destinations/destinations/sprig-web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-sprig",
   "version": "1.98.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/sprig-web"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/stackadapt/package.json
+++ b/packages/browser-destinations/destinations/stackadapt/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-stackadapt",
   "version": "1.100.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/stackadapt"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/survicate/package.json
+++ b/packages/browser-destinations/destinations/survicate/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-survicate",
   "version": "1.74.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/survicate"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/tiktok-pixel/package.json
+++ b/packages/browser-destinations/destinations/tiktok-pixel/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-tiktok-pixel",
   "version": "1.100.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/tiktok-pixel"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/userpilot/package.json
+++ b/packages/browser-destinations/destinations/userpilot/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-userpilot",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/userpilot"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/vwo/package.json
+++ b/packages/browser-destinations/destinations/vwo/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-vwo",
   "version": "1.102.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/vwo"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/browser-destinations/destinations/wisepops/package.json
+++ b/packages/browser-destinations/destinations/wisepops/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/analytics-browser-actions-wiseops",
   "version": "1.99.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/browser-destinations/destinations/wisepops"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/packages/cli/src/__tests__/generate-metadata-payload.test.ts
+++ b/packages/cli/src/__tests__/generate-metadata-payload.test.ts
@@ -13,6 +13,13 @@ jest.mock('fs-extra', () => ({
   }
 }))
 
+// Prevent the command's post-generation `execFileSync('npx', ['prettier', ...])`
+// from spawning a real npx process during tests — it isn't needed here and is
+// slow enough to exceed Jest's timeout in CI.
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn()
+}))
+
 import fs from 'fs-extra'
 import { generatePublicMetadata } from '../commands/generate/metadata-payload'
 import { resolveSourceDir, extractDestinationDirs } from '../commands/generate/metadata-payload'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "version": "3.168.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/segmentio/fab-5-engine",
+    "url": "https://github.com/segmentio/action-destinations",
     "directory": "packages/core"
   },
   "main": "dist/cjs",

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/destinations-manifest",
   "version": "1.159.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/destinations-manifest"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/warehouse-destinations/package.json
+++ b/packages/warehouse-destinations/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@segment/warehouse-destinations",
   "version": "1.23.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/segmentio/action-destinations",
+    "directory": "packages/warehouse-destinations"
+  },
   "description": "Definitions for warehouse destinations. Only used for definitions - should not be imported for anything other than types.",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This PR fixes `package.json` in all mono-repo packages so that `repository.url` correctly points to `https://github.com/segmentio/action-destinations`

## Testing

Testing not required as this is a metadata change.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
