### PR TITLE
mntn test was importing crypto package and failing lint check

### DIFF
--- a/packages/destination-actions/src/destinations/mntn-audiences/__tests__/syncAudience.test.ts
+++ b/packages/destination-actions/src/destinations/mntn-audiences/__tests__/syncAudience.test.ts
@@ -13,8 +13,8 @@
  */
 
 import nock from 'nock'
-import { createHash } from 'crypto'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { processHashing } from '../../../lib/hashing-utils'
 import Destination from '../index'
 import { MNTN_API_VERSION } from '../versioning-info'
 
@@ -36,7 +36,7 @@ const TEST_SETTINGS = {
 }
 
 function sha256(value: string): string {
-  return createHash('sha256').update(value).digest('hex')
+  return processHashing(value, 'sha256', 'hex')
 }
 
 // Pull the action directly for testing performBatch without the test harness


### PR DESCRIPTION
MNTN destination had a test importing crypto package - which caused it to fail lint check. 

## Testing
None needed

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
