### PR TITLE
[ STRATCONN-6907 : Algolia-insights ] : Fixed the appId accepts URL path injection and forwards masked API keys to attacker hosts

### DIFF
--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
@@ -40,7 +40,7 @@ describe('Algolia Insights', () => {
       await expect(testDestination.testAuthentication(settings)).rejects.toThrow()
     })
 
-    it('should reject a malicious appId containing path injection characters', async () => {
+    it('should reject a malicious appId containing path injection characters', () => {
       const settings = {
         appId: 'evil.attacker.com/path?x=',
         apiKey: 'algolia-api-key'

--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
@@ -48,7 +48,7 @@ describe('Algolia Insights', () => {
       expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
     })
 
-    it('should accept a valid 10-character alphanumeric appId', async () => {
+    it('should accept a valid 10-character alphanumeric appId', () => {
       const settings = {
         appId: 'ABCDE12345',
         apiKey: 'algolia-api-key'
@@ -56,7 +56,7 @@ describe('Algolia Insights', () => {
       expect(() => algoliaApiPermissionsUrl(settings)).not.toThrow()
     })
 
-    it('should reject an appId shorter than 10 characters', async () => {
+    it('should reject an appId shorter than 10 characters', () => {
       const settings = {
         appId: 'ABCD1234',
         apiKey: 'algolia-api-key'
@@ -64,7 +64,7 @@ describe('Algolia Insights', () => {
       expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
     })
 
-    it('should reject an appId longer than 10 characters', async () => {
+    it('should reject an appId longer than 10 characters', () => {
       const settings = {
         appId: 'ABCDE123456',
         apiKey: 'algolia-api-key'
@@ -72,7 +72,7 @@ describe('Algolia Insights', () => {
       expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
     })
 
-    it('should reject an appId with special characters', async () => {
+    it('should reject an appId with special characters', () => {
       const settings = {
         appId: 'ABCD!@#$%^',
         apiKey: 'algolia-api-key'

--- a/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/__tests__/index.test.ts
@@ -9,7 +9,7 @@ describe('Algolia Insights', () => {
   describe('testAuthentication', () => {
     it('should validate authentication inputs', async () => {
       const settings = {
-        appId: 'algolia-application-id',
+        appId: 'ABCDE12345',
         apiKey: 'algolia-api-key'
       }
       const authenticateUrl = algoliaApiPermissionsUrl(settings)
@@ -24,7 +24,7 @@ describe('Algolia Insights', () => {
 
     it('should reject invalid credentials', async () => {
       const settings = {
-        appId: 'algolia-application-id',
+        appId: 'ABCDE12345',
         apiKey: 'algolia-api-key'
       }
       const authenticateUrl = algoliaApiPermissionsUrl(settings)
@@ -40,9 +40,49 @@ describe('Algolia Insights', () => {
       await expect(testDestination.testAuthentication(settings)).rejects.toThrow()
     })
 
+    it('should reject a malicious appId containing path injection characters', async () => {
+      const settings = {
+        appId: 'evil.attacker.com/path?x=',
+        apiKey: 'algolia-api-key'
+      }
+      expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
+    })
+
+    it('should accept a valid 10-character alphanumeric appId', async () => {
+      const settings = {
+        appId: 'ABCDE12345',
+        apiKey: 'algolia-api-key'
+      }
+      expect(() => algoliaApiPermissionsUrl(settings)).not.toThrow()
+    })
+
+    it('should reject an appId shorter than 10 characters', async () => {
+      const settings = {
+        appId: 'ABCD1234',
+        apiKey: 'algolia-api-key'
+      }
+      expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
+    })
+
+    it('should reject an appId longer than 10 characters', async () => {
+      const settings = {
+        appId: 'ABCDE123456',
+        apiKey: 'algolia-api-key'
+      }
+      expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
+    })
+
+    it('should reject an appId with special characters', async () => {
+      const settings = {
+        appId: 'ABCD!@#$%^',
+        apiKey: 'algolia-api-key'
+      }
+      expect(() => algoliaApiPermissionsUrl(settings)).toThrow('Provide Valid Alphanumeric Application ID.')
+    })
+
     it('should reject invalid acl', async () => {
       const settings = {
-        appId: 'algolia-application-id',
+        appId: 'ABCDE12345',
         apiKey: 'algolia-api-key'
       }
       const authenticateUrl = algoliaApiPermissionsUrl(settings)

--- a/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
+++ b/packages/destination-actions/src/destinations/algolia-insights/algolia-insight-api.ts
@@ -1,8 +1,13 @@
+import { InvalidAuthenticationError } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 export const BaseAlgoliaInsightsURL = 'https://insights.algolia.io'
 export const AlgoliaBehaviourURL = BaseAlgoliaInsightsURL + '/1/events'
-export const algoliaApiPermissionsUrl = (settings: Settings) =>
-  `https://${settings.appId}.algolia.net/1/keys/${settings.apiKey}`
+export const algoliaApiPermissionsUrl = (settings: Settings) => {
+  if (!/^[A-Z0-9]{10}$/i.test(settings.appId)) {
+    throw new InvalidAuthenticationError('Provide Valid Alphanumeric Application ID.')
+  }
+  return `https://${settings.appId}.algolia.net/1/keys/${settings.apiKey}`
+}
 
 export type AlgoliaEventType = 'view' | 'click' | 'conversion'
 


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

 https://twilio-engineering.atlassian.net/browse/STRATCONN-6907
 https://twilio-engineering.atlassian.net/browse/SECOPS-25214

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. This PR introduces the changes for fixing the URL path injection in the algolia action destinations .
2. It checks for the invalid app id which can be given in the settings and that can potentially cause the forwarding the masked api keys to the attacker hosts .
3. Regex /^[A-Z0-9]{10}$/i — allows only alphanumeric characters (letters and digits) to fixed 10 characters .
4. If app id contains the special characters like `/`, `:`, `@`, `%`, `?`, `#`, backslashes, and other  URL metacharacters then it will throw the error .

## Testing

Tested done in staging 
please find the testing document .
https://docs.google.com/document/d/1clim851AT0FuNH7BpOSQupPm40e1Z_G9bXELFbI52n0/edit?tab=t.0

Existing customer's app id are alphanumeric 10 characters long 
https://docs.google.com/document/d/149XgTeqOCkH9Sl_fhPpF2m8wFRRoeNM-Ps0g4Ki5efQ/edit?tab=t.0

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
