### PR TITLE
feat(stackadapt-audiences): add custom_user_properties v2 field with mode toggle

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/fields.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/fields.ts
@@ -2,235 +2,300 @@ import { InputField } from '@segment/actions-core'
 import { MarketingStatus } from './constants'
 
 export const audience_only_fields: Record<string, InputField> = {
-    traits_or_props: {
-      label: 'Event Properties',
-      type: 'object',
-      description: 'The properties of the user or event.',
-      unsafe_hidden: true,
-      required: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties' },
-          then: { '@path': '$.properties' },
-          else: { '@path': '$.traits' }
-        }
-      }
-    },
-    segment_computation_class: {
-      label: 'Segment Computation Class',
-      required: true,
-      description: "Segment computation class used to determine if input event is from an Engage Audience'.",
-      type: 'string',
-      unsafe_hidden: true,
-      default: {
-        '@path': '$.context.personas.computation_class'
-      },
-      choices: [{ label: 'audience', value: 'audience' },{ label: 'journey_step', value: 'journey_step' }]
-    },
-    segment_computation_id: {
-      label: 'Segment Computation ID',
-      description: 'For audience enter/exit events, this will be the audience ID.',
-      type: 'string',
-      required: true,
-      unsafe_hidden: true,
-      default: {
-        '@path': '$.context.personas.computation_id'
-      }
-    },
-    segment_computation_key: {
-      label: 'Segment Computation Key',
-      description: 'For audience enter/exit events, this will be the audience key.',
-      type: 'string',
-      unsafe_hidden: true,
-      required: true,
-      default: {
-        '@path': '$.context.personas.computation_key'
+  traits_or_props: {
+    label: 'Event Properties',
+    type: 'object',
+    description: 'The properties of the user or event.',
+    unsafe_hidden: true,
+    required: true,
+    default: {
+      '@if': {
+        exists: { '@path': '$.properties' },
+        then: { '@path': '$.properties' },
+        else: { '@path': '$.traits' }
       }
     }
+  },
+  segment_computation_class: {
+    label: 'Segment Computation Class',
+    required: true,
+    description: "Segment computation class used to determine if input event is from an Engage Audience'.",
+    type: 'string',
+    unsafe_hidden: true,
+    default: {
+      '@path': '$.context.personas.computation_class'
+    },
+    choices: [
+      { label: 'audience', value: 'audience' },
+      { label: 'journey_step', value: 'journey_step' }
+    ]
+  },
+  segment_computation_id: {
+    label: 'Segment Computation ID',
+    description: 'For audience enter/exit events, this will be the audience ID.',
+    type: 'string',
+    required: true,
+    unsafe_hidden: true,
+    default: {
+      '@path': '$.context.personas.computation_id'
+    }
+  },
+  segment_computation_key: {
+    label: 'Segment Computation Key',
+    description: 'For audience enter/exit events, this will be the audience key.',
+    type: 'string',
+    unsafe_hidden: true,
+    required: true,
+    default: {
+      '@path': '$.context.personas.computation_key'
+    }
+  }
 }
 
 export const profile_fields: Record<string, InputField> = {
-    standard_traits: {
-      label: 'Standard User Properties',
-      type: 'object',
-      description: 'Standard properties for the user.',
-      defaultObjectUI: 'keyvalue',
-      additionalProperties: false,
-      required: false,
-      properties: {
-        first_name: {
-          label: 'First Name',
-          type: 'string',
-          description: "The user's first name."
-        },
-        last_name: {
-          label: 'Last Name',
-          type: 'string',
-          description: "The user's last name."
-        },
-        phone: {
-          label: 'Phone',
-          type: 'string',
-          description: 'The phone number of the user.'
-        },
-        address: {
-          label: 'Address',
-          type: 'string',
-          description: 'The address of the user.'
-        },
-        city: {
-          label: 'City',
-          type: 'string',
-          description: 'The city of the user.'
-        },
-        country: {
-          label: 'Country',
-          type: 'string',
-          description: 'The country of the user.'
-        },
-        state: {
-          label: 'State',
-          type: 'string',
-          description: 'The state of the user.'
-        },
-        timezone: {
-          label: 'Time Zone',
-          type: 'string',
-          description: 'The timezone of the user.'
-        },
-        postal_code: {
-          label: 'Postal Code',
-          type: 'string',
-          description: 'The postal code of the user.'
-        },
-        birth_date: {
-          label: 'Birth Date',
-          type: 'string',
-          format: 'date',
-          description: "The birthday of the user in YYYY-MM-DD format."
+  standard_traits: {
+    label: 'Standard User Properties',
+    type: 'object',
+    description: 'Standard properties for the user.',
+    defaultObjectUI: 'keyvalue',
+    additionalProperties: false,
+    required: false,
+    properties: {
+      first_name: {
+        label: 'First Name',
+        type: 'string',
+        description: "The user's first name."
+      },
+      last_name: {
+        label: 'Last Name',
+        type: 'string',
+        description: "The user's last name."
+      },
+      phone: {
+        label: 'Phone',
+        type: 'string',
+        description: 'The phone number of the user.'
+      },
+      address: {
+        label: 'Address',
+        type: 'string',
+        description: 'The address of the user.'
+      },
+      city: {
+        label: 'City',
+        type: 'string',
+        description: 'The city of the user.'
+      },
+      country: {
+        label: 'Country',
+        type: 'string',
+        description: 'The country of the user.'
+      },
+      state: {
+        label: 'State',
+        type: 'string',
+        description: 'The state of the user.'
+      },
+      timezone: {
+        label: 'Time Zone',
+        type: 'string',
+        description: 'The timezone of the user.'
+      },
+      postal_code: {
+        label: 'Postal Code',
+        type: 'string',
+        description: 'The postal code of the user.'
+      },
+      birth_date: {
+        label: 'Birth Date',
+        type: 'string',
+        format: 'date',
+        description: 'The birthday of the user in YYYY-MM-DD format.'
+      }
+    },
+    default: {
+      first_name: {
+        '@if': {
+          exists: { '@path': '$.traits.first_name' },
+          then: { '@path': '$.traits.first_name' },
+          else: { '@path': '$.properties.first_name' }
         }
       },
-      default: {
-        first_name: {
-          '@if': {
-            exists: { '@path': '$.traits.first_name' },
-            then: { '@path': '$.traits.first_name' },
-            else: { '@path': '$.properties.first_name' }
-          }
-        },
-        last_name: {
-          '@if': {
-            exists: { '@path': '$.traits.last_name' },
-            then: { '@path': '$.traits.last_name' },
-            else: { '@path': '$.properties.last_name' }
-          }
-        },
-        phone: {
-          '@if': {
-            exists: { '@path': '$.traits.phone' },
-            then: { '@path': '$.traits.phone' },
-            else: { '@path': '$.properties.phone' }
-          }
-        },
-        address: {
-          '@if': {
-            exists: { '@path': '$.traits.street' },
-            then: { '@path': '$.traits.street' },
-            else: { '@path': '$.properties.street' }
-          }
-        },
-        city: {
-          '@if': {
-            exists: { '@path': '$.traits.city' },
-            then: { '@path': '$.traits.city' },
-            else: { '@path': '$.properties.city' }
-          }
-        },
-        country: {
-          '@if': {
-            exists: { '@path': '$.traits.country' },
-            then: { '@path': '$.traits.country' },
-            else: { '@path': '$.properties.country' }
-          }
-        },
-        state: {
-          '@if': {
-            exists: { '@path': '$.traits.state' },
-            then: { '@path': '$.traits.state' },
-            else: { '@path': '$.properties.state' }
-          }
-        },
-        postal_code: {
-          '@if': {
-            exists: { '@path': '$.traits.postal_code' },
-            then: { '@path': '$.traits.postal_code' },
-            else: { '@path': '$.properties.postal_code' }
-          }
-        },
-        timezone: {
-          '@if': {
-            exists: { '@path': '$.traits.timezone' },
-            then: { '@path': '$.traits.timezone' },
-            else: { '@path': '$.properties.timezone' }
-          }
-        },
-        birth_date: {
-          '@if': {
-            exists: { '@path': '$.traits.birthday' },
-            then: { '@path': '$.traits.birthday' },
-            else: { '@path': '$.properties.birthday' }
-          }
-        }
-      }
-    },
-    custom_traits: {
-      label: 'Custom User Properties',
-      type: 'object',
-      description: 'Custom properties for the user.',
-      defaultObjectUI: 'keyvalue',
-      required: false
-    },
-    user_id: {
-      label: 'Segment User ID',
-      description: 'The ID of the user in Segment',
-      type: 'string',
-      default: {
-        // By default we want to use the permanent user id that's consistent across a customer's lifetime.
-        // But if we don't have that we can fall back to the anonymous id
+      last_name: {
         '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
+          exists: { '@path': '$.traits.last_name' },
+          then: { '@path': '$.traits.last_name' },
+          else: { '@path': '$.properties.last_name' }
+        }
+      },
+      phone: {
+        '@if': {
+          exists: { '@path': '$.traits.phone' },
+          then: { '@path': '$.traits.phone' },
+          else: { '@path': '$.properties.phone' }
+        }
+      },
+      address: {
+        '@if': {
+          exists: { '@path': '$.traits.street' },
+          then: { '@path': '$.traits.street' },
+          else: { '@path': '$.properties.street' }
+        }
+      },
+      city: {
+        '@if': {
+          exists: { '@path': '$.traits.city' },
+          then: { '@path': '$.traits.city' },
+          else: { '@path': '$.properties.city' }
+        }
+      },
+      country: {
+        '@if': {
+          exists: { '@path': '$.traits.country' },
+          then: { '@path': '$.traits.country' },
+          else: { '@path': '$.properties.country' }
+        }
+      },
+      state: {
+        '@if': {
+          exists: { '@path': '$.traits.state' },
+          then: { '@path': '$.traits.state' },
+          else: { '@path': '$.properties.state' }
+        }
+      },
+      postal_code: {
+        '@if': {
+          exists: { '@path': '$.traits.postal_code' },
+          then: { '@path': '$.traits.postal_code' },
+          else: { '@path': '$.properties.postal_code' }
+        }
+      },
+      timezone: {
+        '@if': {
+          exists: { '@path': '$.traits.timezone' },
+          then: { '@path': '$.traits.timezone' },
+          else: { '@path': '$.properties.timezone' }
+        }
+      },
+      birth_date: {
+        '@if': {
+          exists: { '@path': '$.traits.birthday' },
+          then: { '@path': '$.traits.birthday' },
+          else: { '@path': '$.properties.birthday' }
         }
       }
-    },
-    event_type: {
-      label: 'Event Type',
-      description: 'The Segment event type - track or identify',
-      type: 'string',
-      required: true,
-      default: {
-        '@path': '$.type'
+    }
+  },
+  custom_properties_mode: {
+    label: 'Custom Properties Mode',
+    description: 'Select how to configure custom user properties.',
+    type: 'string',
+    required: false,
+    default: 'v2',
+    choices: [
+      { label: 'Legacy (Key-Value)', value: 'v1' },
+      { label: 'Custom User Properties', value: 'v2' }
+    ],
+    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment']
+  },
+  custom_traits: {
+    label: 'Custom User Properties (Legacy)',
+    type: 'object',
+    description: 'Custom properties for the user.',
+    defaultObjectUI: 'keyvalue:only',
+    required: false,
+    depends_on: {
+      match: 'any',
+      conditions: [
+        { fieldKey: 'custom_properties_mode', operator: 'is', value: 'v1' },
+        { fieldKey: 'custom_properties_mode', operator: 'is', value: undefined }
+      ]
+    }
+  },
+  custom_user_properties: {
+    label: 'Custom User Properties',
+    description: 'Custom properties for the user. Each property requires a name, type, and value.',
+    type: 'object',
+    multiple: true,
+    required: false,
+    defaultObjectUI: 'arrayeditor',
+    additionalProperties: false,
+    properties: {
+      name: {
+        label: 'Name',
+        description: 'The name of the custom user property.',
+        type: 'string',
+        required: true,
+        disabledInputMethods: ['variable', 'function', 'freeform', 'enrichment']
+      },
+      type: {
+        label: 'Type',
+        description: 'The data type of the custom user property.',
+        type: 'string',
+        required: true,
+        choices: [
+          { label: 'String', value: 'STRING' },
+          { label: 'Number', value: 'NUMBER' },
+          { label: 'Boolean', value: 'BOOLEAN' },
+          { label: 'Date', value: 'DATE' }
+        ],
+        disabledInputMethods: ['variable', 'function', 'freeform', 'enrichment']
+      },
+      value: {
+        label: 'Value',
+        description: 'The value of the custom user property.',
+        type: 'string'
       }
     },
-    marketing_status: {
-      label: 'Marketing Status',
-      description: 'In certain jurisdictions, explicit consent may be required to send email marketing communications to imported profiles. Consult independent counsel for further guidance.',
-      type: 'string',
-      required: true,
-      disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
-      choices: [
-        { label: 'Opted-in (Profiles can receive email marketing)', value: MarketingStatus.OPT_IN },
-        { label: 'Indeterminate (Profiles that have not opted-out, but are excluded from email marketing)', value: MarketingStatus.Indeterminate }
-      ]
-    },
-    enable_batching: {
-      type: 'boolean',
-      label: 'Batch Profiles',
-      unsafe_hidden: true,
-      description:
-        'When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.',
-      required: true,
-      default: true
+    depends_on: {
+      match: 'all',
+      conditions: [{ fieldKey: 'custom_properties_mode', operator: 'is', value: 'v2' }]
     }
+  },
+  user_id: {
+    label: 'Segment User ID',
+    description: 'The ID of the user in Segment',
+    type: 'string',
+    default: {
+      // By default we want to use the permanent user id that's consistent across a customer's lifetime.
+      // But if we don't have that we can fall back to the anonymous id
+      '@if': {
+        exists: { '@path': '$.userId' },
+        then: { '@path': '$.userId' },
+        else: { '@path': '$.anonymousId' }
+      }
+    }
+  },
+  event_type: {
+    label: 'Event Type',
+    description: 'The Segment event type - track or identify',
+    type: 'string',
+    required: true,
+    default: {
+      '@path': '$.type'
+    }
+  },
+  marketing_status: {
+    label: 'Marketing Status',
+    description:
+      'In certain jurisdictions, explicit consent may be required to send email marketing communications to imported profiles. Consult independent counsel for further guidance.',
+    type: 'string',
+    required: true,
+    disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
+    choices: [
+      { label: 'Opted-in (Profiles can receive email marketing)', value: MarketingStatus.OPT_IN },
+      {
+        label: 'Indeterminate (Profiles that have not opted-out, but are excluded from email marketing)',
+        value: MarketingStatus.Indeterminate
+      }
+    ]
+  },
+  enable_batching: {
+    type: 'boolean',
+    label: 'Batch Profiles',
+    unsafe_hidden: true,
+    description: 'When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.',
+    required: true,
+    default: true
+  }
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -1,46 +1,51 @@
 import { RequestClient } from '@segment/actions-core'
 import { Settings } from '../generated-types'
-import {PROFILE_DEFAULT_FIELDS, MAPPING_SCHEMA, MarketingStatus as MarketingStatuses } from './constants'
-import {GQL_ENDPOINT, EXTERNAL_PROVIDER } from '../common-constants'
-import {  Mapping, MarketingStatus, ProfileFieldConfig } from './types'
+import { PROFILE_DEFAULT_FIELDS, MAPPING_SCHEMA, MarketingStatus as MarketingStatuses } from './constants'
+import { GQL_ENDPOINT, EXTERNAL_PROVIDER } from '../common-constants'
+import { CustomUserProperty, Mapping, MarketingStatus, ProfileFieldConfig } from './types'
 import type { Payload } from './generated-types'
 import { sha256hash } from '../common-functions'
 
 export async function send(request: RequestClient, payloads: Payload[], settings: Settings) {
-
-  const fieldTypes = getDefaultFieldTypes()
-  const fieldsToMap = getDefaultFieldsToMap()
   const advertiserId = settings.advertiser_id
   const marketingStatus = payloads[0].marketing_status as MarketingStatus
-  
-  const profileUpdates = payloads.map((p) => {  
-    const {
-      user_id,
-      standard_traits,
-      custom_traits,
-      email
-    } = p
+  const useV2 = payloads[0].custom_properties_mode === 'v2'
 
+  const fieldTypes = useV2 ? getV2FieldTypes(payloads[0]?.custom_user_properties) : getDefaultFieldTypes()
+  const fieldsToMap = useV2 ? getV2FieldsToMap(payloads[0]?.custom_user_properties) : getDefaultFieldsToMap()
+
+  const profileUpdates = payloads.map((p) => {
+    const { user_id, standard_traits, custom_traits, custom_user_properties, email } = p
     const { segment_computation_key, segment_computation_id, traits_or_props } = p
-
-    if(custom_traits) {
-        // Remove reserved keys from custom traits just incase the customer accidentally maps them
-        delete custom_traits[segment_computation_key] 
-        delete custom_traits[segment_computation_id] 
-    }
 
     const profile: Record<string, string | number | undefined> = {
       userId: user_id,
       email,
-      ...standard_traits,
-      ...custom_traits
+      ...standard_traits
+    }
+
+    if (useV2) {
+      if (custom_user_properties) {
+        const reservedKeys = [segment_computation_key, segment_computation_id].filter(Boolean)
+        for (const prop of custom_user_properties) {
+          if (prop.name && !reservedKeys.includes(prop.name)) {
+            profile[prop.name] = prop.value
+          }
+        }
+      }
+    } else {
+      if (custom_traits) {
+        // Remove reserved keys from custom traits just incase the customer accidentally maps them
+        delete custom_traits[segment_computation_key]
+        delete custom_traits[segment_computation_id]
+        Object.assign(profile, custom_traits)
+      }
+      updateFieldsToMapAndFieldTypes(fieldsToMap, fieldTypes, custom_traits)
     }
 
     profile.audienceId = segment_computation_id
     profile.audienceName = segment_computation_key
     profile.action = traits_or_props[segment_computation_key] ? 'enter' : 'exit'
-
-    updateFieldsToMapAndFieldTypes(fieldsToMap, fieldTypes, custom_traits)
 
     return profile
   })
@@ -73,7 +78,7 @@ export async function send(request: RequestClient, payloads: Payload[], settings
           message
         }
       }
-      ${ audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
+      ${audienceMutation(advertiserId, stringifyMappingSchemaForGraphQL(MAPPING_SCHEMA))}
   }`
 
   return await request(GQL_ENDPOINT, {
@@ -92,22 +97,25 @@ function audienceMutation(advertiserId: string, audienceMapping: string): string
           userErrors {
             message
           }
-        }`;
+        }`
 }
 
-
-function updateFieldsToMapAndFieldTypes(fieldsToMap: Set<string>, fieldTypes: Record<string, string>, customTraits: Payload['custom_traits'] = {}) {
-   // Process trait keys (already in snake_case) and capture any non-standard fields as mappings 
+function updateFieldsToMapAndFieldTypes(
+  fieldsToMap: Set<string>,
+  fieldTypes: Record<string, string>,
+  customTraits: Payload['custom_traits'] = {}
+) {
+  // Process trait keys (already in snake_case) and capture any non-standard fields as mappings
   return Object.keys(customTraits).reduce((acc: Record<string, unknown>, key) => {
     const value = customTraits[key]
-    
+
     // Skip if key is empty string or value is empty string
     if (key === '' || value === '') {
       return acc
     }
-    
+
     acc[key] = value
-    
+
     const standardFields = getDefaultFieldsToMap()
 
     if (!standardFields.has(key)) {
@@ -131,7 +139,7 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
   for (const field of customFields) {
     // Keys are already in snake_case, so find directly in PROFILE_DEFAULT_FIELDS
     const fieldConfig = PROFILE_DEFAULT_FIELDS.find((f: ProfileFieldConfig) => f.key === field)
-    
+
     if (fieldConfig) {
       // Special mapping cases for StackAdapt destination keys
       let destinationKey: string
@@ -142,8 +150,8 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
         default:
           destinationKey = fieldConfig.key
       }
-      
-      // StackAdapt uses destinationKey to look up global fields so it has to match 
+
+      // StackAdapt uses destinationKey to look up global fields so it has to match
       mappingSchema.push({
         incomingKey: field, // Use original snake_case field name as incomingKey
         destinationKey,
@@ -187,45 +195,44 @@ function getType(value: unknown) {
 
 function isDateStr(value: unknown) {
   if (typeof value !== 'string') return false
-  
+
   const datePatterns = [
     /^\d{4}-\d{2}-\d{2}/, // YYYY-MM-DD
     /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
     /^\d{1,2}\/\d{1,2}\/\d{4}/, // MM/DD/YYYY
     /^\d{1,2}-\d{1,2}-\d{4}/ // MM-DD-YYYY
   ]
-  
-  const hasDatePattern = datePatterns.some(pattern => pattern.test(value))
+
+  const hasDatePattern = datePatterns.some((pattern) => pattern.test(value))
   if (!hasDatePattern) return false
-  
+
   const parsed = Date.parse(value)
   return !isNaN(parsed)
 }
 
 // transform an array of mapping objects into a string which can be sent as parameter in a GQL request
 export function stringifyJsonWithEscapedQuotes(value: unknown) {
-  const jsonString = JSON.stringify(value);
-  
+  const jsonString = JSON.stringify(value)
+
   // Finally escape all remaining quotes
-  return jsonString.replace(/"/g, '\\"');
+  return jsonString.replace(/"/g, '\\"')
 }
 
 // transform mapping schema for direct insertion into GraphQL queries (no quote escaping)
 export function stringifyMappingSchemaForGraphQL(value: unknown) {
   let jsonString = JSON.stringify(value)
-  
+
   // Replace "type":"VALUE" with type:VALUE (unquoted enum and field)
-  jsonString = jsonString.replace(/"type":"([^"]+)"/g, (_, typeValue: string) => 
-    `type:${typeValue.toUpperCase()}`)
-  
+  jsonString = jsonString.replace(/"type":"([^"]+)"/g, (_, typeValue: string) => `type:${typeValue.toUpperCase()}`)
+
   // Remove quotes from all object keys to make it valid GraphQL syntax
-  jsonString = jsonString.replace(/"([a-zA-Z_][a-zA-Z0-9_]*)"\s*:/g, '$1:');
-  
+  jsonString = jsonString.replace(/"([a-zA-Z_][a-zA-Z0-9_]*)"\s*:/g, '$1:')
+
   return jsonString
 }
 
 const getDefaultFieldsToMap = (): Set<string> => {
-  return new Set(PROFILE_DEFAULT_FIELDS.map(field => field.key))
+  return new Set(PROFILE_DEFAULT_FIELDS.map((field) => field.key))
 }
 
 const getDefaultFieldTypes = (): Record<string, string> => {
@@ -233,4 +240,34 @@ const getDefaultFieldTypes = (): Record<string, string> => {
     acc[field.key] = field.type.toUpperCase()
     return acc
   }, {} as Record<string, string>)
+}
+
+function getV2FieldsToMap(customUserProperties: CustomUserProperty[] | undefined): Set<string> {
+  const standardFieldsToMap = getDefaultFieldsToMap()
+
+  if (customUserProperties) {
+    for (const prop of customUserProperties) {
+      const key = prop.name?.trim()
+      if (key && !standardFieldsToMap.has(key)) {
+        standardFieldsToMap.add(key)
+      }
+    }
+  }
+
+  return standardFieldsToMap
+}
+
+function getV2FieldTypes(customUserProperties: CustomUserProperty[] | undefined): Record<string, string> {
+  const standardFieldTypes = getDefaultFieldTypes()
+
+  if (customUserProperties) {
+    for (const prop of customUserProperties) {
+      const key = prop.name?.trim()
+      if (key && !standardFieldTypes[key]) {
+        standardFieldTypes[key] = prop.type
+      }
+    }
+  }
+
+  return standardFieldTypes
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/generated-types.ts
@@ -47,11 +47,23 @@ export interface Payload {
     birth_date?: string
   }
   /**
+   * Select how to configure custom user properties.
+   */
+  custom_properties_mode?: string
+  /**
    * Custom properties for the user.
    */
   custom_traits?: {
     [k: string]: unknown
   }
+  /**
+   * Custom properties for the user. Each property requires a name, type, and value.
+   */
+  custom_user_properties?: {
+    name: string
+    type: string
+    value?: string
+  }[]
   /**
    * The ID of the user in Segment
    */

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/types.ts
@@ -35,8 +35,14 @@ export interface Mapping {
   destinationKey: string
   label: string
   type: string
-  isPii: boolean  
+  isPii: boolean
   value?: string
 }
 
 export type MarketingStatus = typeof MarketingStatus[keyof typeof MarketingStatus]
+
+export interface CustomUserProperty {
+  name: string
+  type: string
+  value?: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/metadata.json
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/metadata.json
@@ -437,8 +437,47 @@
           "format": null,
           "additionalProperties": false
         },
+        "custom_properties_mode": {
+          "label": "Custom Properties Mode",
+          "description": "Select how to configure custom user properties.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "v2",
+          "choices": [
+            {
+              "label": "Legacy (Key-Value)",
+              "value": "v1"
+            },
+            {
+              "label": "Custom User Properties",
+              "value": "v2"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": [
+            "literal",
+            "variable",
+            "function",
+            "freeform",
+            "enrichment"
+          ],
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
         "custom_traits": {
-          "label": "Custom User Properties",
+          "label": "Custom User Properties (Legacy)",
           "description": "Custom properties for the user.",
           "type": "object",
           "required": false,
@@ -450,12 +489,158 @@
           "placeholder": null,
           "properties": null,
           "category": null,
-          "depends_on": null,
+          "depends_on": {
+            "match": "any",
+            "conditions": [
+              {
+                "fieldKey": "custom_properties_mode",
+                "operator": "is",
+                "value": "v1"
+              },
+              {
+                "fieldKey": "custom_properties_mode",
+                "operator": "is"
+              }
+            ]
+          },
           "readOnly": null,
           "hidden": null,
           "minimum": null,
           "maximum": null,
-          "defaultObjectUI": "keyvalue",
+          "defaultObjectUI": "keyvalue:only",
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "custom_user_properties": {
+          "label": "Custom User Properties",
+          "description": "Custom properties for the user. Each property requires a name, type, and value.",
+          "type": "object",
+          "required": false,
+          "multiple": true,
+          "allowNull": false,
+          "dynamic": false,
+          "default": null,
+          "choices": null,
+          "placeholder": null,
+          "properties": {
+            "name": {
+              "label": "Name",
+              "description": "The name of the custom user property.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": null,
+              "hidden": null,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": [
+                "variable",
+                "function",
+                "freeform",
+                "enrichment"
+              ],
+              "displayMode": null,
+              "format": null,
+              "additionalProperties": false
+            },
+            "type": {
+              "label": "Type",
+              "description": "The data type of the custom user property.",
+              "type": "string",
+              "required": true,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": [
+                {
+                  "label": "String",
+                  "value": "STRING"
+                },
+                {
+                  "label": "Number",
+                  "value": "NUMBER"
+                },
+                {
+                  "label": "Boolean",
+                  "value": "BOOLEAN"
+                },
+                {
+                  "label": "Date",
+                  "value": "DATE"
+                }
+              ],
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": null,
+              "hidden": null,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": [
+                "variable",
+                "function",
+                "freeform",
+                "enrichment"
+              ],
+              "displayMode": null,
+              "format": null,
+              "additionalProperties": false
+            },
+            "value": {
+              "label": "Value",
+              "description": "The value of the custom user property.",
+              "type": "string",
+              "required": false,
+              "multiple": false,
+              "allowNull": false,
+              "dynamic": false,
+              "default": null,
+              "choices": null,
+              "placeholder": null,
+              "properties": null,
+              "category": null,
+              "depends_on": null,
+              "readOnly": null,
+              "hidden": null,
+              "minimum": null,
+              "maximum": null,
+              "defaultObjectUI": null,
+              "disabledInputMethods": null,
+              "displayMode": null,
+              "format": null,
+              "additionalProperties": false
+            }
+          },
+          "category": null,
+          "depends_on": {
+            "match": "all",
+            "conditions": [
+              {
+                "fieldKey": "custom_properties_mode",
+                "operator": "is",
+                "value": "v2"
+              }
+            ]
+          },
+          "readOnly": null,
+          "hidden": null,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "arrayeditor",
           "disabledInputMethods": null,
           "displayMode": null,
           "format": null,


### PR DESCRIPTION
## Summary

- Adds a new `Custom Properties Mode` dropdown (`v1` / `v2`) that controls which custom properties field is shown
- Adds `custom_user_properties`: a structured array-editor field where each item has a `name` (static), `type` (static dropdown: STRING/NUMBER/BOOLEAN/DATE), and `value` (freely mappable)
- `custom_traits` (legacy key-value) is now gated behind the `v1` mode or `undefined` (pre-existing instances with no saved mode value continue to see the legacy field unchanged)
- New instances default to `v2`
- v2 code path derives field names and explicit types directly from array items; v1 path is unchanged

## Test plan

- [ ] New instance: verify `Custom Properties Mode` defaults to "Custom User Properties" (v2) and the array editor is shown
- [ ] Toggle to "Legacy (Key-Value)": verify `custom_traits` key-value field appears and array editor is hidden
- [ ] Pre-existing instance with no mode value: verify legacy `custom_traits` field is shown
- [ ] v2 path: add properties with each type (STRING, NUMBER, BOOLEAN, DATE) and confirm the mapping schema sent to StackAdapt uses the correct types
- [ ] v2 path: confirm reserved keys (`segment_computation_key`, `segment_computation_id`) are filtered from profile properties
- [ ] v1 path: confirm existing custom_traits behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)