### PR TITLE
fix(rokt-capi): repair test file broken by #3808 merge resolution

### DIFF
--- a/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
@@ -645,6 +645,41 @@ describe('RoktCapi.send', () => {
           expect(body.ip).toBeUndefined()
           return true
         })
+        .reply(200, { success: true })
+
+      const responses = await testDestination.testAction('send', {
+        event,
+        useDefaultMappings: true,
+        mapping: {
+          hashingConfiguration: {
+            hashEmail: true,
+            hashFirstName: true,
+            hashLastName: true,
+            hashMobile: true,
+            hashBillingZipcode: true
+          },
+          user_identities: {
+            email: '   ',
+            customerid: 'user-ws'
+          },
+          user_attributes: {
+            firstname: '',
+            lastname: '   ',
+            mobile: ' ',
+            billingzipcode: ''
+          },
+          device_info: {
+            http_header_user_agent: '  ',
+            ios_advertising_id: ''
+          },
+          ip: '   '
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
     it('should use distinct source_message_ids when a conversion and an audience event are sent together', async () => {
       const event = createTestEvent({
         event: 'Order Completed',
@@ -712,28 +747,6 @@ describe('RoktCapi.send', () => {
         event,
         useDefaultMappings: true,
         mapping: {
-          hashingConfiguration: {
-            hashEmail: true,
-            hashFirstName: true,
-            hashLastName: true,
-            hashMobile: true,
-            hashBillingZipcode: true
-          },
-          user_identities: {
-            email: '   ',
-            customerid: 'user-ws'
-          },
-          user_attributes: {
-            firstname: '',
-            lastname: '   ',
-            mobile: ' ',
-            billingzipcode: ''
-          },
-          device_info: {
-            http_header_user_agent: '  ',
-            ios_advertising_id: ''
-          },
-          ip: '   '
           eventDetails: {
             conversiontype: 'Order Completed',
             source_message_id: 'msg-combined',


### PR DESCRIPTION
## Summary
PR #3808 merged a bad merge-conflict resolution that spliced two `rokt-capi` `send` tests together, leaving `main` with a syntax error (`TS1005: ',' expected`) that fails compilation and the test suite.

Specifically:
- `should not send empty or whitespace-only strings as hashed values` lost its `.reply()` / `testAction()` / closing `})` — its `nock()` block ran straight into the next `it(...)`.
- That test's `mapping` fields were mashed into the following test's `mapping` (no comma after `ip: '   '`).

This de-interleaves them back into two separate, complete `it` blocks. No test logic changed — both tests are preserved as originally intended.

## Testing
- All 23 `rokt-capi` tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)