### PR TITLE
ci: remove Create PR step from version-packages.yml (blocked by org policy)

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -29,7 +29,6 @@ jobs:
       RUN_ID: ${{ github.event.inputs.run_id }}
     runs-on: ubuntu-latest-large
     permissions:
-      pull-requests: write
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,28 +70,13 @@ jobs:
           fi
 
       - name: Commit and push
-        id: commit_and_push
         run: |
           git add .
           count=$(git diff --cached --stat)
           if [ -z "$count" ]; then
             echo "No changes to commit"
-            echo "SKIP_PR=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          packages_published=$(git status -s -uno| grep "package.json" |awk '{print $2}'| xargs jq -r '.name + "@" + .version' --argjson null {})
-          echo "packages_published<<EOF" >> $GITHUB_OUTPUT
-          echo "$packages_published" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
           git commit -m "Publish"
           git push origin ${{ env.BRANCH }}
-
-      - name: Create PR
-        if: ${{ steps.commit_and_push.outputs.SKIP_PR != 'true' }}
-        run: |
-          pr_message="This PR was opened by GithHub Actions. Whenever you're ready to publish the packages, merge this PR."
-          description="$(printf "%s\n # Packages\n%s" "$pr_message" "${{ steps.commit_and_push.outputs.packages_published }}")"
-          gh pr create --base ${{ env.BASE_BRANCH }} --head ${{ env.BRANCH }} --title "Publish" --body "$description"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `version-packages.yml`'s "Create PR" step (`gh pr create` using `GITHUB_TOKEN`) has been failing every run with `GitHub Actions is not permitted to create or approve pull requests` — confirmed this is an org-level policy on `segmentio` (repo-level "Allow GitHub Actions to create and approve pull requests" checkbox is greyed out/locked). Example failing run: https://github.com/segmentio/action-destinations/actions/runs/29004149179/job/86071585584
- Removed the "Create PR" step and the now-unused `pull-requests: write` permission. The workflow still checks out the branch, installs, builds, bumps versions with `lerna version`, and commits+pushes — it just stops there.
- PR creation moves to `action-cli`'s `release-cloud-prod` command (segmentio/action-cli#254), which opens the PR itself via a PAT-based `Github` client instead of `GITHUB_TOKEN`, sidestepping the org restriction entirely.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed via `gh api repos/segmentio/action-destinations/actions/permissions/workflow` that `can_approve_pull_request_reviews: false` (org-locked)
- [x] Confirmed this workflow has no other consumers in this repo besides `action-cli`'s `workflow_dispatch` call
- [ ] Manual run of `release-cloud-prod` to confirm the workflow completes and action-cli successfully opens the PR afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)