### PR TITLE
Internal Artifactory release

### DIFF
--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.498.0",
+  "version": "3.499.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",


### PR DESCRIPTION
This PR was opened by action-cli's trigger-action-destinations-publish command.
Merging it bumps package versions ahead of an internal-only NPM Artifactory publish.

# Changed packages
- packages/destination-actions/package.json