### PR TITLE
STRATCONN-6903 - [Rokt] - Unique MessageIds for ROKT CAPI destination

### DIFF
--- a/packages/destination-actions/src/destinations/rokt-capi/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rokt-capi/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,7 +19,7 @@ Object {
         },
         "custom_event_type": "other",
         "event_name": "audiencemembershipupdate",
-        "source_message_id": "xI%Z3kWrnFUD^fL(n8@",
+        "source_message_id": "aud_xI%Z3kWrnFUD^fL(n8@",
         "timestamp_unixtime_ms": null,
       },
       "event_type": "custom_event",

--- a/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -19,7 +19,7 @@ Object {
         },
         "custom_event_type": "other",
         "event_name": "audiencemembershipupdate",
-        "source_message_id": "WKK6WO",
+        "source_message_id": "aud_WKK6WO",
         "timestamp_unixtime_ms": null,
       },
       "event_type": "custom_event",

--- a/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
@@ -542,6 +542,7 @@ describe('RoktCapi.send', () => {
           expect(body.events.length).toBe(1)
           expect(body.events[0].data.event_name).toBe('audiencemembershipupdate')
           expect(body.events[0].data.custom_event_type).toBe('other')
+          expect(body.events[0].data.source_message_id).toBe('aud_msg-011')
           expect(body.events[0].data.custom_attributes.audience_name).toBe('premium_users')
           expect(body.events[0].data.custom_attributes.status).toBe('add')
           expect(body.user_attributes.segment_premium_users).toBe(true)
@@ -589,6 +590,7 @@ describe('RoktCapi.send', () => {
           expect(body.events.length).toBe(1)
           expect(body.events[0].data.event_name).toBe('audiencemembershipupdate')
           expect(body.events[0].data.custom_event_type).toBe('other')
+          expect(body.events[0].data.source_message_id).toBe('aud_msg-012')
           expect(body.events[0].data.custom_attributes.audience_name).toBe('high_value_customers')
           expect(body.events[0].data.custom_attributes.status).toBe('add')
           expect(body.user_attributes.segment_high_value_customers).toBe(true)
@@ -604,6 +606,90 @@ describe('RoktCapi.send', () => {
             source_message_id: 'msg-012',
             timestamp_unixtime_ms: '2024-01-18T12:00:00.000Z'
           }
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('should use distinct source_message_ids when a conversion and an audience event are sent together', async () => {
+      const event = createTestEvent({
+        event: 'Order Completed',
+        messageId: 'msg-combined',
+        timestamp: '2024-01-18T12:00:00.000Z',
+        type: 'track',
+        properties: {
+          order_id: 'order-999',
+          premium_users: true,
+          email: 'combined@example.com'
+        },
+        userId: 'user-combined'
+      })
+
+      // Both an audience membership event and a conversion event are emitted in the same payload.
+      // The conversion keeps the raw source_message_id ('msg-combined'); the audience event's id is
+      // prefixed with 'aud_' so the two events never collide on source_message_id.
+      const expectedRoktPayload = {
+        environment: 'production',
+        device_info: {
+          http_header_user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+        },
+        user_attributes: {
+          segment_premium_users: true
+        },
+        user_identities: {
+          email: 'combined@example.com',
+          customerid: 'user-combined'
+        },
+        events: [
+          {
+            event_type: 'custom_event',
+            data: {
+              custom_event_type: 'other',
+              source_message_id: 'aud_msg-combined',
+              timestamp_unixtime_ms: 1705579200000,
+              event_name: 'audiencemembershipupdate',
+              custom_attributes: {
+                audience_name: 'premium_users',
+                status: 'add'
+              }
+            }
+          },
+          {
+            event_type: 'custom_event',
+            data: {
+              custom_event_type: 'transaction',
+              source_message_id: 'msg-combined',
+              timestamp_unixtime_ms: 1705579200000,
+              event_name: 'conversion',
+              custom_attributes: {
+                conversiontype: 'Order Completed'
+              }
+            }
+          }
+        ],
+        ip: '8.8.8.8'
+      }
+
+      nock('https://inbound.mparticle.com')
+        .post('/s2s/v2/events', expectedRoktPayload)
+        .reply(200, { success: true })
+
+      const responses = await testDestination.testAction('send', {
+        event,
+        useDefaultMappings: true,
+        mapping: {
+          eventDetails: {
+            conversiontype: 'Order Completed',
+            source_message_id: 'msg-combined',
+            timestamp_unixtime_ms: '2024-01-18T12:00:00.000Z'
+          },
+          engageAudienceName: 'premium_users',
+          traitsOrProps: {
+            premium_users: true
+          },
+          computationAction: 'audience'
         }
       })
 

--- a/packages/destination-actions/src/destinations/rokt-capi/send/functions.ts
+++ b/packages/destination-actions/src/destinations/rokt-capi/send/functions.ts
@@ -208,7 +208,7 @@ function getAudienceJSON(payload: Payload): AudienceJSON | undefined {
         event_type: "custom_event",
         data: {
             custom_event_type: "other",
-            source_message_id,
+            source_message_id: `aud_${source_message_id}`,
             timestamp_unixtime_ms: new Date(timestamp_unixtime_ms).getTime(), 
             event_name: "audiencemembershipupdate",
             custom_attributes: {


### PR DESCRIPTION
## Summary

When a single payload emits both an **audience membership event** and a **conversion event** for the Rokt CAPI destination, both events previously carried the same `source_message_id`. Rokt requires these to be distinct.

This PR prefixes the audience event's `source_message_id` with `aud_`, so the two events in the same payload never collide.

## Changes
- `send/functions.ts`: audience event `source_message_id` is now `aud_${source_message_id}` (conversion event keeps the raw value).

Testing
- staging: done - see screenshot and video belo
- Unit tests:
  - New test asserting the exact payload when a conversion and an audience event are sent together, verifying the two `source_message_id` values are distinct.
  - Extended the existing audience-membership tests to assert the prefixed id.
  - Regenerated snapshots.

<img width="2520" height="1359" alt="image" src="https://github.com/user-attachments/assets/e2da880a-9267-48be-a4b5-92a1df2450f1" />

https://github.com/user-attachments/assets/e5dc692c-6272-44f3-973d-f9f7daf11ced




JIRA: STRATCONN-6903
