### PR TITLE
STRATCONN-6819 - Add Journeys unit tests for Audience destinations

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-amc/syncAudiencesToDSP/__tests__/index.test.ts
@@ -144,6 +144,36 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
     expect(response[0].options.headers).toMatchSnapshot()
   })
 
+  it('Should add user to audience when Event is Audience Entered with journey_step computation_class', async () => {
+    nock(`https://advertising-api.amazon.com`)
+      .post('/amc/audiences/records')
+      .matchHeader('content-type', 'application/vnd.amcaudiences.v1+json')
+      .reply(202, { jobRequestId: '1155d3e3-b18c-4b2b-a3b2-26173cdaf770' })
+
+    const response = await testDestination.testAction('syncAudiencesToDSP', {
+      event: {
+        ...event,
+        context: {
+          ...event.context,
+          personas: {
+            ...event.context?.personas,
+            computation_class: 'journey_step'
+          }
+        }
+      },
+      settings,
+      useDefaultMappings: true,
+      features
+    })
+
+    expect(response.length).toBe(1)
+    expect(response[0].status).toBe(202)
+    expect(response[0].data).toEqual({ jobRequestId: '1155d3e3-b18c-4b2b-a3b2-26173cdaf770' })
+    expect(response[0].options.body).toBe(
+      '{"records":[{"externalUserId":"test-kochar-01","countryCode":"US","action":"CREATE","hashedPII":[{"email":"c551027f06bd3f307ccd6abb61edc500def2680944c010e932ab5b27a3a8f151"}],"userConsent":{"geo":{"countryCode":"US"}}}],"audienceId":379909525712777677}'
+    )
+  })
+
   it('Normalise and Hash personally-identifiable input provided with SHA-256', async () => {
     nock(`https://advertising-api.amazon.com`)
       .post('/amc/audiences/records')
@@ -269,6 +299,38 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
     )
     expect(response[0].options.headers).toMatchSnapshot()
   })
+
+  it('Should delete user from audience when Event is Audience Exited with journey_step computation_class', async () => {
+    nock(`https://advertising-api.amazon.com`)
+      .post('/amc/audiences/records')
+      .matchHeader('content-type', 'application/vnd.amcaudiences.v1+json')
+      .reply(202, { jobRequestId: '1155d3e3-b18c-4b2b-a3b2-26173cdaf770' })
+
+    const response = await testDestination.testAction('syncAudiencesToDSP', {
+      event: {
+        ...event,
+        event: 'Audience Exited',
+        context: {
+          ...event.context,
+          personas: {
+            ...event.context?.personas,
+            computation_class: 'journey_step'
+          }
+        }
+      },
+      settings,
+      useDefaultMappings: true,
+      features
+    })
+
+    expect(response.length).toBe(1)
+    expect(response[0].status).toBe(202)
+    expect(response[0].data).toEqual({ jobRequestId: '1155d3e3-b18c-4b2b-a3b2-26173cdaf770' })
+    expect(response[0].options.body).toBe(
+      '{"records":[{"externalUserId":"test-kochar-01","countryCode":"US","action":"DELETE","hashedPII":[{"email":"c551027f06bd3f307ccd6abb61edc500def2680944c010e932ab5b27a3a8f151"}],"userConsent":{"geo":{"countryCode":"US"}}}],"audienceId":379909525712777677}'
+    )
+  })
+
   it('should throw an error when an event has invalid externalUserId', async () => {
     await expect(
       testDestination.testAction('syncAudiencesToDSP', {
@@ -500,9 +562,9 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
         context: {
           ...event.context,
           personas: {
-            ...event.context!.personas,
+            ...event.context?.personas,
             audience_settings: {
-              ...event.context!.personas!.audience_settings,
+              ...event.context?.personas.audience_settings,
               countryCode: 'DE'
             }
           }
@@ -515,9 +577,9 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
         context: {
           ...event.context,
           personas: {
-            ...event.context!.personas,
+            ...event.context?.personas,
             audience_settings: {
-              ...event.context!.personas!.audience_settings,
+              ...event.context?.personas.audience_settings,
               countryCode: 'DE'
             }
           }
@@ -567,9 +629,9 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
         context: {
           ...event.context,
           personas: {
-            ...event.context!.personas,
+            ...event.context?.personas,
             audience_settings: {
-              ...event.context!.personas!.audience_settings,
+              ...event.context?.personas.audience_settings,
               countryCode: 'DE'
             }
           }
@@ -587,9 +649,9 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
         context: {
           ...event.context,
           personas: {
-            ...event.context!.personas,
+            ...event.context?.personas,
             audience_settings: {
-              ...event.context!.personas!.audience_settings,
+              ...event.context?.personas.audience_settings,
               countryCode: 'DE'
             }
           }
@@ -630,9 +692,9 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
       context: {
         ...event.context,
         personas: {
-          ...event.context!.personas,
+          ...event.context?.personas,
           audience_settings: {
-            ...event.context!.personas!.audience_settings,
+            ...event.context?.personas.audience_settings,
             countryCode: 'DE'
           }
         }
@@ -645,8 +707,8 @@ describe('AmazonAds.syncAudiencesToDSP', () => {
         useDefaultMappings: true,
         features
       })
-    ).rejects.toThrowError('Consent required when sending data with UK and EEA country code DE. Please provide valid consent for amznAdStorage and amznUserData or TCF or GPP.')
+    ).rejects.toThrowError(
+      'Consent required when sending data with UK and EEA country code DE. Please provide valid consent for amznAdStorage and amznUserData or TCF or GPP.'
+    )
   })
-
-
 })

--- a/packages/destination-actions/src/destinations/amazon-eventbridge/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-eventbridge/send/__tests__/index.test.ts
@@ -52,8 +52,8 @@ const mapping = {
   time: { '@path': '$.timestamp' },
   enable_batching: true,
   batch_size: 10,
-  onMappingSave: { outputs: { sourceId: 'sourceId1'} },
-  retlOnMappingSave: { outputs: { sourceId: 'sourceId1'} }
+  onMappingSave: { outputs: { sourceId: 'sourceId1' } },
+  retlOnMappingSave: { outputs: { sourceId: 'sourceId1' } }
 }
 
 const settings: Settings = {
@@ -144,7 +144,96 @@ describe('AWS EventBridge Integration', () => {
           useDefaultMappings: true,
           mapping: mappingNoHook
         })
-      ).rejects.toThrowError(new Error("Partner Event Source ID not found. Create a Partner Event Source using the 'Create Partner Source' button in the Action Mapping, then try again."))
+      ).rejects.toThrowError(
+        new Error(
+          "Partner Event Source ID not found. Create a Partner Event Source using the 'Create Partner Source' button in the Action Mapping, then try again."
+        )
+      )
+    })
+  })
+
+  describe('retlOnMappingSave hook - performHook validate()', () => {
+    // The tests above stub the hook's *output* directly in the mapping (onMappingSave/
+    // retlOnMappingSave.outputs), and hook.test.ts unit-tests ensurePartnerSource() directly.
+    // Neither exercises performHook's own validate() step (hooks.ts), which runs before
+    // ensurePartnerSource() and short-circuits with a graceful `{ error }` value - never a thrown
+    // exception - when subscriptionMetadata.sourceId, settings.region, or settings.accountId is
+    // missing. These tests call the hook end-to-end via executeHook() to close that gap.
+    it('returns an error when subscriptionMetadata.sourceId is missing', async () => {
+      const response = await testDestination.actions.send.executeHook('retlOnMappingSave', {
+        settings,
+        payload: {},
+        hookInputs: {},
+        subscriptionMetadata: {}
+      })
+
+      expect(response).toMatchObject({
+        error: {
+          message:
+            "Partner Event Source ID not found. Create a Partner Event Source using the 'Create Partner Source' button in the Action Mapping, then try again.",
+          code: 'ERROR'
+        }
+      })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('returns an error when settings.region is missing', async () => {
+      const response = await testDestination.actions.send.executeHook('retlOnMappingSave', {
+        settings: { accountId: settings.accountId } as Settings,
+        payload: {},
+        hookInputs: {},
+        subscriptionMetadata: { sourceId: 'sourceId1' }
+      })
+
+      expect(response).toMatchObject({
+        error: {
+          message:
+            "Failed to create Partner Source ID. Region required. Ensure 'AWS Region' Settings field is populated.",
+          code: 'ERROR'
+        }
+      })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('returns an error when settings.accountId is missing', async () => {
+      const response = await testDestination.actions.send.executeHook('retlOnMappingSave', {
+        settings: { region: settings.region } as Settings,
+        payload: {},
+        hookInputs: {},
+        subscriptionMetadata: { sourceId: 'sourceId1' }
+      })
+
+      expect(response).toMatchObject({
+        error: {
+          message:
+            "Failed to create Partner Source ID failed. Account ID required. Ensure 'AWS Account ID' Settings field is populated.",
+          code: 'ERROR'
+        }
+      })
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('returns success and savedData.sourceId end-to-end when validation passes', async () => {
+      // mockReset (not just clearAllMocks from beforeEach) to drop any leftover queued
+      // mockResolvedValueOnce from earlier tests in this file that were never consumed (e.g. a
+      // preceding test that throws before its own mocked send() call is reached).
+      mockSend.mockReset()
+      mockSend.mockResolvedValueOnce({
+        PartnerEventSources: [{ SourceId: 'sourceId1' }]
+      })
+
+      const response = await testDestination.actions.send.executeHook('retlOnMappingSave', {
+        settings,
+        payload: {},
+        hookInputs: {},
+        subscriptionMetadata: { sourceId: 'sourceId1' }
+      })
+
+      expect(response).toMatchObject({
+        successMessage: 'SourceId found',
+        savedData: { sourceId: 'sourceId1' }
+      })
+      expect(mockSend).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze-cohorts/syncAudiences/__tests__/index.test.ts
@@ -340,6 +340,51 @@ describe('BrazeCohorts.syncAudiences', () => {
     expect(responses[1].options.json).toMatchSnapshot()
   })
 
+  it('should add user to braze when computation_class is journey_step (Journeys)', async () => {
+    // This destination has no computation_class-aware code at all - add/remove is decided
+    // purely by the event_properties[personas_audience_key] boolean, and computation_class
+    // is never read. Journeys sends the same "Audience Entered"/"Audience Exited" shape (this
+    // destination's defaultSubscription) with computation_class: 'journey_step' instead of
+    // 'audience'. This test pins down that Journeys traffic is handled identically to Engage.
+    nock('https://rest.iad-01.braze.com').post('/partners/segment/cohorts').reply(201, {})
+    nock('https://rest.iad-01.braze.com').post('/partners/segment/cohorts/users').reply(201, {})
+
+    const responses = await testDestination.testAction('syncAudiences', {
+      event: {
+        ...event,
+        context: {
+          ...event.context,
+          personas: {
+            ...event.context.personas,
+            computation_class: 'journey_step'
+          }
+        },
+        properties: {
+          audience_key: 'j_o_jons__step_1_ns3i7',
+          j_o_jons__step_1_ns3i7: true
+        }
+      },
+      settings: {
+        endpoint: 'https://rest.iad-01.braze.com',
+        client_secret: 'valid_client_secret_key'
+      },
+      useDefaultMappings: true,
+      mapping
+    })
+    expect(responses.length).toBe(2)
+    expect(responses[0].status).toBe(201)
+    expect(responses[1].status).toBe(201)
+    expect(responses[1].options.json).toMatchObject({
+      cohort_changes: expect.arrayContaining([
+        expect.objectContaining({
+          user_ids: ['w8KWCsdTxe1Ydaf3s62UMc'],
+          device_ids: [],
+          aliases: []
+        })
+      ])
+    })
+  })
+
   it('should not hit create cohort api when cohort_name is available in state context is matching with computation key', async () => {
     nock('https://rest.iad-01.braze.com').post('/partners/segment/cohorts/users').reply(201, {})
 

--- a/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
+++ b/packages/destination-actions/src/destinations/braze/__tests__/braze.test.ts
@@ -112,7 +112,7 @@ describe('Braze Cloud Mode (Actions)', () => {
           external_id: 'user1234',
           email: 'test@example.com',
           first_name: 'John',
-          subscription_groups: { '@path': '$.traits.subscription_groups'}
+          subscription_groups: { '@path': '$.traits.subscription_groups' }
         }
       })
 
@@ -159,7 +159,7 @@ describe('Braze Cloud Mode (Actions)', () => {
         mapping: {
           external_id: 'user1234',
           email: 'test@example.com',
-          subscription_groups: { '@path': '$.traits.subscription_groups'}
+          subscription_groups: { '@path': '$.traits.subscription_groups' }
         }
       })
 
@@ -650,6 +650,205 @@ describe('Braze Cloud Mode (Actions)', () => {
 
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
+    })
+  })
+
+  describe('presets', () => {
+    it('should route the "Entities Audience Entered" preset through trackEvent with the correct payload', async () => {
+      const preset = Braze.presets?.find((p) => p.name === 'Entities Audience Entered')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('trackEvent')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('warehouse_audience_entered_track')
+
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
+
+      // This preset has no FQL `subscribe` filter — it's matched purely by eventSlug — so build a
+      // realistic warehouse "audience entered" track event carrying the fields the preset's
+      // (default) mapping reads from.
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Audience Entered',
+        userId: 'user1234',
+        receivedAt,
+        properties: {
+          audience_key: 'sneakers_buyers',
+          audience_name: 'Sneakers Buyers'
+        }
+      })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        settings,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        events: [
+          {
+            external_id: 'user1234',
+            app_id: 'my-app-id',
+            name: 'Audience Entered',
+            time: receivedAt,
+            properties: {
+              audience_key: 'sneakers_buyers',
+              audience_name: 'Sneakers Buyers'
+            },
+            _update_existing_only: false
+          }
+        ]
+      })
+    })
+
+    it('should route the "Entities Exited" preset through trackEvent with the correct payload', async () => {
+      const preset = Braze.presets?.find((p) => p.name === 'Entities Exited')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('trackEvent')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('warehouse_audience_exited_track')
+
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Audience Exited',
+        userId: 'user1234',
+        receivedAt,
+        properties: {
+          audience_key: 'sneakers_buyers',
+          audience_name: 'Sneakers Buyers'
+        }
+      })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        settings,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        events: [
+          {
+            external_id: 'user1234',
+            app_id: 'my-app-id',
+            name: 'Audience Exited',
+            time: receivedAt,
+            properties: {
+              audience_key: 'sneakers_buyers',
+              audience_name: 'Sneakers Buyers'
+            },
+            _update_existing_only: false
+          }
+        ]
+      })
+    })
+
+    it('should route the "Entities Audience Membership Changed" preset through updateUserProfile with the correct payload', async () => {
+      const preset = Braze.presets?.find((p) => p.name === 'Entities Audience Membership Changed')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('updateUserProfile')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('warehouse_audience_membership_changed_identify')
+
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
+
+      const event = createTestEvent({
+        type: 'identify',
+        userId: 'user1234',
+        receivedAt,
+        traits: {
+          sneakers_buyers: true,
+          loyalty_tier: 'gold'
+        }
+      })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        settings,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        attributes: [
+          expect.objectContaining({
+            external_id: 'user1234',
+            sneakers_buyers: true,
+            loyalty_tier: 'gold',
+            _update_existing_only: false
+          })
+        ]
+      })
+    })
+
+    it('should route the "Journeys Step Transition Track" preset through trackEvent with the correct payload', async () => {
+      const preset = Braze.presets?.find((p) => p.name === 'Journeys Step Transition Track')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('trackEvent')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('journeys_step_entered_track')
+
+      nock('https://rest.iad-01.braze.com').post('/users/track').reply(200, {})
+
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Journey Step Entered',
+        userId: 'user1234',
+        receivedAt,
+        properties: {
+          journey_metadata: {
+            journey_id: 'test-journey-id',
+            journey_name: 'test-journey-name',
+            step_id: 'test-step-id',
+            step_name: 'test-step-name'
+          }
+        }
+      })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        settings,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+      expect(responses[0].options.json).toMatchObject({
+        events: [
+          {
+            external_id: 'user1234',
+            app_id: 'my-app-id',
+            name: 'Journey Step Entered',
+            time: receivedAt,
+            properties: {
+              journey_metadata: {
+                journey_id: 'test-journey-id',
+                journey_name: 'test-journey-name',
+                step_id: 'test-step-id',
+                step_name: 'test-step-name'
+              }
+            },
+            _update_existing_only: false
+          }
+        ]
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/braze/createAlias2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/createAlias2/__tests__/index.test.ts
@@ -1,0 +1,56 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+const settings: Settings = {
+  api_key: 'test_api_key',
+  app_id: 'test_app_id',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
+
+describe('Braze.createAlias2 syncMode', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should succeed and create the alias when the only supported syncMode ("add") is used', async () => {
+    const event = createTestEvent({
+      event: 'Create Alias',
+      type: 'track',
+      userId: 'user-1'
+    })
+
+    nock(settings.endpoint).post('/users/alias/new').reply(201, {})
+
+    const responses = await testDestination.testAction('createAlias2', {
+      event,
+      settings,
+      mapping: {
+        external_id: 'user-1',
+        alias_name: 'alias-1',
+        alias_label: 'label-1',
+        __segment_internal_sync_mode: 'add'
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(201)
+    expect(responses[0].options.json).toEqual({
+      user_aliases: [
+        {
+          external_id: 'user-1',
+          alias_name: 'alias-1',
+          alias_label: 'label-1'
+        }
+      ]
+    })
+  })
+
+  // createAlias2's syncMode field only exposes a single valid choice ('add'). Unlike the other
+  // Braze V2 actions, the perform() function doesn't branch behavior based on the syncMode value -
+  // it only uses syncMode as a gate (any value other than 'add' throws). The request body sent to
+  // Braze is identical regardless of what a hypothetical additional syncMode value would be.
+})

--- a/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
@@ -52,7 +52,7 @@ const payload = {
         product_url: 'https://example.com/prod1',
         quantity: 2,
         price: 25.0,
-        color: 'red', 
+        color: 'red',
         size: 'M'
       },
       {
@@ -71,7 +71,7 @@ const payload = {
       variant: 'Size M',
       image_url: 'https://example.com/prod1.jpg',
       product_url: 'https://example.com/prod1',
-      price: 25.0,
+      price: 25.0
     },
     metadata: {
       custom_field_1: 'custom_value_1',
@@ -100,32 +100,32 @@ const mapping = {
   cart_id: { '@path': '$.properties.cart_id' },
   total_value: { '@path': '$.properties.total' },
   total_discounts: { '@path': '$.properties.discount' },
-  discounts: {'@path': '$.properties.discount_items' },
+  discounts: { '@path': '$.properties.discount_items' },
   currency: { '@path': '$.properties.currency' },
   source: { '@path': '$.properties.source' },
   products: {
-      '@arrayPath': [
-          '$.properties.products',
-          {
-              product_id: { '@path': '$.product_id' },
-              product_name: { '@path': '$.name' },
-              variant_id: { '@path': '$.variant'},
-              image_url: {'@path': '$.image_url'},
-              product_url: {'@path': '$.url'},
-              quantity: {'@path': '$.quantity'},
-              price: {'@path': '$.price'}, 
-              color: { '@path': '$.color' },
-              size: { '@path': '$.size' }
-          }
-      ]
+    '@arrayPath': [
+      '$.properties.products',
+      {
+        product_id: { '@path': '$.product_id' },
+        product_name: { '@path': '$.name' },
+        variant_id: { '@path': '$.variant' },
+        image_url: { '@path': '$.image_url' },
+        product_url: { '@path': '$.url' },
+        quantity: { '@path': '$.quantity' },
+        price: { '@path': '$.price' },
+        color: { '@path': '$.color' },
+        size: { '@path': '$.size' }
+      }
+    ]
   },
   product: {
-      product_id: { '@path': '$.properties.product.product_id' },
-      product_name: { '@path': '$.properties.product.name' },
-      variant_id: { '@path': '$.properties.product.variant'},
-      image_url: {'@path': '$.properties.product.image_url'},
-      product_url: {'@path': '$.properties.product.url'},
-      price: {'@path': '$.properties.product.price'}
+    product_id: { '@path': '$.properties.product.product_id' },
+    product_name: { '@path': '$.properties.product.name' },
+    variant_id: { '@path': '$.properties.product.variant' },
+    image_url: { '@path': '$.properties.product.image_url' },
+    product_url: { '@path': '$.properties.product.url' },
+    price: { '@path': '$.properties.product.price' }
   },
   metadata: { '@path': '$.properties.metadata' },
   type: { '@path': '$.properties.type' },
@@ -145,7 +145,6 @@ afterEach(() => {
 })
 
 describe('Braze.ecommerce', () => {
-
   describe('single event', () => {
     it('should send Order Completed event correctly', async () => {
       const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
@@ -155,60 +154,60 @@ describe('Braze.ecommerce', () => {
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
             user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            app_id: "test_app_id",
-            name: "ecommerce.order_placed",
-            time: "2024-06-10T12:00:00.000Z",
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_placed',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
                   metadata: {
-                    color: "red",
-                    size: "M"
+                    color: 'red',
+                    size: 'M'
                   }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ],
-              cart_id: "cart_id_1",
+              cart_id: 'cart_id_1',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
+                custom_field_4: ['a', 'b', 'c'],
                 custom_field_5: {
-                  nested_key: "nested_value"
+                  nested_key: 'nested_value'
                 },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               }
             },
             _update_existing_only: true
@@ -216,9 +215,7 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.testAction('ecommerce', {
         event: e,
@@ -226,15 +223,14 @@ describe('Braze.ecommerce', () => {
         useDefaultMappings: true,
         mapping
       })
-    
+
       expect(response.length).toBe(1)
     })
 
     it('should send Checkout Started event correctly', async () => {
-
-      const mapping2 = { 
-        ...mapping, 
-        name: EVENT_NAMES.CHECKOUT_STARTED 
+      const mapping2 = {
+        ...mapping,
+        name: EVENT_NAMES.CHECKOUT_STARTED
       }
 
       const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
@@ -244,53 +240,53 @@ describe('Braze.ecommerce', () => {
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
             user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            app_id: "test_app_id",
-            name: "ecommerce.checkout_started",
-            time: "2024-06-10T12:00:00.000Z",
+            app_id: 'test_app_id',
+            name: 'ecommerce.checkout_started',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
                   metadata: {
-                    color: "red",
-                    size: "M"
+                    color: 'red',
+                    size: 'M'
                   }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              checkout_id: "checkout_id_1",
-              cart_id: "cart_id_1",
+              checkout_id: 'checkout_id_1',
+              cart_id: 'cart_id_1',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               }
             },
             _update_existing_only: true
@@ -298,9 +294,7 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.testAction('ecommerce', {
         event: e,
@@ -308,15 +302,14 @@ describe('Braze.ecommerce', () => {
         useDefaultMappings: true,
         mapping: mapping2
       })
-    
+
       expect(response.length).toBe(1)
     })
 
     it('should send Order Refunded event correctly', async () => {
-
-      const mapping2 = { 
-        ...mapping, 
-        name: EVENT_NAMES.ORDER_REFUNDED 
+      const mapping2 = {
+        ...mapping,
+        name: EVENT_NAMES.ORDER_REFUNDED
       }
 
       const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
@@ -326,57 +319,57 @@ describe('Braze.ecommerce', () => {
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
             user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            app_id: "test_app_id",
-            name: "ecommerce.order_refunded",
-            time: "2024-06-10T12:00:00.000Z",
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_refunded',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
                   metadata: {
-                    color: "red",
-                    size: "M"
+                    color: 'red',
+                    size: 'M'
                   }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ],
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               }
             },
             _update_existing_only: true
@@ -384,9 +377,7 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.testAction('ecommerce', {
         event: e,
@@ -394,15 +385,14 @@ describe('Braze.ecommerce', () => {
         useDefaultMappings: true,
         mapping: mapping2
       })
-    
+
       expect(response.length).toBe(1)
-    })  
+    })
 
     it('should send Order Cancelled event correctly', async () => {
-
-      const mapping2 = { 
-        ...mapping, 
-        name: EVENT_NAMES.ORDER_CANCELLED 
+      const mapping2 = {
+        ...mapping,
+        name: EVENT_NAMES.ORDER_CANCELLED
       }
 
       const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
@@ -412,58 +402,58 @@ describe('Braze.ecommerce', () => {
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
             user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            app_id: "test_app_id",
-            name: "ecommerce.order_cancelled",
-            time: "2024-06-10T12:00:00.000Z",
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_cancelled',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
                   metadata: {
-                    color: "red",
-                    size: "M"
+                    color: 'red',
+                    size: 'M'
                   }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               cancel_reason: "I didn't like it",
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ],
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               }
             },
             _update_existing_only: true
@@ -471,9 +461,7 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.testAction('ecommerce', {
         event: e,
@@ -481,12 +469,11 @@ describe('Braze.ecommerce', () => {
         useDefaultMappings: true,
         mapping: mapping2
       })
-    
+
       expect(response.length).toBe(1)
-    })  
+    })
 
     it('should throw an error if missing identifier', async () => {
-
       const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const e = createTestEvent(deepCopy)
 
@@ -504,7 +491,9 @@ describe('Braze.ecommerce', () => {
           useDefaultMappings: true,
           mapping
         })
-      ).rejects.toThrowError(new Error('One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.'))
+      ).rejects.toThrowError(
+        new Error('One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.')
+      )
     })
 
     it('should throw an error if missing syncMode', async () => {
@@ -514,7 +503,7 @@ describe('Braze.ecommerce', () => {
           settings,
           useDefaultMappings: true,
           mapping: {
-            ...mapping, 
+            ...mapping,
             __segment_internal_sync_mode: ''
           }
         })
@@ -524,219 +513,218 @@ describe('Braze.ecommerce', () => {
 
   describe('batch events', () => {
     it('should send batched multi product ecommerce events correctly', async () => {
-
       const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy4: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
 
-      const e1 = createTestEvent({...deepCopy1, userId: 'userId1', event: 'ecommerce.order_placed' })
-      const e2 = createTestEvent({...deepCopy2, userId: 'userId2', event: 'ecommerce.order_refunded' })
-      const e3 = createTestEvent({...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
-      const e4 = createTestEvent({...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })
+      const e1 = createTestEvent({ ...deepCopy1, userId: 'userId1', event: 'ecommerce.order_placed' })
+      const e2 = createTestEvent({ ...deepCopy2, userId: 'userId2', event: 'ecommerce.order_refunded' })
+      const e3 = createTestEvent({ ...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
+      const e4 = createTestEvent({ ...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })
       const events = [e1, e2, e3, e4]
 
-      const mapping2 = { 
-        ...mapping, 
-        name: { '@path': '$.event' },
+      const mapping2 = {
+        ...mapping,
+        name: { '@path': '$.event' }
       }
 
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_placed",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_placed',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ],
-              cart_id: "cart_id_1"
+              cart_id: 'cart_id_1'
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId2",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_refunded",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId2',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_refunded',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
-                  metadata: { color: "red", size: "M" },
+                  metadata: { color: 'red', size: 'M' },
                   price: 25
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId3",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.checkout_started",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId3',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.checkout_started',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              checkout_id: "checkout_id_1",
-              cart_id: "cart_id_1"
+              checkout_id: 'checkout_id_1',
+              cart_id: 'cart_id_1'
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId4",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_cancelled",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId4',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_cancelled',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               cancel_reason: "I didn't like it",
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
@@ -744,31 +732,26 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .matchHeader('X-Braze-Batch', 'true')
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).matchHeader('X-Braze-Batch', 'true').reply(200)
 
       const response = await testDestination.testBatchAction('ecommerce', {
         events,
         settings,
         mapping: mapping2
       })
-    
-      expect(response.length).toBe(1)
 
+      expect(response.length).toBe(1)
     })
 
     it('should return correct multistatus response if there is a bad event', async () => {
-
       const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy4: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
 
-      const e1 = createTestEvent({...deepCopy1, userId: 'userId1', event: 'ecommerce.order_refunded' })
+      const e1 = createTestEvent({ ...deepCopy1, userId: 'userId1', event: 'ecommerce.order_refunded' })
 
-      const e2 = createTestEvent({...deepCopy2})
+      const e2 = createTestEvent({ ...deepCopy2 })
       e2.userId = undefined
       delete e2.properties?.email
       delete e2.properties?.phone
@@ -777,156 +760,156 @@ describe('Braze.ecommerce', () => {
       delete e2.properties?.user_alias
       e2.event = 'ecommerce.order_placed'
 
-      const e3 = createTestEvent({...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
-      const e4 = createTestEvent({...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })   
+      const e3 = createTestEvent({ ...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
+      const e4 = createTestEvent({ ...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })
 
       const events = [e1, e2, e3, e4]
-      
+
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_refunded",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_refunded',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId3",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.checkout_started",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId3',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.checkout_started',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              checkout_id: "checkout_id_1",
-              cart_id: "cart_id_1"
+              checkout_id: 'checkout_id_1',
+              cart_id: 'cart_id_1'
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId4",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_cancelled",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId4',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_cancelled',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               cancel_reason: "I didn't like it",
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
@@ -934,298 +917,280 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      const mapping2 = { 
-        ...mapping, 
-        name: { '@path': '$.event' },
+      const mapping2 = {
+        ...mapping,
+        name: { '@path': '$.event' }
       }
 
       const responseJSON = [
         {
-          "status": 200,
-          "sent": {
-            "name": "ecommerce.order_refunded",
-            "external_id": "userId1",
-            "user_alias": {
-              "alias_name": "alias_name_1",
-              "alias_label": "alias_label_1"
+          status: 200,
+          sent: {
+            name: 'ecommerce.order_refunded',
+            external_id: 'userId1',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            "email": "email@email.com",
-            "phone": "+14155551234",
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "time": "2024-06-10T12:00:00.000Z",
-            "checkout_id": "checkout_id_1",
-            "order_id": "order_id_1",
-            "cart_id": "cart_id_1",
-            "total_value": 100,
-            "total_discounts": 10,
-            "discounts": [
+            email: 'email@email.com',
+            phone: '+14155551234',
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            time: '2024-06-10T12:00:00.000Z',
+            checkout_id: 'checkout_id_1',
+            order_id: 'order_id_1',
+            cart_id: 'cart_id_1',
+            total_value: 100,
+            total_discounts: 10,
+            discounts: [
               {
-                "code": "SUMMER21",
-                "amount": 5
+                code: 'SUMMER21',
+                amount: 5
               },
               {
-                "code": "VIPCUSTOMER",
-                "amount": 5
+                code: 'VIPCUSTOMER',
+                amount: 5
               }
             ],
-            "currency": "USD",
-            "source": "test_source",
-            "products": [
+            currency: 'USD',
+            source: 'test_source',
+            products: [
               {
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "variant_id": "Size M",
-                "image_url": "https://example.com/prod1.jpg",
-                "quantity": 2,
-                "price": 25,
-                "color": "red",
-                "size": "M"
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                variant_id: 'Size M',
+                image_url: 'https://example.com/prod1.jpg',
+                quantity: 2,
+                price: 25,
+                color: 'red',
+                size: 'M'
               },
               {
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "variant_id": "Size L",
-                "image_url": "https://example.com/prod2.jpg",
-                "quantity": 1,
-                "price": 50
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                variant_id: 'Size L',
+                image_url: 'https://example.com/prod2.jpg',
+                quantity: 1,
+                price: 50
               }
             ],
-            "metadata": {
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": [
-                "a",
-                "b",
-                "c"
-              ],
-              "custom_field_5": {
-                "nested_key": "nested_value"
+            metadata: {
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: {
+                nested_key: 'nested_value'
               },
-              "checkout_url": "https://example.com/checkout",
-              "order_status_url": "https://example.com/order/status"
+              checkout_url: 'https://example.com/checkout',
+              order_status_url: 'https://example.com/order/status'
             },
-            "enable_batching": true,
-            "batch_size": 75,
-            "index": 0
+            enable_batching: true,
+            batch_size: 75,
+            index: 0
           },
-          "body": "{\"external_id\":\"userId1\",\"braze_id\":\"braze_id_1\",\"email\":\"email@email.com\",\"phone\":\"+14155551234\",\"user_alias\":{\"alias_name\":\"alias_name_1\",\"alias_label\":\"alias_label_1\"},\"app_id\":\"test_app_id\",\"name\":\"ecommerce.order_refunded\",\"time\":\"2024-06-10T12:00:00.000Z\",\"properties\":{\"currency\":\"USD\",\"source\":\"test_source\",\"metadata\":{\"custom_field_1\":\"custom_value_1\",\"custom_field_2\":100,\"custom_field_3\":true,\"custom_field_4\":[\"a\",\"b\",\"c\"],\"custom_field_5\":{\"nested_key\":\"nested_value\"},\"checkout_url\":\"https://example.com/checkout\",\"order_status_url\":\"https://example.com/order/status\"},\"products\":[{\"quantity\":2,\"product_id\":\"prod_1\",\"product_name\":\"Product 1\",\"variant_id\":\"Size M\",\"price\":25,\"image_url\":\"https://example.com/prod1.jpg\",\"metadata\":{\"color\":\"red\",\"size\":\"M\"}},{\"quantity\":1,\"product_id\":\"prod_2\",\"product_name\":\"Product 2\",\"variant_id\":\"Size L\",\"price\":50,\"image_url\":\"https://example.com/prod2.jpg\"}],\"total_value\":100,\"order_id\":\"order_id_1\",\"total_discounts\":10,\"discounts\":[{\"code\":\"SUMMER21\",\"amount\":5},{\"code\":\"VIPCUSTOMER\",\"amount\":5}]},\"_update_existing_only\":true}"
+          body: '{"external_id":"userId1","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.order_refunded","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"order_id":"order_id_1","total_discounts":10,"discounts":[{"code":"SUMMER21","amount":5},{"code":"VIPCUSTOMER","amount":5}]},"_update_existing_only":true}'
         },
         {
-          "status": 400,
-          "errormessage": "One of \"external_id\" or \"user_alias\" or \"braze_id\" or \"email\" or \"phone\" is required.",
-          "sent": {
-            "name": "ecommerce.order_placed",
-            "cancel_reason": "I didn't like it",
-            "time": "2024-06-10T12:00:00.000Z",
-            "checkout_id": "checkout_id_1",
-            "order_id": "order_id_1",
-            "cart_id": "cart_id_1",
-            "total_value": 100,
-            "total_discounts": 10,
-            "discounts": [
+          status: 400,
+          errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.',
+          sent: {
+            name: 'ecommerce.order_placed',
+            cancel_reason: "I didn't like it",
+            time: '2024-06-10T12:00:00.000Z',
+            checkout_id: 'checkout_id_1',
+            order_id: 'order_id_1',
+            cart_id: 'cart_id_1',
+            total_value: 100,
+            total_discounts: 10,
+            discounts: [
               {
-                "code": "SUMMER21",
-                "amount": 5
+                code: 'SUMMER21',
+                amount: 5
               },
               {
-                "code": "VIPCUSTOMER",
-                "amount": 5
+                code: 'VIPCUSTOMER',
+                amount: 5
               }
             ],
-            "currency": "USD",
-            "source": "test_source",
-            "products": [
+            currency: 'USD',
+            source: 'test_source',
+            products: [
               {
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "variant_id": "Size M",
-                "image_url": "https://example.com/prod1.jpg",
-                "quantity": 2,
-                "price": 25,
-                "color": "red",
-                "size": "M"
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                variant_id: 'Size M',
+                image_url: 'https://example.com/prod1.jpg',
+                quantity: 2,
+                price: 25,
+                color: 'red',
+                size: 'M'
               },
               {
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "variant_id": "Size L",
-                "image_url": "https://example.com/prod2.jpg",
-                "quantity": 1,
-                "price": 50
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                variant_id: 'Size L',
+                image_url: 'https://example.com/prod2.jpg',
+                quantity: 1,
+                price: 50
               }
             ],
-            "metadata": {
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": [
-                "a",
-                "b",
-                "c"
-              ],
-              "custom_field_5": {
-                "nested_key": "nested_value"
+            metadata: {
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: {
+                nested_key: 'nested_value'
               },
-              "checkout_url": "https://example.com/checkout",
-              "order_status_url": "https://example.com/order/status"
+              checkout_url: 'https://example.com/checkout',
+              order_status_url: 'https://example.com/order/status'
             },
-            "enable_batching": true,
-            "batch_size": 75
+            enable_batching: true,
+            batch_size: 75
           },
-          "errortype": "BAD_REQUEST",
-          "errorreporter": "DESTINATION"
+          errortype: 'BAD_REQUEST',
+          errorreporter: 'DESTINATION'
         },
         {
-          "status": 200,
-          "sent": {
-            "name": "ecommerce.checkout_started",
-            "external_id": "userId3",
-            "user_alias": {
-              "alias_name": "alias_name_1",
-              "alias_label": "alias_label_1"
+          status: 200,
+          sent: {
+            name: 'ecommerce.checkout_started',
+            external_id: 'userId3',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            "email": "email@email.com",
-            "phone": "+14155551234",
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "time": "2024-06-10T12:00:00.000Z",
-            "checkout_id": "checkout_id_1",
-            "order_id": "order_id_1",
-            "cart_id": "cart_id_1",
-            "total_value": 100,
-            "total_discounts": 10,
-            "discounts": [
+            email: 'email@email.com',
+            phone: '+14155551234',
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            time: '2024-06-10T12:00:00.000Z',
+            checkout_id: 'checkout_id_1',
+            order_id: 'order_id_1',
+            cart_id: 'cart_id_1',
+            total_value: 100,
+            total_discounts: 10,
+            discounts: [
               {
-                "code": "SUMMER21",
-                "amount": 5
+                code: 'SUMMER21',
+                amount: 5
               },
               {
-                "code": "VIPCUSTOMER",
-                "amount": 5
+                code: 'VIPCUSTOMER',
+                amount: 5
               }
             ],
-            "currency": "USD",
-            "source": "test_source",
-            "products": [
+            currency: 'USD',
+            source: 'test_source',
+            products: [
               {
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "variant_id": "Size M",
-                "image_url": "https://example.com/prod1.jpg",
-                "quantity": 2,
-                "price": 25,
-                "color": "red",
-                "size": "M"
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                variant_id: 'Size M',
+                image_url: 'https://example.com/prod1.jpg',
+                quantity: 2,
+                price: 25,
+                color: 'red',
+                size: 'M'
               },
               {
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "variant_id": "Size L",
-                "image_url": "https://example.com/prod2.jpg",
-                "quantity": 1,
-                "price": 50
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                variant_id: 'Size L',
+                image_url: 'https://example.com/prod2.jpg',
+                quantity: 1,
+                price: 50
               }
             ],
-            "metadata": {
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": [
-                "a",
-                "b",
-                "c"
-              ],
-              "custom_field_5": {
-                "nested_key": "nested_value"
+            metadata: {
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: {
+                nested_key: 'nested_value'
               },
-              "checkout_url": "https://example.com/checkout",
-              "order_status_url": "https://example.com/order/status"
+              checkout_url: 'https://example.com/checkout',
+              order_status_url: 'https://example.com/order/status'
             },
-            "enable_batching": true,
-            "batch_size": 75,
-            "index": 1
+            enable_batching: true,
+            batch_size: 75,
+            index: 1
           },
-          "body": "{\"external_id\":\"userId3\",\"braze_id\":\"braze_id_1\",\"email\":\"email@email.com\",\"phone\":\"+14155551234\",\"user_alias\":{\"alias_name\":\"alias_name_1\",\"alias_label\":\"alias_label_1\"},\"app_id\":\"test_app_id\",\"name\":\"ecommerce.checkout_started\",\"time\":\"2024-06-10T12:00:00.000Z\",\"properties\":{\"currency\":\"USD\",\"source\":\"test_source\",\"metadata\":{\"custom_field_1\":\"custom_value_1\",\"custom_field_2\":100,\"custom_field_3\":true,\"custom_field_4\":[\"a\",\"b\",\"c\"],\"custom_field_5\":{\"nested_key\":\"nested_value\"},\"checkout_url\":\"https://example.com/checkout\",\"order_status_url\":\"https://example.com/order/status\"},\"products\":[{\"quantity\":2,\"product_id\":\"prod_1\",\"product_name\":\"Product 1\",\"variant_id\":\"Size M\",\"price\":25,\"image_url\":\"https://example.com/prod1.jpg\",\"metadata\":{\"color\":\"red\",\"size\":\"M\"}},{\"quantity\":1,\"product_id\":\"prod_2\",\"product_name\":\"Product 2\",\"variant_id\":\"Size L\",\"price\":50,\"image_url\":\"https://example.com/prod2.jpg\"}],\"total_value\":100,\"checkout_id\":\"checkout_id_1\",\"cart_id\":\"cart_id_1\"},\"_update_existing_only\":true}"
+          body: '{"external_id":"userId3","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.checkout_started","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"checkout_id":"checkout_id_1","cart_id":"cart_id_1"},"_update_existing_only":true}'
         },
         {
-          "status": 200,
-          "sent": {
-            "name": "ecommerce.order_cancelled",
-            "external_id": "userId4",
-            "user_alias": {
-              "alias_name": "alias_name_1",
-              "alias_label": "alias_label_1"
+          status: 200,
+          sent: {
+            name: 'ecommerce.order_cancelled',
+            external_id: 'userId4',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            "email": "email@email.com",
-            "phone": "+14155551234",
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "time": "2024-06-10T12:00:00.000Z",
-            "checkout_id": "checkout_id_1",
-            "order_id": "order_id_1",
-            "cart_id": "cart_id_1",
-            "total_value": 100,
-            "total_discounts": 10,
-            "discounts": [
+            email: 'email@email.com',
+            phone: '+14155551234',
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            time: '2024-06-10T12:00:00.000Z',
+            checkout_id: 'checkout_id_1',
+            order_id: 'order_id_1',
+            cart_id: 'cart_id_1',
+            total_value: 100,
+            total_discounts: 10,
+            discounts: [
               {
-                "code": "SUMMER21",
-                "amount": 5
+                code: 'SUMMER21',
+                amount: 5
               },
               {
-                "code": "VIPCUSTOMER",
-                "amount": 5
+                code: 'VIPCUSTOMER',
+                amount: 5
               }
             ],
-            "currency": "USD",
-            "source": "test_source",
-            "products": [
+            currency: 'USD',
+            source: 'test_source',
+            products: [
               {
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "variant_id": "Size M",
-                "image_url": "https://example.com/prod1.jpg",
-                "quantity": 2,
-                "price": 25,
-                "color": "red",
-                "size": "M"
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                variant_id: 'Size M',
+                image_url: 'https://example.com/prod1.jpg',
+                quantity: 2,
+                price: 25,
+                color: 'red',
+                size: 'M'
               },
               {
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "variant_id": "Size L",
-                "image_url": "https://example.com/prod2.jpg",
-                "quantity": 1,
-                "price": 50
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                variant_id: 'Size L',
+                image_url: 'https://example.com/prod2.jpg',
+                quantity: 1,
+                price: 50
               }
             ],
-            "metadata": {
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": [
-                "a",
-                "b",
-                "c"
-              ],
-              "custom_field_5": {
-                "nested_key": "nested_value"
+            metadata: {
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: {
+                nested_key: 'nested_value'
               },
-              "checkout_url": "https://example.com/checkout",
-              "order_status_url": "https://example.com/order/status"
+              checkout_url: 'https://example.com/checkout',
+              order_status_url: 'https://example.com/order/status'
             },
-            "enable_batching": true,
-            "batch_size": 75,
-            "index": 2
+            enable_batching: true,
+            batch_size: 75,
+            index: 2
           },
-          "body": "{\"external_id\":\"userId4\",\"braze_id\":\"braze_id_1\",\"email\":\"email@email.com\",\"phone\":\"+14155551234\",\"user_alias\":{\"alias_name\":\"alias_name_1\",\"alias_label\":\"alias_label_1\"},\"app_id\":\"test_app_id\",\"name\":\"ecommerce.order_cancelled\",\"time\":\"2024-06-10T12:00:00.000Z\",\"properties\":{\"currency\":\"USD\",\"source\":\"test_source\",\"metadata\":{\"custom_field_1\":\"custom_value_1\",\"custom_field_2\":100,\"custom_field_3\":true,\"custom_field_4\":[\"a\",\"b\",\"c\"],\"custom_field_5\":{\"nested_key\":\"nested_value\"},\"checkout_url\":\"https://example.com/checkout\",\"order_status_url\":\"https://example.com/order/status\"},\"products\":[{\"quantity\":2,\"product_id\":\"prod_1\",\"product_name\":\"Product 1\",\"variant_id\":\"Size M\",\"price\":25,\"image_url\":\"https://example.com/prod1.jpg\",\"metadata\":{\"color\":\"red\",\"size\":\"M\"}},{\"quantity\":1,\"product_id\":\"prod_2\",\"product_name\":\"Product 2\",\"variant_id\":\"Size L\",\"price\":50,\"image_url\":\"https://example.com/prod2.jpg\"}],\"total_value\":100,\"order_id\":\"order_id_1\",\"cancel_reason\":\"I didn't like it\",\"total_discounts\":10,\"discounts\":[{\"code\":\"SUMMER21\",\"amount\":5},{\"code\":\"VIPCUSTOMER\",\"amount\":5}]},\"_update_existing_only\":true}"
+          body: '{"external_id":"userId4","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.order_cancelled","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"order_id":"order_id_1","cancel_reason":"I didn\'t like it","total_discounts":10,"discounts":[{"code":"SUMMER21","amount":5},{"code":"VIPCUSTOMER","amount":5}]},"_update_existing_only":true}'
         }
       ]
-      
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.executeBatch('ecommerce', {
         events,
@@ -1237,15 +1202,14 @@ describe('Braze.ecommerce', () => {
     })
 
     it('should return correct multistatus response if there no SyncMode', async () => {
-
       const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
       const deepCopy4: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
 
-      const e1 = createTestEvent({...deepCopy1, userId: 'userId1', event: 'ecommerce.order_refunded' })
+      const e1 = createTestEvent({ ...deepCopy1, userId: 'userId1', event: 'ecommerce.order_refunded' })
 
-      const e2 = createTestEvent({...deepCopy2})
+      const e2 = createTestEvent({ ...deepCopy2 })
       e2.userId = undefined
       delete e2.properties?.email
       delete e2.properties?.phone
@@ -1254,156 +1218,156 @@ describe('Braze.ecommerce', () => {
       delete e2.properties?.user_alias
       e2.event = 'ecommerce.order_placed'
 
-      const e3 = createTestEvent({...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
-      const e4 = createTestEvent({...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })   
+      const e3 = createTestEvent({ ...deepCopy3, userId: 'userId3', event: 'ecommerce.checkout_started' })
+      const e4 = createTestEvent({ ...deepCopy4, userId: 'userId4', event: 'ecommerce.order_cancelled' })
 
       const events = [e1, e2, e3, e4]
-      
+
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_refunded",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_refunded',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId3",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.checkout_started",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId3',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.checkout_started',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              checkout_id: "checkout_id_1",
-              cart_id: "cart_id_1"
+              checkout_id: 'checkout_id_1',
+              cart_id: 'cart_id_1'
             },
             _update_existing_only: true
           },
           {
-            external_id: "userId4",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: { alias_name: "alias_name_1", alias_label: "alias_label_1" },
-            app_id: "test_app_id",
-            name: "ecommerce.order_cancelled",
-            time: "2024-06-10T12:00:00.000Z",
+            external_id: 'userId4',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: { alias_name: 'alias_name_1', alias_label: 'alias_label_1' },
+            app_id: 'test_app_id',
+            name: 'ecommerce.order_cancelled',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: { nested_key: "nested_value" },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: { nested_key: 'nested_value' },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
               products: [
                 {
-                  product_id: "prod_1",
-                  product_name: "Product 1",
-                  variant_id: "Size M",
-                  image_url: "https://example.com/prod1.jpg",
+                  product_id: 'prod_1',
+                  product_name: 'Product 1',
+                  variant_id: 'Size M',
+                  image_url: 'https://example.com/prod1.jpg',
                   quantity: 2,
                   price: 25,
-                  metadata: { color: "red", size: "M" }
+                  metadata: { color: 'red', size: 'M' }
                 },
                 {
-                  product_id: "prod_2",
-                  product_name: "Product 2",
-                  variant_id: "Size L",
-                  image_url: "https://example.com/prod2.jpg",
+                  product_id: 'prod_2',
+                  product_name: 'Product 2',
+                  variant_id: 'Size L',
+                  image_url: 'https://example.com/prod2.jpg',
                   quantity: 1,
                   price: 50
                 }
               ],
               total_value: 100,
-              order_id: "order_id_1",
+              order_id: 'order_id_1',
               cancel_reason: "I didn't like it",
               total_discounts: 10,
               discounts: [
-                { code: "SUMMER21", amount: 5 },
-                { code: "VIPCUSTOMER", amount: 5 }
+                { code: 'SUMMER21', amount: 5 },
+                { code: 'VIPCUSTOMER', amount: 5 }
               ]
             },
             _update_existing_only: true
@@ -1411,254 +1375,252 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      const mapping2 = { 
+      const mapping2 = {
         ...mapping,
         __segment_internal_sync_mode: '',
-        name: { '@path': '$.event' },
+        name: { '@path': '$.event' }
       }
 
       const responseJSON = [
         {
-          "errormessage": "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          "errorreporter": "DESTINATION",
-          "errortype": "BAD_REQUEST",
-          "sent": {
-            "batch_size": 75,
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "cart_id": "cart_id_1",
-            "checkout_id": "checkout_id_1",
-            "currency": "USD",
-            "discounts": [
-              { "amount": 5, "code": "SUMMER21" },
-              { "amount": 5, "code": "VIPCUSTOMER" }
+          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
+          errorreporter: 'DESTINATION',
+          errortype: 'BAD_REQUEST',
+          sent: {
+            batch_size: 75,
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            cart_id: 'cart_id_1',
+            checkout_id: 'checkout_id_1',
+            currency: 'USD',
+            discounts: [
+              { amount: 5, code: 'SUMMER21' },
+              { amount: 5, code: 'VIPCUSTOMER' }
             ],
-            "email": "email@email.com",
-            "enable_batching": true,
-            "external_id": "userId1",
-            "metadata": {
-              "checkout_url": "https://example.com/checkout",
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": ["a", "b", "c"],
-              "custom_field_5": { "nested_key": "nested_value" },
-              "order_status_url": "https://example.com/order/status"
+            email: 'email@email.com',
+            enable_batching: true,
+            external_id: 'userId1',
+            metadata: {
+              checkout_url: 'https://example.com/checkout',
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: { nested_key: 'nested_value' },
+              order_status_url: 'https://example.com/order/status'
             },
-            "name": "ecommerce.order_refunded",
-            "order_id": "order_id_1",
-            "phone": "+14155551234",
-            "products": [
+            name: 'ecommerce.order_refunded',
+            order_id: 'order_id_1',
+            phone: '+14155551234',
+            products: [
               {
-                "color": "red",
-                "image_url": "https://example.com/prod1.jpg",
-                "price": 25,
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "quantity": 2,
-                "size": "M",
-                "variant_id": "Size M"
+                color: 'red',
+                image_url: 'https://example.com/prod1.jpg',
+                price: 25,
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                quantity: 2,
+                size: 'M',
+                variant_id: 'Size M'
               },
               {
-                "image_url": "https://example.com/prod2.jpg",
-                "price": 50,
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "quantity": 1,
-                "variant_id": "Size L"
+                image_url: 'https://example.com/prod2.jpg',
+                price: 50,
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                quantity: 1,
+                variant_id: 'Size L'
               }
             ],
-            "source": "test_source",
-            "time": "2024-06-10T12:00:00.000Z",
-            "total_discounts": 10,
-            "total_value": 100,
-            "user_alias": {
-              "alias_label": "alias_label_1",
-              "alias_name": "alias_name_1"
+            source: 'test_source',
+            time: '2024-06-10T12:00:00.000Z',
+            total_discounts: 10,
+            total_value: 100,
+            user_alias: {
+              alias_label: 'alias_label_1',
+              alias_name: 'alias_name_1'
             }
           },
-          "status": 400
+          status: 400
         },
         {
-          "errormessage": "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          "errorreporter": "DESTINATION",
-          "errortype": "BAD_REQUEST",
-          "sent": {
-            "batch_size": 75,
-            "cancel_reason": "I didn't like it",
-            "cart_id": "cart_id_1",
-            "checkout_id": "checkout_id_1",
-            "currency": "USD",
-            "discounts": [
-              { "amount": 5, "code": "SUMMER21" },
-              { "amount": 5, "code": "VIPCUSTOMER" }
+          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
+          errorreporter: 'DESTINATION',
+          errortype: 'BAD_REQUEST',
+          sent: {
+            batch_size: 75,
+            cancel_reason: "I didn't like it",
+            cart_id: 'cart_id_1',
+            checkout_id: 'checkout_id_1',
+            currency: 'USD',
+            discounts: [
+              { amount: 5, code: 'SUMMER21' },
+              { amount: 5, code: 'VIPCUSTOMER' }
             ],
-            "enable_batching": true,
-            "metadata": {
-              "checkout_url": "https://example.com/checkout",
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": ["a", "b", "c"],
-              "custom_field_5": { "nested_key": "nested_value" },
-              "order_status_url": "https://example.com/order/status"
+            enable_batching: true,
+            metadata: {
+              checkout_url: 'https://example.com/checkout',
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: { nested_key: 'nested_value' },
+              order_status_url: 'https://example.com/order/status'
             },
-            "name": "ecommerce.order_placed",
-            "order_id": "order_id_1",
-            "products": [
+            name: 'ecommerce.order_placed',
+            order_id: 'order_id_1',
+            products: [
               {
-                "color": "red",
-                "image_url": "https://example.com/prod1.jpg",
-                "price": 25,
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "quantity": 2,
-                "size": "M",
-                "variant_id": "Size M"
+                color: 'red',
+                image_url: 'https://example.com/prod1.jpg',
+                price: 25,
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                quantity: 2,
+                size: 'M',
+                variant_id: 'Size M'
               },
               {
-                "image_url": "https://example.com/prod2.jpg",
-                "price": 50,
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "quantity": 1,
-                "variant_id": "Size L"
+                image_url: 'https://example.com/prod2.jpg',
+                price: 50,
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                quantity: 1,
+                variant_id: 'Size L'
               }
             ],
-            "source": "test_source",
-            "time": "2024-06-10T12:00:00.000Z",
-            "total_discounts": 10,
-            "total_value": 100
+            source: 'test_source',
+            time: '2024-06-10T12:00:00.000Z',
+            total_discounts: 10,
+            total_value: 100
           },
-          "status": 400
+          status: 400
         },
         {
-          "errormessage": "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          "errorreporter": "DESTINATION",
-          "errortype": "BAD_REQUEST",
-          "sent": {
-            "batch_size": 75,
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "cart_id": "cart_id_1",
-            "checkout_id": "checkout_id_1",
-            "currency": "USD",
-            "discounts": [
-              { "amount": 5, "code": "SUMMER21" },
-              { "amount": 5, "code": "VIPCUSTOMER" }
+          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
+          errorreporter: 'DESTINATION',
+          errortype: 'BAD_REQUEST',
+          sent: {
+            batch_size: 75,
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            cart_id: 'cart_id_1',
+            checkout_id: 'checkout_id_1',
+            currency: 'USD',
+            discounts: [
+              { amount: 5, code: 'SUMMER21' },
+              { amount: 5, code: 'VIPCUSTOMER' }
             ],
-            "email": "email@email.com",
-            "enable_batching": true,
-            "external_id": "userId3",
-            "metadata": {
-              "checkout_url": "https://example.com/checkout",
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": ["a", "b", "c"],
-              "custom_field_5": { "nested_key": "nested_value" },
-              "order_status_url": "https://example.com/order/status"
+            email: 'email@email.com',
+            enable_batching: true,
+            external_id: 'userId3',
+            metadata: {
+              checkout_url: 'https://example.com/checkout',
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: { nested_key: 'nested_value' },
+              order_status_url: 'https://example.com/order/status'
             },
-            "name": "ecommerce.checkout_started",
-            "order_id": "order_id_1",
-            "phone": "+14155551234",
-            "products": [
+            name: 'ecommerce.checkout_started',
+            order_id: 'order_id_1',
+            phone: '+14155551234',
+            products: [
               {
-                "color": "red",
-                "image_url": "https://example.com/prod1.jpg",
-                "price": 25,
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "quantity": 2,
-                "size": "M",
-                "variant_id": "Size M"
+                color: 'red',
+                image_url: 'https://example.com/prod1.jpg',
+                price: 25,
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                quantity: 2,
+                size: 'M',
+                variant_id: 'Size M'
               },
               {
-                "image_url": "https://example.com/prod2.jpg",
-                "price": 50,
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "quantity": 1,
-                "variant_id": "Size L"
+                image_url: 'https://example.com/prod2.jpg',
+                price: 50,
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                quantity: 1,
+                variant_id: 'Size L'
               }
             ],
-            "source": "test_source",
-            "time": "2024-06-10T12:00:00.000Z",
-            "total_discounts": 10,
-            "total_value": 100,
-            "user_alias": {
-              "alias_label": "alias_label_1",
-              "alias_name": "alias_name_1"
+            source: 'test_source',
+            time: '2024-06-10T12:00:00.000Z',
+            total_discounts: 10,
+            total_value: 100,
+            user_alias: {
+              alias_label: 'alias_label_1',
+              alias_name: 'alias_name_1'
             }
           },
-          "status": 400
+          status: 400
         },
         {
-          "errormessage": "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          "errorreporter": "DESTINATION",
-          "errortype": "BAD_REQUEST",
-          "sent": {
-            "batch_size": 75,
-            "braze_id": "braze_id_1",
-            "cancel_reason": "I didn't like it",
-            "cart_id": "cart_id_1",
-            "checkout_id": "checkout_id_1",
-            "currency": "USD",
-            "discounts": [
-              { "amount": 5, "code": "SUMMER21" },
-              { "amount": 5, "code": "VIPCUSTOMER" }
+          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
+          errorreporter: 'DESTINATION',
+          errortype: 'BAD_REQUEST',
+          sent: {
+            batch_size: 75,
+            braze_id: 'braze_id_1',
+            cancel_reason: "I didn't like it",
+            cart_id: 'cart_id_1',
+            checkout_id: 'checkout_id_1',
+            currency: 'USD',
+            discounts: [
+              { amount: 5, code: 'SUMMER21' },
+              { amount: 5, code: 'VIPCUSTOMER' }
             ],
-            "email": "email@email.com",
-            "enable_batching": true,
-            "external_id": "userId4",
-            "metadata": {
-              "checkout_url": "https://example.com/checkout",
-              "custom_field_1": "custom_value_1",
-              "custom_field_2": 100,
-              "custom_field_3": true,
-              "custom_field_4": ["a", "b", "c"],
-              "custom_field_5": { "nested_key": "nested_value" },
-              "order_status_url": "https://example.com/order/status"
+            email: 'email@email.com',
+            enable_batching: true,
+            external_id: 'userId4',
+            metadata: {
+              checkout_url: 'https://example.com/checkout',
+              custom_field_1: 'custom_value_1',
+              custom_field_2: 100,
+              custom_field_3: true,
+              custom_field_4: ['a', 'b', 'c'],
+              custom_field_5: { nested_key: 'nested_value' },
+              order_status_url: 'https://example.com/order/status'
             },
-            "name": "ecommerce.order_cancelled",
-            "order_id": "order_id_1",
-            "phone": "+14155551234",
-            "products": [
+            name: 'ecommerce.order_cancelled',
+            order_id: 'order_id_1',
+            phone: '+14155551234',
+            products: [
               {
-                "color": "red",
-                "image_url": "https://example.com/prod1.jpg",
-                "price": 25,
-                "product_id": "prod_1",
-                "product_name": "Product 1",
-                "quantity": 2,
-                "size": "M",
-                "variant_id": "Size M"
+                color: 'red',
+                image_url: 'https://example.com/prod1.jpg',
+                price: 25,
+                product_id: 'prod_1',
+                product_name: 'Product 1',
+                quantity: 2,
+                size: 'M',
+                variant_id: 'Size M'
               },
               {
-                "image_url": "https://example.com/prod2.jpg",
-                "price": 50,
-                "product_id": "prod_2",
-                "product_name": "Product 2",
-                "quantity": 1,
-                "variant_id": "Size L"
+                image_url: 'https://example.com/prod2.jpg',
+                price: 50,
+                product_id: 'prod_2',
+                product_name: 'Product 2',
+                quantity: 1,
+                variant_id: 'Size L'
               }
             ],
-            "source": "test_source",
-            "time": "2024-06-10T12:00:00.000Z",
-            "total_discounts": 10,
-            "total_value": 100,
-            "user_alias": {
-              "alias_label": "alias_label_1",
-              "alias_name": "alias_name_1"
+            source: 'test_source',
+            time: '2024-06-10T12:00:00.000Z',
+            total_discounts: 10,
+            total_value: 100,
+            user_alias: {
+              alias_label: 'alias_label_1',
+              alias_name: 'alias_name_1'
             }
           },
-          "status": 400
+          status: 400
         }
       ]
-      
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
+
+      nock(settings.endpoint).post('/users/track', json).reply(200)
 
       const response = await testDestination.executeBatch('ecommerce', {
         events,
@@ -1667,6 +1629,69 @@ describe('Braze.ecommerce', () => {
       })
 
       expect(response).toEqual(responseJSON)
+    })
+  })
+
+  describe('syncMode (no user_alias present)', () => {
+    // All of the tests above use a payload with a fully-formed user_alias, which always forces
+    // _update_existing_only to true regardless of syncMode (see the `send` function in
+    // ../functions.ts). These tests remove user_alias so the syncMode -> _update_existing_only
+    // decision logic is actually exercised.
+    it('should set _update_existing_only to true when a valid syncMode of "update" is used', async () => {
+      const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      delete deepCopy.properties?.user_alias
+      const e = createTestEvent(deepCopy)
+      delete e.properties?.product
+
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200)
+
+      const response = await testDestination.testAction('ecommerce', {
+        event: e,
+        settings,
+        useDefaultMappings: true,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'update' }
+      })
+
+      expect(response.length).toBe(1)
+      expect(sentJson.events[0]).toMatchObject({
+        name: 'ecommerce.order_placed',
+        _update_existing_only: true
+      })
+      expect(sentJson.events[0].user_alias).toBeUndefined()
+    })
+
+    it('should omit _update_existing_only when a valid syncMode of "add" is used', async () => {
+      const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      delete deepCopy.properties?.user_alias
+      const e = createTestEvent(deepCopy)
+      delete e.properties?.product
+
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200)
+
+      const response = await testDestination.testAction('ecommerce', {
+        event: e,
+        settings,
+        useDefaultMappings: true,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'add' }
+      })
+
+      expect(response.length).toBe(1)
+      expect(sentJson.events[0]).toMatchObject({
+        name: 'ecommerce.order_placed'
+      })
+      expect(sentJson.events[0]._update_existing_only).toBeUndefined()
     })
   })
 })

--- a/packages/destination-actions/src/destinations/braze/ecommerceSingleProduct/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerceSingleProduct/__tests__/index.test.ts
@@ -73,12 +73,12 @@ const mapping = {
   currency: { '@path': '$.properties.currency' },
   source: { '@path': '$.properties.source' },
   product: {
-      product_id: { '@path': '$.properties.product_id' },
-      product_name: { '@path': '$.properties.name' },
-      variant_id: { '@path': '$.properties.variant'},
-      image_url: {'@path': '$.properties.image_url'},
-      product_url: {'@path': '$.properties.product_url'},
-      price: {'@path': '$.properties.price'}
+    product_id: { '@path': '$.properties.product_id' },
+    product_name: { '@path': '$.properties.name' },
+    variant_id: { '@path': '$.properties.variant' },
+    image_url: { '@path': '$.properties.image_url' },
+    product_url: { '@path': '$.properties.product_url' },
+    price: { '@path': '$.properties.price' }
   },
   metadata: { '@path': '$.properties.metadata' },
   type: { '@path': '$.properties.type' },
@@ -98,180 +98,41 @@ afterEach(() => {
 })
 
 describe('Braze.ecommerce', () => {
-
   describe('single event', () => {
     it('should send Product Viewed event correctly', async () => {
-
-      const json = {
-        events: [
-            {
-              external_id: "userId1",
-              braze_id: "braze_id_1",
-              email: "email@email.com",
-              phone: "+14155551234",
-              user_alias: {
-                alias_name: "alias_name_1",
-                alias_label: "alias_label_1"
-              },
-              app_id: "test_app_id",
-              name: "ecommerce.product_viewed",
-              time: "2024-06-10T12:00:00.000Z",
-              properties: {
-                currency: "USD",
-                source: "test_source",
-                metadata: {
-                  custom_field_1: "custom_value_1",
-                  custom_field_2: 100,
-                  custom_field_3: true,
-                  custom_field_4: ["a", "b", "c"],
-                  custom_field_5: {
-                    nested_key: "nested_value"
-                  },
-                  checkout_url: "https://example.com/checkout",
-                  order_status_url: "https://example.com/order/status"
-                },
-                product_id: "prod_1",
-                product_name: "Product 1",
-                variant_id: "Size M",
-                image_url: "https://example.com/prod1.jpg",
-                product_url: "https://example.com/prod1",
-                price: 25
-              },
-              _update_existing_only: true
-            }
-          ]
-      }
-
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .reply(200)
-
-      const response = await testDestination.testAction('ecommerceSingleProduct', {
-        event: payload,
-        settings,
-        useDefaultMappings: true,
-        mapping
-      })
-    
-      expect(response.length).toBe(1)
-    })  
-  })
-
-  describe('batch events', () => {
-    it('should send batched single product ecommerce events correctly', async () => {
-
-      const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
-      const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
-      const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
-
-      const e1 = createTestEvent({...deepCopy1, userId: 'userId1', event: 'ecommerce.product_viewed' })
-      const e2 = createTestEvent({...deepCopy2, userId: 'userId2', event: 'ecommerce.product_viewed' })
-      const e3 = createTestEvent({...deepCopy3, userId: 'userId3', event: 'ecommerce.product_viewed' })
-      const events = [e1, e2, e3]
-
       const json = {
         events: [
           {
-            external_id: "userId1",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
             user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
             },
-            app_id: "test_app_id",
-            name: "ecommerce.product_viewed",
-            time: "2024-06-10T12:00:00.000Z",
+            app_id: 'test_app_id',
+            name: 'ecommerce.product_viewed',
+            time: '2024-06-10T12:00:00.000Z',
             properties: {
-              currency: "USD",
-              source: "test_source",
+              currency: 'USD',
+              source: 'test_source',
               metadata: {
-                custom_field_1: "custom_value_1",
+                custom_field_1: 'custom_value_1',
                 custom_field_2: 100,
                 custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
+                custom_field_4: ['a', 'b', 'c'],
                 custom_field_5: {
-                  nested_key: "nested_value"
+                  nested_key: 'nested_value'
                 },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
               },
-              product_id: "prod_1",
-              product_name: "Product 1",
-              variant_id: "Size M",
-              image_url: "https://example.com/prod1.jpg",
-              product_url: "https://example.com/prod1",
-              price: 25
-            },
-            _update_existing_only: true
-          },
-          {
-            external_id: "userId2",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
-            },
-            app_id: "test_app_id",
-            name: "ecommerce.product_viewed",
-            time: "2024-06-10T12:00:00.000Z",
-            properties: {
-              currency: "USD",
-              source: "test_source",
-              metadata: {
-                custom_field_1: "custom_value_1",
-                custom_field_2: 100,
-                custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: {
-                  nested_key: "nested_value"
-                },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
-              },
-              product_id: "prod_1",
-              product_name: "Product 1",
-              variant_id: "Size M",
-              image_url: "https://example.com/prod1.jpg",
-              product_url: "https://example.com/prod1",
-              price: 25
-            },
-            _update_existing_only: true
-          },
-          {
-            external_id: "userId3",
-            braze_id: "braze_id_1",
-            email: "email@email.com",
-            phone: "+14155551234",
-            user_alias: {
-              alias_name: "alias_name_1",
-              alias_label: "alias_label_1"
-            },
-            app_id: "test_app_id",
-            name: "ecommerce.product_viewed",
-            time: "2024-06-10T12:00:00.000Z",
-            properties: {
-              currency: "USD",
-              source: "test_source",
-              metadata: {
-                custom_field_1: "custom_value_1",
-                custom_field_2: 100,
-                custom_field_3: true,
-                custom_field_4: ["a", "b", "c"],
-                custom_field_5: {
-                  nested_key: "nested_value"
-                },
-                checkout_url: "https://example.com/checkout",
-                order_status_url: "https://example.com/order/status"
-              },
-              product_id: "prod_1",
-              product_name: "Product 1",
-              variant_id: "Size M",
-              image_url: "https://example.com/prod1.jpg",
-              product_url: "https://example.com/prod1",
+              product_id: 'prod_1',
+              product_name: 'Product 1',
+              variant_id: 'Size M',
+              image_url: 'https://example.com/prod1.jpg',
+              product_url: 'https://example.com/prod1',
               price: 25
             },
             _update_existing_only: true
@@ -279,19 +140,210 @@ describe('Braze.ecommerce', () => {
         ]
       }
 
-      nock(settings.endpoint)
-        .post('/users/track', json)
-        .matchHeader('X-Braze-Batch', 'true')
-        .reply(200)
+      nock(settings.endpoint).post('/users/track', json).reply(200)
+
+      const response = await testDestination.testAction('ecommerceSingleProduct', {
+        event: payload,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(response.length).toBe(1)
+    })
+  })
+
+  describe('batch events', () => {
+    it('should send batched single product ecommerce events correctly', async () => {
+      const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+
+      const e1 = createTestEvent({ ...deepCopy1, userId: 'userId1', event: 'ecommerce.product_viewed' })
+      const e2 = createTestEvent({ ...deepCopy2, userId: 'userId2', event: 'ecommerce.product_viewed' })
+      const e3 = createTestEvent({ ...deepCopy3, userId: 'userId3', event: 'ecommerce.product_viewed' })
+      const events = [e1, e2, e3]
+
+      const json = {
+        events: [
+          {
+            external_id: 'userId1',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
+            },
+            app_id: 'test_app_id',
+            name: 'ecommerce.product_viewed',
+            time: '2024-06-10T12:00:00.000Z',
+            properties: {
+              currency: 'USD',
+              source: 'test_source',
+              metadata: {
+                custom_field_1: 'custom_value_1',
+                custom_field_2: 100,
+                custom_field_3: true,
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: {
+                  nested_key: 'nested_value'
+                },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
+              },
+              product_id: 'prod_1',
+              product_name: 'Product 1',
+              variant_id: 'Size M',
+              image_url: 'https://example.com/prod1.jpg',
+              product_url: 'https://example.com/prod1',
+              price: 25
+            },
+            _update_existing_only: true
+          },
+          {
+            external_id: 'userId2',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
+            },
+            app_id: 'test_app_id',
+            name: 'ecommerce.product_viewed',
+            time: '2024-06-10T12:00:00.000Z',
+            properties: {
+              currency: 'USD',
+              source: 'test_source',
+              metadata: {
+                custom_field_1: 'custom_value_1',
+                custom_field_2: 100,
+                custom_field_3: true,
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: {
+                  nested_key: 'nested_value'
+                },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
+              },
+              product_id: 'prod_1',
+              product_name: 'Product 1',
+              variant_id: 'Size M',
+              image_url: 'https://example.com/prod1.jpg',
+              product_url: 'https://example.com/prod1',
+              price: 25
+            },
+            _update_existing_only: true
+          },
+          {
+            external_id: 'userId3',
+            braze_id: 'braze_id_1',
+            email: 'email@email.com',
+            phone: '+14155551234',
+            user_alias: {
+              alias_name: 'alias_name_1',
+              alias_label: 'alias_label_1'
+            },
+            app_id: 'test_app_id',
+            name: 'ecommerce.product_viewed',
+            time: '2024-06-10T12:00:00.000Z',
+            properties: {
+              currency: 'USD',
+              source: 'test_source',
+              metadata: {
+                custom_field_1: 'custom_value_1',
+                custom_field_2: 100,
+                custom_field_3: true,
+                custom_field_4: ['a', 'b', 'c'],
+                custom_field_5: {
+                  nested_key: 'nested_value'
+                },
+                checkout_url: 'https://example.com/checkout',
+                order_status_url: 'https://example.com/order/status'
+              },
+              product_id: 'prod_1',
+              product_name: 'Product 1',
+              variant_id: 'Size M',
+              image_url: 'https://example.com/prod1.jpg',
+              product_url: 'https://example.com/prod1',
+              price: 25
+            },
+            _update_existing_only: true
+          }
+        ]
+      }
+
+      nock(settings.endpoint).post('/users/track', json).matchHeader('X-Braze-Batch', 'true').reply(200)
 
       const response = await testDestination.testBatchAction('ecommerceSingleProduct', {
         events,
         settings,
         mapping
       })
-    
-      expect(response.length).toBe(1)
 
+      expect(response.length).toBe(1)
+    })
+  })
+
+  describe('syncMode (no user_alias present)', () => {
+    // The tests above use a payload with a fully-formed user_alias, which always forces
+    // _update_existing_only to true regardless of syncMode (see the shared `send` function in
+    // ../../ecommerce/functions.ts). These tests remove user_alias so the syncMode ->
+    // _update_existing_only decision logic is actually exercised.
+    it('should set _update_existing_only to true when a valid syncMode of "update" is used', async () => {
+      const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      delete deepCopy.properties?.user_alias
+      const e = createTestEvent(deepCopy)
+
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200)
+
+      const response = await testDestination.testAction('ecommerceSingleProduct', {
+        event: e,
+        settings,
+        useDefaultMappings: true,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'update' }
+      })
+
+      expect(response.length).toBe(1)
+      expect(sentJson.events[0]).toMatchObject({
+        name: 'ecommerce.product_viewed',
+        _update_existing_only: true
+      })
+      expect(sentJson.events[0].user_alias).toBeUndefined()
+    })
+
+    it('should omit _update_existing_only when a valid syncMode of "add" is used', async () => {
+      const deepCopy: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      delete deepCopy.properties?.user_alias
+      const e = createTestEvent(deepCopy)
+
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200)
+
+      const response = await testDestination.testAction('ecommerceSingleProduct', {
+        event: e,
+        settings,
+        useDefaultMappings: true,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'add' }
+      })
+
+      expect(response.length).toBe(1)
+      expect(sentJson.events[0]).toMatchObject({
+        name: 'ecommerce.product_viewed'
+      })
+      expect(sentJson.events[0]._update_existing_only).toBeUndefined()
     })
   })
 })

--- a/packages/destination-actions/src/destinations/braze/identifyUser2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/identifyUser2/__tests__/index.test.ts
@@ -172,4 +172,57 @@ describe('Braze IdentifyUser2', () => {
       ).rejects.toThrow()
     })
   })
+
+  describe('syncMode', () => {
+    it('should succeed when a valid syncMode of "upsert" is used', async () => {
+      // identifyUser2's perform() treats 'add' and 'upsert' identically - both are accepted and
+      // produce the exact same request body. There is no branching behavior between them; syncMode
+      // is only used as a validity gate (anything other than 'add'/'upsert' throws). This test closes
+      // the gap that only 'add' had previously been exercised.
+      const mockResponse = {
+        aliases_processed: 1,
+        emails_processed: 0,
+        phone_numbers_processed: 0,
+        message: 'success'
+      }
+
+      nock(settings.endpoint).post('/users/identify').reply(200, mockResponse)
+
+      const event = createTestEvent({
+        type: 'identify',
+        userId: 'test-user-upsert'
+      })
+
+      const responses = await testDestination.testAction('identifyUser2', {
+        event,
+        settings,
+        mapping: {
+          external_id: 'test-user-upsert',
+          user_alias: {
+            alias_name: 'alias-name-1',
+            alias_label: 'alias-label-1'
+          },
+          __segment_internal_sync_mode: 'upsert'
+        }
+      })
+
+      expect(responses).toBeDefined()
+      expect(responses.length).toBeGreaterThanOrEqual(1)
+      // Check the last response in the array (current test's response)
+      const currentResponse = responses[responses.length - 1]
+      expect(currentResponse.status).toBe(200)
+      expect(currentResponse.data).toEqual(mockResponse)
+      expect(currentResponse.options.json).toEqual({
+        aliases_to_identify: [
+          {
+            external_id: 'test-user-upsert',
+            user_alias: {
+              alias_name: 'alias-name-1',
+              alias_label: 'alias-label-1'
+            }
+          }
+        ]
+      })
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/braze/trackEvent2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/trackEvent2/__tests__/index.test.ts
@@ -1,0 +1,80 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+const settings: Settings = {
+  api_key: 'test_api_key',
+  app_id: 'test_app_id',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
+
+describe('Braze.trackEvent2 syncMode', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should set _update_existing_only to true when a valid syncMode of "update" is used', async () => {
+    const event = createTestEvent({
+      event: 'Test Event',
+      type: 'track',
+      userId: 'user-1',
+      timestamp: '2024-06-10T12:00:00.000Z',
+      properties: { plan: 'premium' }
+    })
+
+    nock(settings.endpoint).post('/users/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent2', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping: { __segment_internal_sync_mode: 'update' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        expect.objectContaining({
+          external_id: 'user-1',
+          name: 'Test Event',
+          _update_existing_only: true
+        })
+      ]
+    })
+  })
+
+  it('should set _update_existing_only to false when a valid syncMode of "add" is used', async () => {
+    const event = createTestEvent({
+      event: 'Test Event',
+      type: 'track',
+      userId: 'user-1',
+      timestamp: '2024-06-10T12:00:00.000Z',
+      properties: { plan: 'premium' }
+    })
+
+    nock(settings.endpoint).post('/users/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackEvent2', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping: { __segment_internal_sync_mode: 'add' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      events: [
+        expect.objectContaining({
+          external_id: 'user-1',
+          name: 'Test Event',
+          _update_existing_only: false
+        })
+      ]
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/trackPurchase2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/trackPurchase2/__tests__/index.test.ts
@@ -1,0 +1,84 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+const settings: Settings = {
+  api_key: 'test_api_key',
+  app_id: 'test_app_id',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
+
+describe('Braze.trackPurchase2 syncMode', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should set _update_existing_only to true when a valid syncMode of "update" is used', async () => {
+    const event = createTestEvent({
+      event: 'Order Completed',
+      type: 'track',
+      userId: 'user-1',
+      timestamp: '2024-06-10T12:00:00.000Z',
+      properties: {
+        products: [{ product_id: 'sku-1', price: 25, quantity: 1 }]
+      }
+    })
+
+    nock(settings.endpoint).post('/users/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackPurchase2', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping: { __segment_internal_sync_mode: 'update' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      purchases: [
+        expect.objectContaining({
+          external_id: 'user-1',
+          product_id: 'sku-1',
+          _update_existing_only: true
+        })
+      ]
+    })
+  })
+
+  it('should set _update_existing_only to false when a valid syncMode of "add" is used', async () => {
+    const event = createTestEvent({
+      event: 'Order Completed',
+      type: 'track',
+      userId: 'user-1',
+      timestamp: '2024-06-10T12:00:00.000Z',
+      properties: {
+        products: [{ product_id: 'sku-1', price: 25, quantity: 1 }]
+      }
+    })
+
+    nock(settings.endpoint).post('/users/track').reply(200, {})
+
+    const responses = await testDestination.testAction('trackPurchase2', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping: { __segment_internal_sync_mode: 'add' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      purchases: [
+        expect.objectContaining({
+          external_id: 'user-1',
+          product_id: 'sku-1',
+          _update_existing_only: false
+        })
+      ]
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/braze/updateUserProfile2/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/updateUserProfile2/__tests__/index.test.ts
@@ -1,0 +1,47 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+
+const settings: Settings = {
+  api_key: 'test_api_key',
+  app_id: 'test_app_id',
+  endpoint: 'https://rest.iad-01.braze.com'
+}
+
+describe('Braze.updateUserProfile2 syncMode', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should succeed with a valid syncMode of "update" and mark _update_existing_only as true', async () => {
+    const event = createTestEvent({
+      type: 'identify',
+      userId: 'user-1',
+      traits: { email: 'test@example.com', firstName: 'Tony' }
+    })
+
+    nock(settings.endpoint).post('/users/track').reply(200, {})
+
+    const responses = await testDestination.testAction('updateUserProfile2', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping: { __segment_internal_sync_mode: 'update' }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].options.json).toMatchObject({
+      attributes: [
+        expect.objectContaining({
+          external_id: 'user-1',
+          email: 'test@example.com',
+          _update_existing_only: true
+        })
+      ]
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/trackEvent.test.ts
@@ -272,6 +272,86 @@ describe('CustomerIO', () => {
           type: 'person'
         })
       })
+
+      it('should succeed with mapping of preset and Entities Audience Entered event (presets)', async () => {
+        const userId = 'abc123'
+        const name = 'Audience Entered'
+        const data = {
+          audience_key: 'sneakers_buyers',
+          audience_name: 'Sneakers Buyers',
+          sneakers_buyers: true
+        }
+        const timestamp = dayjs.utc().toISOString()
+        const event = createTestEvent({
+          event: name,
+          userId,
+          properties: data,
+          timestamp
+        })
+        const mapping = {
+          ...getDefaultMappings('trackEvent'),
+          convert_timestamp: false,
+          data: {
+            '@path': '$.properties'
+          }
+        }
+        const response = await action('trackEvent', { event, mapping, settings })
+
+        expect(response).toEqual({
+          action: 'event',
+          id: event.messageId,
+          identifiers: {
+            id: userId
+          },
+          name,
+          attributes: {
+            ...data,
+            anonymous_id: event.anonymousId
+          },
+          timestamp: dayjs.utc(timestamp).unix(),
+          type: 'person'
+        })
+      })
+
+      it('should succeed with mapping of preset and Entities Exited event (presets)', async () => {
+        const userId = 'abc123'
+        const name = 'Audience Exited'
+        const data = {
+          audience_key: 'sneakers_buyers',
+          audience_name: 'Sneakers Buyers',
+          sneakers_buyers: false
+        }
+        const timestamp = dayjs.utc().toISOString()
+        const event = createTestEvent({
+          event: name,
+          userId,
+          properties: data,
+          timestamp
+        })
+        const mapping = {
+          ...getDefaultMappings('trackEvent'),
+          convert_timestamp: false,
+          data: {
+            '@path': '$.properties'
+          }
+        }
+        const response = await action('trackEvent', { event, mapping, settings })
+
+        expect(response).toEqual({
+          action: 'event',
+          id: event.messageId,
+          identifiers: {
+            id: userId
+          },
+          name,
+          attributes: {
+            ...data,
+            anonymous_id: event.anonymousId
+          },
+          timestamp: dayjs.utc(timestamp).unix(),
+          type: 'person'
+        })
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/addToAudience.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/addToAudience.test.ts
@@ -1,0 +1,182 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import type { StatsContext } from '@segment/actions-core'
+import { fromBinary } from '@bufbuild/protobuf'
+import Destination from '../index'
+import { UpdateUsersDataRequestSchema, UserIdType } from '../proto/protofile'
+
+const UPLOAD_HOST = 'https://cm.g.doubleclick.net'
+const UPLOAD_PATH = '/upload?nid=segment'
+const EXTERNAL_AUDIENCE_ID = 'products/DISPLAY_VIDEO_ADVERTISER/customers/123/userLists/456'
+
+const testDestination = createTestIntegration(Destination)
+
+const mockStatsClient = {
+  incr: jest.fn(),
+  observe: jest.fn(),
+  _name: jest.fn(),
+  _tags: jest.fn(),
+  histogram: jest.fn(),
+  set: jest.fn()
+}
+
+const mockStatsContext: StatsContext = {
+  statsClient: mockStatsClient,
+  tags: []
+}
+
+// The request body sent to Google's bulk uploader is a raw protobuf-encoded binary payload
+// (Content-Type: application/octet-stream), not JSON. Since the payload is generally not valid
+// UTF-8, nock hands the interceptor the raw bytes hex-encoded (see nock's
+// `requestBodyIsUtf8Representable` handling) instead of mangling it through a lossy utf8 decode.
+// Decoding it back with the same protobuf schema used by the destination lets us assert on the
+// real wire body rather than just checking that the call didn't throw.
+function decodeRequestBody(body: string) {
+  const buffer = /^[0-9a-f]+$/i.test(body) ? Buffer.from(body, 'hex') : Buffer.from(body, 'utf8')
+  return fromBinary(UpdateUsersDataRequestSchema, buffer)
+}
+
+describe('Display Video 360 addToAudience', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    nock.cleanAll()
+  })
+
+  it('sends an add operation for every identifier present on the payload', async () => {
+    let capturedBody = ''
+    nock(UPLOAD_HOST)
+      .post(UPLOAD_PATH, (body) => {
+        capturedBody = body
+        return true
+      })
+      .reply(200)
+
+    const event = createTestEvent({
+      type: 'track',
+      event: 'Audience Entered',
+      anonymousId: 'my-anon-id-42',
+      context: {
+        personas: { external_audience_id: EXTERNAL_AUDIENCE_ID },
+        device: { advertisingId: '3b6e47b3-1437-4ba2-b3c9-446e4d0cd1e5' },
+        DV360: { google_gid: 'CAESEHIV8HXNp0pFdHgi2rElMfk' }
+      }
+    })
+
+    const responses = await testDestination.testAction('addToAudience', {
+      event,
+      statsContext: mockStatsContext,
+      mapping: {
+        external_audience_id: { '@path': '$.context.personas.external_audience_id' },
+        mobile_advertising_id: { '@path': '$.context.device.advertisingId' },
+        google_gid: { '@path': '$.context.DV360.google_gid' },
+        partner_provided_id: { '@path': '$.anonymousId' },
+        enable_batching: true
+      }
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+
+    const decoded = decodeRequestBody(capturedBody)
+    expect(decoded.ops).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: 'CAESEHIV8HXNp0pFdHgi2rElMfk',
+          userIdType: UserIdType.GOOGLE_USER_ID,
+          userListId: 456n,
+          delete: false
+        }),
+        expect.objectContaining({
+          userId: '3b6e47b3-1437-4ba2-b3c9-446e4d0cd1e5',
+          userIdType: UserIdType.IDFA,
+          userListId: 456n,
+          delete: false
+        }),
+        expect.objectContaining({
+          userId: 'my-anon-id-42',
+          userIdType: UserIdType.PARTNER_PROVIDED_ID,
+          userListId: 456n,
+          delete: false
+        })
+      ])
+    )
+    expect(decoded.ops).toHaveLength(3)
+  })
+
+  describe('presets', () => {
+    it('should route the "Journeys Step Entered" preset through addToAudience with the correct payload', async () => {
+      const preset = Destination.presets?.find((p) => p.name === 'Journeys Step Entered')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('addToAudience')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('journeys_step_entered_track')
+
+      let capturedBody = ''
+      nock(UPLOAD_HOST)
+        .post(UPLOAD_PATH, (body) => {
+          capturedBody = body
+          return true
+        })
+        .reply(200)
+
+      // A realistic Journeys "step entered" track event. This preset is matched purely by
+      // eventSlug (no FQL `subscribe` filter), so what matters here is that the fields the
+      // preset's mapping reads from are present.
+      const event = createTestEvent({
+        type: 'track',
+        event: 'Journey Step Entered',
+        anonymousId: 'journey-anon-id-99',
+        properties: {
+          journey_metadata: {
+            journey_id: 'test-journey-id',
+            journey_name: 'test-journey-name',
+            step_id: 'test-step-id',
+            step_name: 'test-step-name'
+          }
+        },
+        context: {
+          personas: { external_audience_id: EXTERNAL_AUDIENCE_ID },
+          device: { advertisingId: 'journey-device-1234-abcd' },
+          DV360: { google_gid: 'journey-google-gid-001' }
+        }
+      })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        statsContext: mockStatsContext,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      const decoded = decodeRequestBody(capturedBody)
+      expect(decoded.ops).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            userId: 'journey-google-gid-001',
+            userIdType: UserIdType.GOOGLE_USER_ID,
+            userListId: 456n,
+            delete: false
+          }),
+          expect.objectContaining({
+            userId: 'journey-device-1234-abcd',
+            userIdType: UserIdType.IDFA,
+            userListId: 456n,
+            delete: false
+          }),
+          expect.objectContaining({
+            userId: 'journey-anon-id-99',
+            userIdType: UserIdType.PARTNER_PROVIDED_ID,
+            userListId: 456n,
+            delete: false
+          })
+        ])
+      )
+      expect(decoded.ops).toHaveLength(3)
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/display-video-360/__tests__/syncAudience.test.ts
+++ b/packages/destination-actions/src/destinations/display-video-360/__tests__/syncAudience.test.ts
@@ -4,6 +4,7 @@ import type { StatsContext } from '@segment/actions-core'
 import * as shared from '../shared'
 import { syncAudience, validateMembership } from '../shared'
 import syncAudienceAction from '../syncAudience'
+import Destination from '../index'
 import createRequestClient from '../../../../../core/src/create-request-client'
 import { Payload } from '../syncAudience/generated-types'
 const UPLOAD_HOST = 'https://cm.g.doubleclick.net'
@@ -49,13 +50,15 @@ const testDestination = createTestIntegration({
 })
 
 // Engage-style track event. audienceMembership is resolved from these by the framework.
-const makeEngageEvent = (membership: boolean) =>
+// computation_class defaults to 'audience' (classic Engage). Journeys sends 'journey_step' instead,
+// and the framework's resolveAudienceMembership() treats both identically.
+const makeEngageEvent = (membership: boolean, computationClass: 'audience' | 'journey_step' = 'audience') =>
   createTestEvent({
     type: 'track',
     anonymousId: 'my-anon-id-42',
     context: {
       personas: {
-        computation_class: 'audience',
+        computation_class: computationClass,
         computation_key: 'my_audience',
         external_audience_id: EXTERNAL_AUDIENCE_ID
       },
@@ -188,6 +191,91 @@ describe('syncAudience action — perform', () => {
       [true]
     )
   })
+
+  it('calls syncAudience with wrapped payload and membership for a single event (journey_step)', async () => {
+    const event = makeEngageEvent(true, 'journey_step')
+
+    await testDestination.testAction('syncAudience', {
+      event,
+      mapping: baseMapping
+    })
+
+    expect(syncAudienceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({ external_audience_id: EXTERNAL_AUDIENCE_ID })],
+      expect.anything(),
+      [true]
+    )
+  })
+})
+
+describe('syncAudience action — presets', () => {
+  let syncAudienceSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    nock.cleanAll()
+    syncAudienceSpy = jest.spyOn(shared, 'syncAudience').mockResolvedValue({ status: 200 })
+  })
+
+  afterEach(() => {
+    syncAudienceSpy.mockRestore()
+  })
+
+  it('should route the "Journey Step All Events" preset through syncAudience with the correct payload', async () => {
+    const preset = Destination.presets?.find((p) => p.name === 'Journey Step All Events')
+    if (!preset) {
+      throw new Error('Expected to find preset')
+    }
+    expect(preset?.partnerAction).toBe('syncAudience')
+    expect(preset?.type).toBe('specificEvent')
+    expect((preset as { eventSlug?: string })?.eventSlug).toBe('journey_step_all_events_track')
+
+    // This preset has no FQL `subscribe` filter — it's matched purely by eventSlug — so build a
+    // realistic Journeys track event carrying the fields the preset's (default) mapping reads from.
+    const event = makeEngageEvent(true, 'journey_step')
+
+    await testDestination.testAction('syncAudience', {
+      event,
+      mapping: preset.mapping,
+      useDefaultMappings: false
+    })
+
+    expect(syncAudienceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        expect.objectContaining({
+          external_audience_id: EXTERNAL_AUDIENCE_ID,
+          google_gid: 'CAESEHIV8HXNp0pFdHgi2rElMfk',
+          mobile_advertising_id: '3b6e47b3-1437-4ba2-b3c9-446e4d0cd1e5',
+          partner_provided_id: 'my-anon-id-42'
+        })
+      ],
+      expect.anything(),
+      [true]
+    )
+  })
+
+  it('routes the "Journey Step All Events" preset to a removal when audience membership is false', async () => {
+    const preset = Destination.presets?.find((p) => p.name === 'Journey Step All Events')
+    if (!preset) {
+      throw new Error('Expected to find preset')
+    }
+    const event = makeEngageEvent(false, 'journey_step')
+
+    await testDestination.testAction('syncAudience', {
+      event,
+      mapping: preset.mapping,
+      useDefaultMappings: false
+    })
+
+    expect(syncAudienceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      [expect.objectContaining({ external_audience_id: EXTERNAL_AUDIENCE_ID })],
+      expect.anything(),
+      [false]
+    )
+  })
 })
 
 describe('syncAudience action — performBatch', () => {
@@ -223,6 +311,39 @@ describe('syncAudience action — performBatch', () => {
 
     await testDestination.executeBatch('syncAudience', {
       events: [makeEngageEvent(true), makeEngageEvent(false)],
+      mapping: baseMapping
+    })
+
+    expect(scope.isDone()).toBe(true)
+  })
+
+  it('sends only an add request for an all-true batch (journey_step)', async () => {
+    const scope = nock(UPLOAD_HOST).post(UPLOAD_PATH).once().reply(200)
+
+    await testDestination.executeBatch('syncAudience', {
+      events: [makeEngageEvent(true, 'journey_step'), makeEngageEvent(true, 'journey_step')],
+      mapping: baseMapping
+    })
+
+    expect(scope.isDone()).toBe(true)
+  })
+
+  it('sends only a delete request for an all-false batch (journey_step)', async () => {
+    const scope = nock(UPLOAD_HOST).post(UPLOAD_PATH).once().reply(200)
+
+    await testDestination.executeBatch('syncAudience', {
+      events: [makeEngageEvent(false, 'journey_step'), makeEngageEvent(false, 'journey_step')],
+      mapping: baseMapping
+    })
+
+    expect(scope.isDone()).toBe(true)
+  })
+
+  it('sends both add and delete requests for a mixed batch (journey_step)', async () => {
+    const scope = nock(UPLOAD_HOST).post(UPLOAD_PATH).twice().reply(200)
+
+    await testDestination.executeBatch('syncAudience', {
+      events: [makeEngageEvent(true, 'journey_step'), makeEngageEvent(false, 'journey_step')],
       mapping: baseMapping
     })
 

--- a/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/dynamic-yield-audiences/syncAudience/__tests__/index.test.ts
@@ -7,23 +7,23 @@ import { Settings } from '../../generated-types'
 let testDestination = createTestIntegration(Destination)
 
 const audienceSettings = {
-  audience_name: "test-audience",
-  identifier_type: "email",
-  dy_identifier_type: "externalid"
+  audience_name: 'test-audience',
+  identifier_type: 'email',
+  dy_identifier_type: 'externalid'
 }
 
 const addToAudienceTrackPayload = createTestEvent({
   type: 'track',
-  userId: "userId1",
-  anonymousId:"anonymousId1",
-  messageId: "messageid1",
-  timestamp: "2021-07-12T23:02:40.563Z",
+  userId: 'userId1',
+  anonymousId: 'anonymousId1',
+  messageId: 'messageid1',
+  timestamp: '2021-07-12T23:02:40.563Z',
   context: {
     personas: {
       computation_class: 'audience',
       computation_key: 'dy_segment_test',
       computation_id: 'dy_segment_audience_id',
-      external_audience_id: "11122233344455", // This must be convertable to a number
+      external_audience_id: '11122233344455', // This must be convertable to a number
       audience_settings: audienceSettings
     },
     traits: {
@@ -55,7 +55,7 @@ const mapping = {
   segment_audience_key: {
     '@path': '$.context.personas.computation_key'
   },
-  traits_or_props: {'@path': '$.properties' },
+  traits_or_props: { '@path': '$.properties' },
   segment_computation_action: {
     '@path': '$.context.personas.computation_class'
   },
@@ -70,17 +70,17 @@ const mapping = {
   userId: { '@path': '$.userId' }
 }
 
-const baseURL = "https://cdp-extensions-api.dev-use1.dynamicyield.com"
-const path = "/cdp/segment/audiences/membership-change"
+const baseURL = 'https://cdp-extensions-api.dev-use1.dynamicyield.com'
+const path = '/cdp/segment/audiences/membership-change'
 
 const header = {
-  "authorization": "mock-secret-DEV",
-  "content-type": "application/json",
-  "user-agent": "Segment (Actions)",
-  "accept": "*/*",
-  "content-length": "469",
-  "accept-encoding": "gzip,deflate",
-  "connection": "close"
+  authorization: 'mock-secret-DEV',
+  'content-type': 'application/json',
+  'user-agent': 'Segment (Actions)',
+  accept: '*/*',
+  'content-length': '469',
+  'accept-encoding': 'gzip,deflate',
+  connection: 'close'
 }
 
 describe('DynamicYieldAudiences.syncAudience', () => {
@@ -92,9 +92,9 @@ describe('DynamicYieldAudiences.syncAudience', () => {
     jest.resetAllMocks()
     jest.resetModules()
     process.env = { ...OLD_ENV }
-    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_US_CLIENT_SECRET = "mock-secret-US"
-    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_EU_CLIENT_SECRET = "mock-secret-EU"
-    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_DEV_CLIENT_SECRET = "mock-secret-DEV"
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_US_CLIENT_SECRET = 'mock-secret-US'
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_EU_CLIENT_SECRET = 'mock-secret-EU'
+    process.env.ACTIONS_DYNAMIC_YIELD_AUDIENCES_DEV_CLIENT_SECRET = 'mock-secret-DEV'
   })
 
   afterEach(() => {
@@ -133,43 +133,90 @@ describe('DynamicYieldAudiences.syncAudience', () => {
   describe('Should add a user to an audience', () => {
     it('where Segment ID type is email but DY ID type is externalid', async () => {
       const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
-      
+
       const event = createTestEvent(payload as Partial<SegmentEvent>)
 
       const json: DynamicYieldRequestJSON = {
-        type: "audience_membership_change_request",
-        id: "messageid1",
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
         timestamp_ms: 1626130960563,
         account: {
           account_settings: {
-            sectionId: "test-section-id",
-            identifier: "externalid",
-            connectionKey: "test-access-key"
+            sectionId: 'test-section-id',
+            identifier: 'externalid',
+            connectionKey: 'test-access-key'
           }
         },
         user_profiles: [
           {
             user_identities: [
               {
-                type: "externalid",
-                encoding: "\"sha-256\"",
-                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+                type: 'externalid',
+                encoding: '"sha-256"',
+                value: '73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2'
               }
             ],
             audiences: [
               {
                 audience_id: 11122233344455,
-                audience_name: "test-audience",
-                action: "add"
+                audience_name: 'test-audience',
+                action: 'add'
               }
             ]
           }
         ]
       }
 
-      nock(baseURL, { reqheaders: header })
-        .post(path, json as any)
-        .reply(200)
+      nock(baseURL, { reqheaders: header }).post(path, json).reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
+
+    it('where Segment ID type is email but DY ID type is externalid, with journey_step computation_class', async () => {
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      payload.context.personas.computation_class = 'journey_step'
+
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json: DynamicYieldRequestJSON = {
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: 'test-section-id',
+            identifier: 'externalid',
+            connectionKey: 'test-access-key'
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: 'externalid',
+                encoding: '"sha-256"',
+                value: '73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2'
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: 'test-audience',
+                action: 'add'
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: header }).post(path, json).reply(200)
 
       const responses = await testDestination.testAction('syncAudience', {
         event,
@@ -187,37 +234,37 @@ describe('DynamicYieldAudiences.syncAudience', () => {
       const event = createTestEvent(payload as Partial<SegmentEvent>)
 
       const json = {
-        type: "audience_membership_change_request",
-        id: "messageid1",
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
         timestamp_ms: 1626130960563,
         account: {
           account_settings: {
-            sectionId: "test-section-id",
-            identifier: "email",
-            connectionKey: "test-access-key"
+            sectionId: 'test-section-id',
+            identifier: 'email',
+            connectionKey: 'test-access-key'
           }
         },
         user_profiles: [
           {
             user_identities: [
               {
-                type: "email",
-                encoding: "\"sha-256\"",
-                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+                type: 'email',
+                encoding: '"sha-256"',
+                value: '73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2'
               }
             ],
             audiences: [
               {
                 audience_id: 11122233344455,
-                audience_name: "test-audience",
-                action: "add"
+                audience_name: 'test-audience',
+                action: 'add'
               }
             ]
           }
         ]
       }
 
-      nock(baseURL, { reqheaders: { ...header,   "content-length": "459"} })
+      nock(baseURL, { reqheaders: { ...header, 'content-length': '459' } })
         .post(path, json)
         .reply(200)
 
@@ -230,47 +277,46 @@ describe('DynamicYieldAudiences.syncAudience', () => {
 
       expect(responses.length).toBe(1)
     })
-    
+
     it('where Segment ID type is userId an DY ID type undefined', async () => {
-     
       const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
       delete payload?.context?.personas.audience_settings.dy_identifier_type
-      payload.context.personas.audience_settings.identifier_type = "userid"
+      payload.context.personas.audience_settings.identifier_type = 'userid'
 
       const event = createTestEvent(payload as Partial<SegmentEvent>)
 
       const json = {
-        type: "audience_membership_change_request",
-        id: "messageid1",
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
         timestamp_ms: 1626130960563,
         account: {
           account_settings: {
-            sectionId: "test-section-id",
-            identifier: "userid",
-            connectionKey: "test-access-key"
+            sectionId: 'test-section-id',
+            identifier: 'userid',
+            connectionKey: 'test-access-key'
           }
         },
         user_profiles: [
           {
             user_identities: [
               {
-                type: "userid",
-                encoding: "raw",
-                value: "userId1"
+                type: 'userid',
+                encoding: 'raw',
+                value: 'userId1'
               }
             ],
             audiences: [
               {
                 audience_id: 11122233344455,
-                audience_name: "test-audience",
-                action: "add"
+                audience_name: 'test-audience',
+                action: 'add'
               }
             ]
           }
         ]
       }
 
-      nock(baseURL, { reqheaders: { ...header,   "content-length": "396"} })
+      nock(baseURL, { reqheaders: { ...header, 'content-length': '396' } })
         .post(path, json)
         .reply(200)
 
@@ -286,9 +332,7 @@ describe('DynamicYieldAudiences.syncAudience', () => {
   })
 
   describe('Should remove a user from an audience', () => {
-
     it('where Segment ID type is email an DY ID type undefined', async () => {
-     
       const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
       payload.properties.dy_segment_test = false
       delete payload?.context?.personas.audience_settings.dy_identifier_type
@@ -296,37 +340,37 @@ describe('DynamicYieldAudiences.syncAudience', () => {
       const event = createTestEvent(payload as Partial<SegmentEvent>)
 
       const json = {
-        type: "audience_membership_change_request",
-        id: "messageid1",
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
         timestamp_ms: 1626130960563,
         account: {
           account_settings: {
-            sectionId: "test-section-id",
-            identifier: "email",
-            connectionKey: "test-access-key"
+            sectionId: 'test-section-id',
+            identifier: 'email',
+            connectionKey: 'test-access-key'
           }
         },
         user_profiles: [
           {
             user_identities: [
               {
-                type: "email",
-                encoding: "\"sha-256\"",
-                value: "73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+                type: 'email',
+                encoding: '"sha-256"',
+                value: '73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2'
               }
             ],
             audiences: [
               {
                 audience_id: 11122233344455,
-                audience_name: "test-audience",
-                action: "delete"
+                audience_name: 'test-audience',
+                action: 'delete'
               }
             ]
           }
         ]
       }
 
-      nock(baseURL, { reqheaders: { ...header,   "content-length": "462"} })
+      nock(baseURL, { reqheaders: { ...header, 'content-length': '462' } })
         .post(path, json)
         .reply(200)
 
@@ -339,6 +383,58 @@ describe('DynamicYieldAudiences.syncAudience', () => {
 
       expect(responses.length).toBe(1)
     })
-    
+
+    it('where Segment ID type is email an DY ID type undefined, with journey_step computation_class', async () => {
+      const payload = JSON.parse(JSON.stringify(addToAudienceTrackPayload))
+      payload.properties.dy_segment_test = false
+      payload.context.personas.computation_class = 'journey_step'
+      delete payload?.context?.personas.audience_settings.dy_identifier_type
+
+      const event = createTestEvent(payload as Partial<SegmentEvent>)
+
+      const json = {
+        type: 'audience_membership_change_request',
+        id: 'messageid1',
+        timestamp_ms: 1626130960563,
+        account: {
+          account_settings: {
+            sectionId: 'test-section-id',
+            identifier: 'email',
+            connectionKey: 'test-access-key'
+          }
+        },
+        user_profiles: [
+          {
+            user_identities: [
+              {
+                type: 'email',
+                encoding: '"sha-256"',
+                value: '73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2'
+              }
+            ],
+            audiences: [
+              {
+                audience_id: 11122233344455,
+                audience_name: 'test-audience',
+                action: 'delete'
+              }
+            ]
+          }
+        ]
+      }
+
+      nock(baseURL, { reqheaders: { ...header, 'content-length': '462' } })
+        .post(path, json)
+        .reply(200)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping
+      })
+
+      expect(responses.length).toBe(1)
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/hook.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/sync/__tests__/hook.test.ts
@@ -1,0 +1,85 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import { API_VERSION, BASE_URL } from '../../constants'
+
+// The upsert/mirror/delete/legacy test files exercise the `sync` action's perform/performBatch
+// path with a pre-resolved `mapping.retlOnMappingSave.outputs`, and functions.test.ts unit-tests
+// `getAudienceId`'s hookOutputs-resolution logic in isolation. Neither invokes the
+// `retlOnMappingSave` hook itself. This file calls it end-to-end via executeHook(), covering the
+// main create/select-existing-audience paths implemented in `hook-functions.ts`'s `performHook`.
+
+const testDestination = createTestIntegration(Destination)
+
+const AD_ACCOUNT_ID = '1500000000000000'
+const AUDIENCE_ID = '900'
+
+const settings = {
+  retlAdAccountId: AD_ACCOUNT_ID
+}
+
+describe('FacebookCustomAudiences.sync - retlOnMappingSave hook (executeHook end-to-end)', () => {
+  beforeEach(() => {
+    nock.cleanAll()
+  })
+
+  it('creates a new audience when operation is "create"', async () => {
+    nock(`${BASE_URL}/${API_VERSION}/act_${AD_ACCOUNT_ID}`)
+      .post('/customaudiences', {
+        name: 'test-audience',
+        subtype: 'CUSTOM',
+        customer_file_source: 'BOTH_USER_AND_PARTNER_PROVIDED'
+      })
+      .reply(200, { id: AUDIENCE_ID })
+
+    const response = await testDestination.actions.sync.executeHook('retlOnMappingSave', {
+      settings,
+      hookInputs: { operation: 'create', audienceName: 'test-audience' },
+      payload: {}
+    })
+
+    expect(response).toMatchObject({
+      successMessage: `Audience created with ID: ${AUDIENCE_ID}`,
+      savedData: {
+        audienceId: AUDIENCE_ID,
+        audienceName: 'test-audience'
+      }
+    })
+  })
+
+  it('connects to an existing audience when operation is "existing"', async () => {
+    nock(`${BASE_URL}/${API_VERSION}`)
+      .get(`/${AUDIENCE_ID}`)
+      .query({ fields: 'id,name' })
+      .reply(200, { id: AUDIENCE_ID, name: 'Existing Audience' })
+
+    const response = await testDestination.actions.sync.executeHook('retlOnMappingSave', {
+      settings,
+      hookInputs: { operation: 'existing', existingAudienceId: AUDIENCE_ID },
+      payload: {}
+    })
+
+    expect(response).toMatchObject({
+      successMessage: `Connected to audience with ID: ${AUDIENCE_ID}`,
+      savedData: {
+        audienceId: AUDIENCE_ID,
+        audienceName: 'Existing Audience'
+      }
+    })
+  })
+
+  it('returns an error object (not a thrown exception) when a required hook input is missing', async () => {
+    // operation: 'create' but no audienceName provided.
+    const response = await testDestination.actions.sync.executeHook('retlOnMappingSave', {
+      settings,
+      hookInputs: { operation: 'create' },
+      payload: {}
+    })
+
+    expect(response).toMatchObject({
+      error: {
+        message: 'Missing audience name value'
+      }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/first-party-dv360/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/_tests_/index.test.ts
@@ -131,6 +131,81 @@ describe('Audience Destination', () => {
       }
     })
 
+    // Journeys sends computation_class: 'journey_step' instead of 'audience'. The perform() functions for
+    // addToAudContactInfo/removeFromAudContactInfo never read computation_class (add vs remove is determined
+    // solely by which action is invoked), so behavior must be identical to the tests above.
+    const journeyStepEvent = createTestEvent({
+      event: 'Audience Entered',
+      type: 'track',
+      properties: {},
+      context: {
+        traits: payloadContactInfo,
+        personas: {
+          external_audience_id: 'audience-id-123',
+          audience_settings: {
+            advertiserId: '12345',
+            token: 'temp-token'
+          },
+          computation_class: 'journey_step'
+        }
+      }
+    })
+
+    it('should add customer match members successfully with journey_step computation_class', async () => {
+      nock('https://displayvideo.googleapis.com')
+        .post('/v4/firstPartyAndPartnerAudiences/audience-id-123:editCustomerMatchMembers')
+        .reply(200, { firstPartyAndPartnerAudienceId: 'audience-id-123' })
+      const result = await testDestination.testAction('addToAudContactInfo', {
+        event: journeyStepEvent,
+        useDefaultMappings: true,
+        features: { 'first-party-dv360-canary-version': true }
+      })
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstPartyAndPartnerAudienceId: 'audience-id-123'
+          })
+        })
+      )
+    })
+
+    it('should remove customer match members successfully with journey_step computation_class', async () => {
+      nock('https://displayvideo.googleapis.com')
+        .post('/v4/firstPartyAndPartnerAudiences/audience-id-123:editCustomerMatchMembers', {
+          advertiserId: '12345',
+          removedContactInfoList: {
+            contactInfos: [
+              {
+                hashedEmails: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674',
+                hashedPhoneNumbers: 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646',
+                zipCodes: '12345',
+                hashedFirstName: '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
+                hashedLastName: '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
+                countryCode: '+1'
+              }
+            ],
+            consent: {
+              adUserData: 'CONSENT_STATUS_GRANTED',
+              adPersonalization: 'CONSENT_STATUS_GRANTED'
+            }
+          }
+        })
+        .reply(200, { firstPartyAndPartnerAudienceId: 'audience-id-123' })
+
+      const result = await testDestination.testAction('removeFromAudContactInfo', {
+        event: journeyStepEvent,
+        useDefaultMappings: true,
+        features: { 'first-party-dv360-canary-version': true }
+      })
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstPartyAndPartnerAudienceId: 'audience-id-123'
+          })
+        })
+      )
+    })
+
     it('should add customer match members successfully with CANARY VERSION', async () => {
       nock('https://displayvideo.googleapis.com')
         .post('/v4/firstPartyAndPartnerAudiences/audience-id-123:editCustomerMatchMembers')

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
@@ -52,6 +52,45 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     )
   })
 
+  it('should hash pii data if not already hashed, with journey_step computation_class', async () => {
+    // addToAudContactInfo's perform() never reads context.personas.computation_class (add vs remove is
+    // determined solely by which action is invoked), so a Journeys 'journey_step' payload must behave
+    // identically to the classic Engage 'audience' payload used in the test above.
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/1234567890:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    const journeyStepEvent = createTestEvent({
+      ...event,
+      context: {
+        ...event.context,
+        personas: {
+          computation_class: 'journey_step'
+        }
+      }
+    })
+
+    const responses = await testDestination.testAction('addToAudContactInfo', {
+      event: journeyStepEvent,
+      mapping: {
+        emails: ['testing@testing.com'],
+        phoneNumbers: ['+1234567890'],
+        zipCodes: ['12345'],
+        firstName: 'John',
+        lastName: 'Doe',
+        countryCode: 'US',
+        external_id: '1234567890',
+        advertiser_id: '1234567890',
+        enable_batching: false,
+        batch_size: 1
+      }
+    })
+
+    expect(responses[0].options.body).toMatchInlineSnapshot(
+      '"{\\"advertiserId\\":\\"1234567890\\",\\"addedContactInfoList\\":{\\"contactInfos\\":[{\\"hashedEmails\\":\\"584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777\\",\\"hashedPhoneNumbers\\":\\"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8\\",\\"zipCodes\\":\\"12345\\",\\"hashedFirstName\\":\\"96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a\\",\\"hashedLastName\\":\\"799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f\\",\\"countryCode\\":\\"US\\"}],\\"consent\\":{\\"adUserData\\":\\"CONSENT_STATUS_GRANTED\\",\\"adPersonalization\\":\\"CONSENT_STATUS_GRANTED\\"}}}"'
+    )
+  })
+
   it('should not hash pii data if already hashed', async () => {
     nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
       .post('/1234567890:editCustomerMatchMembers')
@@ -134,6 +173,73 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
     expect(requestBody.addedContactInfoList.contactInfos.length).toBe(2)
     expect(requestBody.addedContactInfoList.contactInfos[0].hashedEmails).toBeDefined()
     expect(requestBody.addedContactInfoList.contactInfos[1].hashedEmails).toBeDefined()
+  })
+
+  it('should route the "Journeys Step Entered" preset through addToAudContactInfo with the correct payload', async () => {
+    const preset = Destination.presets?.find((p) => p.name === 'Journeys Step Entered')
+    if (!preset) {
+      throw new Error('Expected to find preset')
+    }
+    expect(preset?.partnerAction).toBe('addToAudContactInfo')
+    expect(preset?.type).toBe('specificEvent')
+    expect((preset as { eventSlug?: string })?.eventSlug).toBe('journeys_step_entered_track')
+
+    nock('https://displayvideo.googleapis.com/v4/firstPartyAndPartnerAudiences')
+      .post('/9876543210:editCustomerMatchMembers')
+      .reply(200, { success: true })
+
+    // This preset has no FQL `subscribe` filter — it's matched purely by eventSlug — so build a
+    // realistic Journeys "step entered" track event carrying the fields the preset's (default)
+    // mapping reads from.
+    const journeyEvent = createTestEvent({
+      type: 'track',
+      event: 'Journey Step Entered',
+      properties: {
+        journey_metadata: {
+          journey_id: 'test-journey-id',
+          journey_name: 'test-journey-name',
+          step_id: 'test-step-id',
+          step_name: 'test-step-name'
+        }
+      },
+      context: {
+        personas: {
+          external_audience_id: '9876543210',
+          audience_settings: {
+            advertiserId: '1112223333'
+          }
+        },
+        traits: {
+          emails: 'journeys@testing.com',
+          phoneNumbers: '+19876543210',
+          zipCodes: '54321',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          countryCode: 'US'
+        }
+      }
+    })
+
+    const responses = await testDestination.testAction(preset.partnerAction, {
+      event: journeyEvent,
+      mapping: preset.mapping,
+      useDefaultMappings: false
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+
+    const requestBody = JSON.parse(String(responses[0].options.body))
+    expect(requestBody.advertiserId).toBe('1112223333')
+    expect(requestBody.addedContactInfoList.contactInfos).toHaveLength(1)
+    expect(requestBody.addedContactInfoList.contactInfos[0]).toMatchObject({
+      hashedEmails: expect.any(String),
+      hashedPhoneNumbers: expect.any(String),
+      zipCodes: '54321',
+      hashedFirstName: expect.any(String),
+      hashedLastName: expect.any(String),
+      countryCode: 'US'
+    })
   })
 })
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/journeys-presets.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/journeys-presets.test.ts
@@ -1,0 +1,231 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, FLAGS } from '@segment/actions-core'
+import GoogleEnhancedConversions from '../index'
+import { API_VERSION } from '../functions'
+
+// These tests exercise the Journeys `presets` declared in ../index.ts (type: 'specificEvent').
+// Each preset says "when a Journeys event matching `eventSlug` is received, invoke
+// `partnerAction` using `mapping` as the default field mapping." We build a realistic event
+// for the eventSlug, invoke the preset's partnerAction with the preset's own mapping object
+// (not useDefaultMappings), and assert the resulting API request body is correct. This proves
+// the preset's mapping actually extracts the right data - not just that the action doesn't throw.
+
+const testDestination = createTestIntegration(GoogleEnhancedConversions)
+const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
+
+function getPreset(partnerAction: string, eventSlug: string) {
+  const preset = GoogleEnhancedConversions.presets?.find(
+    (p) => p.partnerAction === partnerAction && p.type === 'specificEvent' && p.eventSlug === eventSlug
+  )
+  if (!preset) {
+    throw new Error(`Could not find a preset for partnerAction="${partnerAction}" eventSlug="${eventSlug}"`)
+  }
+  return preset
+}
+
+describe('GoogleEnhancedConversions Journeys presets', () => {
+  describe('"Journeys Step Entered" -> userList', () => {
+    it('uses the preset mapping to add a user to a Customer Match list', async () => {
+      const preset = getPreset('userList', 'journeys_step_entered_track')
+      const customerId = '1234'
+
+      // A real "Journeys Step Entered" event carries the journey_step computation context but,
+      // unlike "Journey Step All Events", never carries a membership boolean. With the legacy
+      // journeys flag on, that resolves to an add.
+      const event = createTestEvent({
+        timestamp,
+        type: 'track',
+        event: 'Journeys Step Entered',
+        context: {
+          personas: {
+            computation_class: 'journey_step',
+            computation_key: 'personas_test_audience'
+          }
+        },
+        properties: {
+          email: 'test@gmail.com',
+          phone: '3234567890',
+          firstName: 'Jane',
+          lastName: 'Doe'
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/offlineUserDataJobs:create`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:addOperations`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/offlineDataJob:run`)
+        .post(/.*/)
+        .reply(200, { data: 'offlineDataJob' })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        mapping: {
+          ...(preset.mapping ?? {}),
+          // Required consent fields and the connect-a-list hook are not part of the preset's
+          // mapping (the preset only pre-fills fields that have a schema default) - a customer
+          // would fill these in when they save the mapping in the UI.
+          ad_user_data_consent_state: 'GRANTED',
+          ad_personalization_consent_state: 'GRANTED',
+          retlOnMappingSave: {
+            outputs: {
+              id: '1234',
+              name: 'Journeys List',
+              external_id_type: 'CONTACT_INFO'
+            }
+          }
+        },
+        useDefaultMappings: false,
+        settings: {
+          customerId
+        },
+        features: {
+          [FLAGS.ACTIONS_LEGACY_JOURNEYS_AUDIENCE_MEMBERSHIP]: true
+        }
+      })
+
+      expect(responses.length).toEqual(3)
+      expect(responses[0].options.body).toEqual(
+        JSON.stringify({
+          job: {
+            type: 'CUSTOMER_MATCH_USER_LIST',
+            customerMatchUserListMetadata: {
+              userList: 'customers/1234/userLists/1234',
+              consent: { adUserData: 'GRANTED', adPersonalization: 'GRANTED' }
+            }
+          }
+        })
+      )
+      expect(responses[1].options.body).toEqual(
+        JSON.stringify({
+          operations: [
+            {
+              create: {
+                userIdentifiers: [
+                  { hashedEmail: '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674' },
+                  { hashedPhoneNumber: '0506a1f3f4c515fd310fce54d253b731f71e33e7e7d2b10848528ca4411120b0' },
+                  {
+                    addressInfo: {
+                      hashedFirstName: '4f23798d92708359b734a18172c9c864f1d48044a754115a0d4b843bca3a5332',
+                      hashedLastName: 'fd53ef835b15485572a6e82cf470dcb41fd218ae5751ab7531c956a2a6bcd3c7',
+                      countryCode: '',
+                      postalCode: ''
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          enable_warnings: true
+        })
+      )
+    })
+  })
+
+  describe('"Journeys Step Entered" -> postConversion', () => {
+    it('uses the preset mapping to upload a legacy enhanced conversion', async () => {
+      const preset = getPreset('postConversion', 'journeys_step_entered_track')
+      const conversionTrackingId = '_conversion_id_'
+      const conversionLabel = '_conversion_'
+
+      const event = createTestEvent({
+        timestamp,
+        type: 'track',
+        event: 'Journeys Step Entered',
+        properties: {
+          email: 'janedoe@gmail.com',
+          orderId: '123',
+          firstName: 'Bob John',
+          lastName: 'Smith',
+          phone: '14150000000',
+          address: {
+            street: '123 Market Street',
+            city: 'San Francisco',
+            state: 'CA',
+            postalCode: '94000',
+            country: 'USA'
+          }
+        }
+      })
+
+      nock('https://www.google.com/ads/event/api/v1')
+        .post(`?conversion_tracking_id=${conversionTrackingId}`)
+        .reply(201, {})
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        mapping: {
+          ...(preset.mapping ?? {}),
+          // conversion_label defaults to '' in the field schema (there is no sensible default
+          // for a Google-specific label) - a customer supplies the real value when saving.
+          conversion_label: conversionLabel
+        },
+        useDefaultMappings: false,
+        settings: {
+          conversionTrackingId
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"pii_data\\":{\\"hashed_email\\":\\"1hFzBkhe0OUK-rOshx6Y-BaZFR8wKBUn1j_18jNlbGk=\\",\\"hashed_phone_number\\":[\\"5pAiami9y4LWCmP12H9fXJpoqrnOFRL7u9q1pkqlMmI=\\"],\\"address\\":[{\\"hashed_first_name\\":\\"IGT0sXMskUo9vWuqGeOhA-RylOG2Oj_IcIX2Zr5f7GU=\\",\\"hashed_last_name\\":\\"ZieDX5iOLF5QUz1JEWMHLT9PQfXIsEYwFQ3rs3Isot0=\\",\\"hashed_street_address\\":\\"tHP71r8-GY59XKpmdb6ssI3fd7TIBB6E6aCWN06RGBw=\\",\\"city\\":\\"sanfrancisco\\",\\"region\\":\\"ca\\",\\"postcode\\":\\"94000\\",\\"country\\":\\"USA\\"}]},\\"oid\\":\\"123\\",\\"user_agent\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\",\\"conversion_time\\":1623348484000000,\\"label\\":\\"_conversion_\\"}"`
+      )
+    })
+  })
+
+  describe('"Journeys Step Entered" -> uploadClickConversion', () => {
+    it('uses the preset mapping to upload a click conversion', async () => {
+      const preset = getPreset('uploadClickConversion', 'journeys_step_entered_track')
+      const customerId = '1234'
+
+      const event = createTestEvent({
+        timestamp,
+        type: 'track',
+        event: 'Journeys Step Entered',
+        properties: {
+          email: 'test@gmail.com',
+          phone: '6161729102',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '1234',
+              quantity: 3,
+              price: 10.99
+            }
+          ]
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        event,
+        mapping: {
+          ...(preset.mapping ?? {}),
+          // conversion_action is required but has no schema default (it's a dynamic lookup
+          // against the customer's Google Ads account) - a customer supplies it when saving.
+          conversion_action: '12345'
+        },
+        useDefaultMappings: false,
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"conversions\\":[{\\"conversionAction\\":\\"customers/1234/conversionActions/12345\\",\\"conversionDateTime\\":\\"2021-06-10 18:08:04+00:00\\",\\"userIpAddress\\":\\"8.8.8.8\\",\\"sessionAttributesKeyValuePairs\\":{\\"keyValuePairs\\":[{\\"sessionAttributeKey\\":\\"landing_page_url\\",\\"sessionAttributeValue\\":\\"https://segment.com/academy/\\"},{\\"sessionAttributeKey\\":\\"landing_page_user_agent\\",\\"sessionAttributeValue\\":\\"Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1\\"}]},\\"orderId\\":\\"1234\\",\\"conversionValue\\":200,\\"currencyCode\\":\\"USD\\",\\"cartData\\":{\\"items\\":[{\\"productId\\":\\"1234\\",\\"quantity\\":3,\\"unitPrice\\":10.99}]},\\"userIdentifiers\\":[{\\"hashedEmail\\":\\"87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674\\"},{\\"hashedPhoneNumber\\":\\"76ff44c6428f2fc2750fec01cb3190423adaebb21e797d942f339f3c7c1761dd\\"}]}],\\"partialFailure\\":true}"`
+      )
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/userList.test.ts
@@ -1912,5 +1912,23 @@ describe('GoogleEnhancedConversions', () => {
         errorreporter: 'DESTINATION'
       })
     })
+
+    describe('retlOnMappingSave hook - performHook validate()', () => {
+      // performHook's very first line calls verifyCustomerId(settings.customerId) *before* the
+      // try/catch blocks that wrap the rest of the hook's create/get-list logic (see
+      // userList/index.ts). Every other failure path inside performHook is caught and returned as
+      // a graceful `{ error: {...} }` value, but a missing customerId causes verifyCustomerId to
+      // throw a PayloadValidationError that escapes performHook uncaught - i.e. executeHook()
+      // rejects instead of resolving with an error object. This test closes that gap.
+      it('rejects with PayloadValidationError when settings.customerId is missing, rather than returning a graceful hook error', async () => {
+        await expect(
+          testDestination.actions.userList.executeHook('retlOnMappingSave', {
+            settings: {},
+            hookInputs: { list_name: 'Test List' },
+            payload: {}
+          })
+        ).rejects.toThrow(PayloadValidationError)
+      })
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/hubspot/upsertObject/__tests__/lists.test.ts
+++ b/packages/destination-actions/src/destinations/hubspot/upsertObject/__tests__/lists.test.ts
@@ -15,7 +15,7 @@ const payload = {
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'contact_list_2',
+      computation_key: 'contact_list_2'
     }
   },
   properties: {
@@ -49,6 +49,19 @@ const payload = {
   }
 } as Partial<SegmentEvent>
 
+// Mirrors `payload` above but exercises the Journeys gate value. resolveAudienceMembership()
+// (packages/core/src/audience-membership.ts) and ENGAGE_AUDIENCE_COMPUTATION_CLASSES
+// (hubspot/upsertObject/constants.ts) both treat 'journey_step' identically to 'audience'.
+const journeyStepPayload = {
+  ...payload,
+  context: {
+    personas: {
+      computation_class: 'journey_step',
+      computation_key: 'contact_list_2'
+    }
+  }
+} as Partial<SegmentEvent>
+
 const mapping = {
   __segment_internal_sync_mode: 'upsert',
   object_details: {
@@ -63,10 +76,10 @@ const mapping = {
   associations: [],
   enable_batching: true,
   batch_size: 100,
-  batch_keys:['list_details'],
+  batch_keys: ['list_details'],
   traits_or_props: { '@path': '$.properties' },
   computation_key: { '@path': '$.context.personas.computation_key' },
-  computation_class: { '@path': '$.context.personas.computation_class'},
+  computation_class: { '@path': '$.context.personas.computation_class' },
   list_details: {
     connected_to_engage_audience: true,
     should_create_list: true
@@ -263,17 +276,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -288,7 +297,7 @@ describe('Hubspot.upsertObject', () => {
 
     it('should remove a user from an existing Hubspot List.', async () => {
       const modifiedPayload = { ...payload, properties: { ...payload.properties, contact_list_2: false } }
-    
+
       const event = createTestEvent(modifiedPayload)
 
       nock(HUBSPOT_BASE_URL)
@@ -309,17 +318,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -335,20 +340,18 @@ describe('Hubspot.upsertObject', () => {
     it('should add a user to an non existing Hubspot List - by creating the List first.', async () => {
       const event = createTestEvent(payload)
 
-      nock(HUBSPOT_BASE_URL)
-        .get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`)
-        .reply(400, {
-          status: 'error',
-          message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
-        })
+      nock(HUBSPOT_BASE_URL).get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`).reply(400, {
+        status: 'error',
+        message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
+      })
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/lists', {name: "contact_list_2", objectTypeId: "contact", processingType: "MANUAL"})
+        .post('/crm/v3/lists', { name: 'contact_list_2', objectTypeId: 'contact', processingType: 'MANUAL' })
         .reply(200, {
           list: {
-            listId: "21",
-            objectTypeId: "0-2",
-            name: "contact_list_2"
+            listId: '21',
+            objectTypeId: '0-2',
+            name: 'contact_list_2'
           }
         })
 
@@ -359,17 +362,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -382,16 +381,98 @@ describe('Hubspot.upsertObject', () => {
       expect(responses.length).toBe(6)
     })
 
+    it('should add a user to an existing Hubspot List. (journey_step computation_class)', async () => {
+      const event = createTestEvent(journeyStepPayload)
+
+      nock(HUBSPOT_BASE_URL)
+        .get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`)
+        .reply(200, {
+          list: {
+            listId: '21',
+            processingType: 'MANUAL',
+            objectTypeId: '0-2',
+            name: 'contact_list_2'
+          }
+        })
+
+      nock(HUBSPOT_BASE_URL)
+        .put(`/crm/v3/lists/21/memberships/add-and-remove`, {
+          recordIdsToAdd: ['62102303560'],
+          recordIdsToRemove: []
+        })
+        .reply(200)
+
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
+
+      nock(HUBSPOT_BASE_URL)
+        .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
+        .reply(200, sensitivePropertiesResp)
+
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
+
+      const responses = await testDestination.testAction('upsertObject', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping,
+        features: { 'actions-hubspot-lists-association-support': true }
+      })
+
+      expect(responses.length).toBe(5)
+    })
+
+    it('should remove a user from an existing Hubspot List. (journey_step computation_class)', async () => {
+      const modifiedPayload = { ...journeyStepPayload, properties: { ...payload.properties, contact_list_2: false } }
+
+      const event = createTestEvent(modifiedPayload)
+
+      nock(HUBSPOT_BASE_URL)
+        .get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`)
+        .reply(200, {
+          list: {
+            listId: '21',
+            processingType: 'MANUAL',
+            objectTypeId: '0-2',
+            name: 'contact_list_2'
+          }
+        })
+
+      nock(HUBSPOT_BASE_URL)
+        .put(`/crm/v3/lists/21/memberships/add-and-remove`, {
+          recordIdsToAdd: [],
+          recordIdsToRemove: ['62102303560']
+        })
+        .reply(200)
+
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
+
+      nock(HUBSPOT_BASE_URL)
+        .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
+        .reply(200, sensitivePropertiesResp)
+
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
+
+      const responses = await testDestination.testAction('upsertObject', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping,
+        features: { 'actions-hubspot-lists-association-support': true }
+      })
+
+      expect(responses.length).toBe(5)
+    })
+
     it('should not create a List if it is in the LRU Cache.', async () => {
       const subscriptionMetadata = {
         // cache key for testing
         actionConfigId: 'test-cache-key'
       }
-      
+
       // To simplify this test properties and sensitive_properties are excluded
-      const modifiedPayload = { 
-        ...payload, 
-        properties: {    
+      const modifiedPayload = {
+        ...payload,
+        properties: {
           contact_list_2: true,
           email: 'test@test.com'
         }
@@ -416,8 +497,9 @@ describe('Hubspot.upsertObject', () => {
         .reply(200)
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert',
-          {inputs:[{idProperty:"email",id:"test@test.com",properties:{email:"test@test.com"}}]})
+        .post('/crm/v3/objects/contact/batch/upsert', {
+          inputs: [{ idProperty: 'email', id: 'test@test.com', properties: { email: 'test@test.com' } }]
+        })
         .reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
@@ -437,8 +519,9 @@ describe('Hubspot.upsertObject', () => {
         .reply(200)
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert',
-          {inputs:[{idProperty:"email",id:"test@test.com",properties:{email:"test@test.com"}}]})
+        .post('/crm/v3/objects/contact/batch/upsert', {
+          inputs: [{ idProperty: 'email', id: 'test@test.com', properties: { email: 'test@test.com' } }]
+        })
         .reply(200, upsertObjectResp)
 
       const responses2 = await testDestination.testAction('upsertObject', {
@@ -454,19 +537,19 @@ describe('Hubspot.upsertObject', () => {
       expect(responses2.length).toBe(2)
     })
 
-    it('should batch events together and update Lists correctly (List already exists in Hubspot)', async () => {      
+    it('should batch events together and update Lists correctly (List already exists in Hubspot)', async () => {
       // To simplify this test properties and sensitive_properties are excluded
-      const modifiedPayload = { 
-        ...payload, 
-        properties: {    
+      const modifiedPayload = {
+        ...payload,
+        properties: {
           contact_list_2: true,
           email: 'test@test.com'
         }
       } as SegmentEvent
 
-      const modifiedPayload2 = { 
-        ...payload, 
-        properties: {    
+      const modifiedPayload2 = {
+        ...payload,
+        properties: {
           contact_list_2: false,
           email: 'test2@test.com'
         }
@@ -508,8 +591,12 @@ describe('Hubspot.upsertObject', () => {
         .reply(200)
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert',
-          {inputs:[{idProperty:"email",id:"test@test.com",properties:{email:"test@test.com"}}, {idProperty:"email",id:"test2@test.com",properties:{email:"test2@test.com"}}]})
+        .post('/crm/v3/objects/contact/batch/upsert', {
+          inputs: [
+            { idProperty: 'email', id: 'test@test.com', properties: { email: 'test@test.com' } },
+            { idProperty: 'email', id: 'test2@test.com', properties: { email: 'test2@test.com' } }
+          ]
+        })
         .reply(200, modifiedUpsertObjectResp)
 
       const responses = await testDestination.testBatchAction('upsertObject', {
@@ -525,17 +612,17 @@ describe('Hubspot.upsertObject', () => {
 
     it('should batch events together and update Lists correctly (List does not already exist in Hubspot)', async () => {
       // To simplify this test properties and sensitive_properties are excluded
-      const modifiedPayload = { 
-        ...payload, 
-        properties: {    
+      const modifiedPayload = {
+        ...payload,
+        properties: {
           contact_list_2: true,
           email: 'test@test.com'
         }
       } as SegmentEvent
 
-      const modifiedPayload2 = { 
-        ...payload, 
-        properties: {    
+      const modifiedPayload2 = {
+        ...payload,
+        properties: {
           contact_list_2: true,
           email: 'test2@test.com'
         }
@@ -558,20 +645,18 @@ describe('Hubspot.upsertObject', () => {
         ]
       }
 
-      nock(HUBSPOT_BASE_URL)
-        .get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`)
-        .reply(400, {
-          status: 'error',
-          message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
-        })
+      nock(HUBSPOT_BASE_URL).get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`).reply(400, {
+        status: 'error',
+        message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
+      })
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/lists', {name: "contact_list_2", objectTypeId: "contact", processingType: "MANUAL"})
+        .post('/crm/v3/lists', { name: 'contact_list_2', objectTypeId: 'contact', processingType: 'MANUAL' })
         .reply(200, {
           list: {
-            listId: "21",
-            objectTypeId: "0-2",
-            name: "contact_list_2"
+            listId: '21',
+            objectTypeId: '0-2',
+            name: 'contact_list_2'
           }
         })
 
@@ -583,8 +668,12 @@ describe('Hubspot.upsertObject', () => {
         .reply(200)
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert',
-          {inputs:[{idProperty:"email",id:"test@test.com",properties:{email:"test@test.com"}}, {idProperty:"email",id:"test2@test.com",properties:{email:"test2@test.com"}}]})
+        .post('/crm/v3/objects/contact/batch/upsert', {
+          inputs: [
+            { idProperty: 'email', id: 'test@test.com', properties: { email: 'test@test.com' } },
+            { idProperty: 'email', id: 'test2@test.com', properties: { email: 'test2@test.com' } }
+          ]
+        })
         .reply(200, modifiedUpsertObjectResp)
 
       const responses = await testDestination.testBatchAction('upsertObject', {
@@ -601,11 +690,11 @@ describe('Hubspot.upsertObject', () => {
 
   describe('Not an Engage Audience', () => {
     it('should add a user to an existing Hubspot List.', async () => {
-      const modifiedPayload = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
-          ...payload.properties, 
+      const modifiedPayload = {
+        ...payload,
+        context: {},
+        properties: {
+          ...payload.properties,
           list_details: {
             connected_to_engage_audience: false,
             should_create_list: true,
@@ -648,17 +737,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -672,11 +757,11 @@ describe('Hubspot.upsertObject', () => {
     })
 
     it('should remove a user from an existing Hubspot List.', async () => {
-      const modifiedPayload = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
-          ...payload.properties, 
+      const modifiedPayload = {
+        ...payload,
+        context: {},
+        properties: {
+          ...payload.properties,
           list_details: {
             connected_to_engage_audience: false,
             should_create_list: true,
@@ -719,17 +804,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -743,12 +824,11 @@ describe('Hubspot.upsertObject', () => {
     })
 
     it('should add a user to an non existing Hubspot List - by creating the List first.', async () => {
-      
-      const modifiedPayload = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
-          ...payload.properties, 
+      const modifiedPayload = {
+        ...payload,
+        context: {},
+        properties: {
+          ...payload.properties,
           list_details: {
             connected_to_engage_audience: false,
             should_create_list: true,
@@ -767,23 +847,21 @@ describe('Hubspot.upsertObject', () => {
           list_action: { '@path': '$.properties.list_details.list_action' }
         }
       }
-      
+
       const event = createTestEvent(modifiedPayload)
 
-      nock(HUBSPOT_BASE_URL)
-        .get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`)
-        .reply(400, {
-          status: 'error',
-          message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
-        })
+      nock(HUBSPOT_BASE_URL).get(`/crm/v3/lists/object-type-id/contact/name/contact_list_2`).reply(400, {
+        status: 'error',
+        message: 'List does not exist with name contact_list_2 and object type ID 0-2.'
+      })
 
       nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/lists', {name: "contact_list_2", objectTypeId: "contact", processingType: "MANUAL"})
+        .post('/crm/v3/lists', { name: 'contact_list_2', objectTypeId: 'contact', processingType: 'MANUAL' })
         .reply(200, {
           list: {
-            listId: "21",
-            objectTypeId: "0-2",
-            name: "contact_list_2"
+            listId: '21',
+            objectTypeId: '0-2',
+            name: 'contact_list_2'
           }
         })
 
@@ -794,17 +872,13 @@ describe('Hubspot.upsertObject', () => {
         })
         .reply(200)
 
-      nock(HUBSPOT_BASE_URL)
-        .get('/crm/v3/properties/contact')
-        .reply(200, propertiesResp)
+      nock(HUBSPOT_BASE_URL).get('/crm/v3/properties/contact').reply(200, propertiesResp)
 
       nock(HUBSPOT_BASE_URL)
         .get('/crm/v3/properties/contact?dataSensitivity=sensitive')
         .reply(200, sensitivePropertiesResp)
 
-      nock(HUBSPOT_BASE_URL)
-        .post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq)
-        .reply(200, upsertObjectResp)
+      nock(HUBSPOT_BASE_URL).post('/crm/v3/objects/contact/batch/upsert', upsertObjectReq).reply(200, upsertObjectResp)
 
       const responses = await testDestination.testAction('upsertObject', {
         event,
@@ -816,13 +890,13 @@ describe('Hubspot.upsertObject', () => {
 
       expect(responses.length).toBe(6)
     })
-    
+
     it('should error if more than 1 list is included in the same batch', async () => {
       // To simplify this test properties and sensitive_properties are excluded
-      const modifiedPayload = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
+      const modifiedPayload = {
+        ...payload,
+        context: {},
+        properties: {
           email: 'test@test.com',
           list_details: {
             connected_to_engage_audience: false,
@@ -833,10 +907,10 @@ describe('Hubspot.upsertObject', () => {
         }
       } as SegmentEvent
 
-      const modifiedPayload2 = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
+      const modifiedPayload2 = {
+        ...payload,
+        context: {},
+        properties: {
           email: 'test2@test.com',
           list_details: {
             connected_to_engage_audience: false,
@@ -847,10 +921,10 @@ describe('Hubspot.upsertObject', () => {
         }
       } as SegmentEvent
 
-      const modifiedPayload3 = { 
-        ...payload, 
-        context: {}, 
-        properties: { 
+      const modifiedPayload3 = {
+        ...payload,
+        context: {},
+        properties: {
           email: 'test3@test.com',
           list_details: {
             connected_to_engage_audience: false,
@@ -860,7 +934,7 @@ describe('Hubspot.upsertObject', () => {
           }
         }
       } as SegmentEvent
-      
+
       const modifiedMapping: JSONObject = {
         ...mapping,
         list_details: {
@@ -871,16 +945,18 @@ describe('Hubspot.upsertObject', () => {
         }
       }
 
-      try{
+      try {
         await testDestination.testBatchAction('upsertObject', {
-            events: [modifiedPayload, modifiedPayload2, modifiedPayload3],
-            settings,
-            useDefaultMappings: true,
-            mapping: modifiedMapping,
-            features: { 'actions-hubspot-lists-association-support': true }
+          events: [modifiedPayload, modifiedPayload2, modifiedPayload3],
+          settings,
+          useDefaultMappings: true,
+          mapping: modifiedMapping,
+          features: { 'actions-hubspot-lists-association-support': true }
         })
       } catch (err) {
-        expect((err as Error).message).toBe('When updating List membership, all payloads must reference the same list. Found multiple lists in the batch: contact_list_2, contact_list_3')
+        expect((err as Error).message).toBe(
+          'When updating List membership, all payloads must reference the same list. Found multiple lists in the batch: contact_list_2, contact_list_3'
+        )
       }
     })
   })

--- a/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/launchdarkly-audiences/syncAudience/__tests__/index.test.ts
@@ -1,15 +1,54 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import isEqual from 'lodash/isEqual'
 import Destination from '../../index'
 import { CONSTANTS } from '../../constants'
+import { Settings } from '../../generated-types'
 
 const testDestination = createTestIntegration(Destination)
+
+const settings: Settings = { apiKey: 'test-api-key', clientId: 'test-client-id' }
+
+// Expected LaunchDarkly segment-targets request body for goodTrackEvent / goodTrackEventJourneyStep below.
+// computation_class is only used as a gate (see ENGAGE_AUDIENCE_COMPUTATION_CLASSES-equivalent choices on
+// segment_computation_action) - it is not otherwise referenced when building the request, so 'audience' and
+// 'journey_step' payloads that are otherwise identical produce an identical request body.
+const expectedTrackBody = {
+  environmentId: 'test-client-id',
+  contextKind: 'user',
+  batch: [
+    {
+      userId: 'user1234',
+      cohortName: 'Ld segment test',
+      cohortId: 'ld_segment_audience_id',
+      value: true
+    }
+  ]
+}
 
 const goodTrackEvent = createTestEvent({
   type: 'track',
   context: {
     personas: {
       computation_class: 'audience',
+      computation_key: 'ld_segment_test',
+      computation_id: 'ld_segment_audience_id'
+    },
+    traits: {
+      email: 'test@email.com'
+    }
+  },
+  properties: {
+    audience_key: 'ld_segment_test',
+    ld_segment_test: true
+  }
+})
+
+const goodTrackEventJourneyStep = createTestEvent({
+  type: 'track',
+  context: {
+    personas: {
+      computation_class: 'journey_step',
       computation_key: 'ld_segment_test',
       computation_id: 'ld_segment_audience_id'
     },
@@ -57,14 +96,33 @@ const badEvent = createTestEvent({
 
 describe('LaunchDarklyAudiences.syncAudience', () => {
   it('should not throw an error if the audience creation succeed - track', async () => {
-    nock(CONSTANTS.LD_API_BASE_URL).post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT).reply(204)
+    nock(CONSTANTS.LD_API_BASE_URL)
+      .post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT, (body) => isEqual(body, expectedTrackBody))
+      .reply(204)
 
-    await expect(
-      testDestination.testAction('syncAudience', {
-        event: goodTrackEvent,
-        useDefaultMappings: true
-      })
-    ).resolves.not.toThrowError()
+    const responses = await testDestination.testAction('syncAudience', {
+      event: goodTrackEvent,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
+  })
+
+  it('should not throw an error if the audience creation succeed - track (journey_step)', async () => {
+    nock(CONSTANTS.LD_API_BASE_URL)
+      .post(CONSTANTS.LD_API_CUSTOM_AUDIENCE_ENDPOINT, (body) => isEqual(body, expectedTrackBody))
+      .reply(204)
+
+    const responses = await testDestination.testAction('syncAudience', {
+      event: goodTrackEventJourneyStep,
+      settings,
+      useDefaultMappings: true
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
   })
 
   it('should not throw an error if the audience creation succeed - identify', async () => {

--- a/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/updateAudience/__tests__/index.test.ts
@@ -211,6 +211,58 @@ describe('LinkedinAudiences.updateAudience', () => {
       expect(response).toBeTruthy()
     })
 
+    it('should set action to "ADD" for a Journeys event (computation_class: journey_step) in AUTO mode', async () => {
+      // This destination has no computation_class-aware code: in AUTO mode (the default),
+      // getAction() (functions.ts) decides ADD/REMOVE purely from the literal `event` name
+      // ("Audience Entered"/"Audience Exited"), never from computation_class. This test pins
+      // down that a Journeys-originated event (computation_class: 'journey_step') is handled
+      // identically to a classic Engage one, since only the event name matters here.
+      const journeysEvent = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          audience_key: 'personas_test_audience'
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          },
+          traits: {
+            email: 'testing@testing.com'
+          },
+          personas: {
+            computation_class: 'journey_step',
+            computation_key: 'personas_test_audience'
+          }
+        }
+      })
+
+      nock(`${BASE_URL}/dmpSegments`)
+        .get(/.*/)
+        .query(() => true)
+        .reply(200, { elements: [{ id: 'dmp_segment_id' }] })
+
+      nock(`${BASE_URL}/dmpSegments/dmp_segment_id/users`)
+        .post(/.*/, (body) => body.elements[0].action === 'ADD')
+        .reply(200)
+
+      const response = await testDestination.testAction('updateAudience', {
+        event: journeysEvent,
+        settings: {
+          ad_account_id: '123',
+          send_email: true,
+          send_google_advertising_id: true
+        },
+        useDefaultMappings: true,
+        auth,
+        mapping: {
+          personas_audience_key: 'personas_test_audience'
+        }
+      })
+
+      expect(response).toBeTruthy()
+    })
+
     it('Email comes from traits.email', async () => {
       const eventWithTraits = createTestEvent({
         event: 'Audience Entered',

--- a/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/marketo-static-lists/addToList/__tests__/index.test.ts
@@ -176,4 +176,132 @@ describe('MarketoStaticLists.addToList', () => {
       'Static list not found'
     )
   })
+
+  describe('Journeys "Journeys Step Entered" preset', () => {
+    // ../../index.ts declares a `specificEvent` preset (eventSlug: 'journeys_step_entered_track')
+    // that routes to addToList using `defaultValues(addToList.fields)` as its mapping. addToList
+    // doesn't read computation_class/audienceMembership at all - add vs. remove is decided purely
+    // by which action the preset routes to (addToList here, removeFromList for the "exited"
+    // presets). So this test only needs to prove that the preset's default mapping correctly
+    // extracts the external_audience_id and lead data from a realistic Journeys step event.
+    it('uses the preset default mapping to add a Journeys user to a Marketo static list', async () => {
+      const preset = Destination.presets?.find(
+        (p) =>
+          p.partnerAction === 'addToList' && p.type === 'specificEvent' && p.eventSlug === 'journeys_step_entered_track'
+      )
+      if (!preset) {
+        throw new Error('Expected to find a "Journeys Step Entered" preset routing to addToList')
+      }
+
+      const JOURNEYS_EXTERNAL_AUDIENCE_ID = '98765'
+      const journeysEvent = createTestEvent({
+        event: 'Journeys Step Entered',
+        type: 'track',
+        properties: {},
+        context: {
+          traits: {
+            email: 'journeys-user@testing.com'
+          },
+          personas: {
+            computation_class: 'journey_step',
+            computation_key: 'personas_test_audience',
+            external_audience_id: JOURNEYS_EXTERNAL_AUDIENCE_ID
+          }
+        }
+      })
+
+      const bulkImport = API_ENDPOINT + BULK_IMPORT_ENDPOINT.replace('externalId', JOURNEYS_EXTERNAL_AUDIENCE_ID)
+      nock(bulkImport).post(/.*/).reply(200, { success: true })
+
+      const r = await testDestination.testAction(preset.partnerAction, {
+        event: journeysEvent,
+        settings,
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      // Use the LAST response, not r[0]: createTestIntegration's testAction() only resets its
+      // internal responses array after a successful call, so when the immediately preceding
+      // test in this file throws (see "fail if list id does not exist" above), that array isn't
+      // cleared and this call's response gets appended after a stale leftover entry. r[0] would
+      // then be that stale entry rather than this call's own result. This is a pre-existing
+      // quirk in createTestIntegration, not something introduced by this test.
+      const response = r[r.length - 1]
+
+      expect(response.status).toEqual(200)
+      expect(response.options.body).toMatchInlineSnapshot(`
+        "----SEGMENT-DATA--
+        Content-Disposition: form-data; name=\\"file\\"; filename=\\"leads.csv\\"
+        Content-Type: text/csv
+
+        email
+        journeys-user@testing.com
+        ----SEGMENT-DATA----
+        "
+      `)
+    })
+  })
+
+  describe('RETL perform() path with saved hook outputs', () => {
+    // The tests above call the retlOnMappingSave hook directly via executeHook(). This test instead
+    // goes through perform() itself (testAction), with a realistic RETL event/mapping that carries
+    // `__segment_internal_sync_mode` (present on real RETL syncs, even though addToList doesn't
+    // declare a top-level `syncMode` and therefore never reads it) and a `retlOnMappingSave.outputs`
+    // mapping key simulating a list previously created/selected via the hook. It asserts that
+    // addToList() prefers the saved hook output list ID over context.personas.external_audience_id
+    // (see functions.ts: `hookOutputs?.id ?? payload.external_id`).
+    it('uses the saved hookOutputs list ID rather than context.personas.external_audience_id', async () => {
+      const hookListId = '999'
+      const hookListName = 'Hook-Created List'
+
+      const retlEvent = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {},
+        context: {
+          traits: {
+            email: 'retl-user@testing.com'
+          },
+          personas: {
+            // A realistic RETL event still carries this, but the saved hook output below must win.
+            external_audience_id: EXTERNAL_AUDIENCE_ID
+          }
+        }
+      })
+
+      const bulkImport = API_ENDPOINT + BULK_IMPORT_ENDPOINT.replace('externalId', hookListId)
+      nock(bulkImport).post(/.*/).reply(200, { success: true })
+
+      const r = await testDestination.testAction('addToList', {
+        event: retlEvent,
+        settings,
+        useDefaultMappings: true,
+        mapping: {
+          __segment_internal_sync_mode: 'add',
+          retlOnMappingSave: {
+            outputs: {
+              id: hookListId,
+              name: hookListName
+            }
+          }
+        }
+      })
+
+      // Use the LAST response - see the comment on the "uses the preset default mapping..." test
+      // above for why r[0] can be a stale entry from a preceding failing test in this file.
+      const response = r[r.length - 1]
+
+      expect(response.status).toEqual(200)
+      expect(response.options.body).toMatchInlineSnapshot(`
+        "----SEGMENT-DATA--
+        Content-Disposition: form-data; name=\\"file\\"; filename=\\"leads.csv\\"
+        Content-Type: text/csv
+
+        email
+        retl-user@testing.com
+        ----SEGMENT-DATA----
+        "
+      `)
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/optimizely-advanced-audience-targeting/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/optimizely-advanced-audience-targeting/syncAudience/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import isEqual from 'lodash/isEqual'
 import Destination from '../../index'
 
 let testDestination = createTestIntegration(Destination)
@@ -12,6 +13,19 @@ describe('OptimizelyAdvancedAudienceTargeting.syncAudience', () => {
   })
 
   describe('single request', () => {
+    // Expected request body for trackEvent / trackEventJourneyStep below. segment_computation_action
+    // (populated from computation_class) is only used as a gate on the field's `choices` - it is not
+    // referenced when building the OptimizelyClient request body, so an 'audience' payload and an
+    // otherwise-identical 'journey_step' payload produce an identical request body.
+    const expectedTrackBody = [
+      {
+        audienceId: 'abc',
+        audienceName: 'some_audience_name',
+        timestamp: '2024-01-08T13:52:50.212Z',
+        subscription: true,
+        userId: 'user1234'
+      }
+    ]
     const trackEvent = createTestEvent({
       context: {
         personas: {
@@ -26,7 +40,25 @@ describe('OptimizelyAdvancedAudienceTargeting.syncAudience', () => {
       traits: {
         email: 'test.email@test.com',
         some_audience_name: true
-      }
+      },
+      timestamp: '2024-01-08T13:52:50.212Z'
+    })
+    const trackEventJourneyStep = createTestEvent({
+      context: {
+        personas: {
+          computation_class: 'journey_step',
+          computation_key: 'some_audience_name',
+          computation_id: 'abc'
+        },
+        traits: {
+          email: 'test.email@test.com'
+        }
+      },
+      traits: {
+        email: 'test.email@test.com',
+        some_audience_name: true
+      },
+      timestamp: '2024-01-08T13:52:50.212Z'
     })
     const identifyEvent = createTestEvent({
       context: {
@@ -43,14 +75,31 @@ describe('OptimizelyAdvancedAudienceTargeting.syncAudience', () => {
     })
 
     it('should handle traits with track', async () => {
-      nock('https://function.zaius.app/twilio_segment').post('/batch_sync_audience').reply(201)
+      nock('https://function.zaius.app/twilio_segment')
+        .post('/batch_sync_audience', (body) => isEqual(body, expectedTrackBody))
+        .reply(201)
 
-      await expect(
-        testDestination.testAction('syncAudience', {
-          event: trackEvent,
-          useDefaultMappings: true
-        })
-      ).resolves.not.toThrowError()
+      const responses = await testDestination.testAction('syncAudience', {
+        event: trackEvent,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+    })
+
+    it('should handle traits with track (journey_step)', async () => {
+      nock('https://function.zaius.app/twilio_segment')
+        .post('/batch_sync_audience', (body) => isEqual(body, expectedTrackBody))
+        .reply(201)
+
+      const responses = await testDestination.testAction('syncAudience', {
+        event: trackEventJourneyStep,
+        useDefaultMappings: true
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
     })
 
     it('should handle props with track', async () => {

--- a/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/reddit-audiences/syncAudience/__tests__/index.test.ts
@@ -76,6 +76,40 @@ const segmentEventRemove: Partial<SegmentEvent> = {
     test_audience_name: false
   }
 }
+const segmentEventAddJourneyStep: Partial<SegmentEvent> = {
+  userId: '+254729159373',
+  type: 'identify',
+  context: {
+    personas: {
+      external_audience_id: 'ca.2066268373552240021',
+      computation_class: 'journey_step',
+      computation_id: 'aud_2mKnduJD6sudXVkAqo0q3qshFTW',
+      computation_key: 'test_audience_name'
+    }
+  },
+  traits: {
+    email: 'Al.ice+Apple@Example.Com',
+    android_idfa: 'test_idfa',
+    test_audience_name: true
+  }
+}
+const segmentEventRemoveJourneyStep: Partial<SegmentEvent> = {
+  userId: '+254729159373',
+  type: 'identify',
+  context: {
+    personas: {
+      external_audience_id: 'ca.2066268373552240021',
+      computation_class: 'journey_step',
+      computation_id: 'aud_2mKnduJD6sudXVkAqo0q3qshFTW',
+      computation_key: 'test_audience_name'
+    }
+  },
+  traits: {
+    email: 'testemail234@gmail.com',
+    android_idfa: 'test_idfa',
+    test_audience_name: false
+  }
+}
 const expectedPayloadEmailOnly = {
   data: {
     column_order: ['EMAIL_SHA256'],
@@ -146,6 +180,46 @@ describe('Reddit-Audiences.customEvent', () => {
   })
   it('will remove a user from an Audience', async () => {
     const event = createTestEvent(segmentEventRemove)
+
+    nock('https://ads-api.reddit.com')
+      .matchHeader('Authorization', 'Bearer undefined') // no need to check access_token
+      .patch(`/api/v3/custom_audiences/${event?.context?.personas?.external_audience_id}/users`, (body) => {
+        return isEqual(body, expectedPayloadRemove)
+      })
+      .reply(204, {})
+
+    const responses = await testDestination.testAction('syncAudience', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
+  })
+  it('will add a user to an Audience when computation_class is journey_step', async () => {
+    const event = createTestEvent(segmentEventAddJourneyStep)
+
+    nock('https://ads-api.reddit.com')
+      .matchHeader('Authorization', 'Bearer undefined') // no need to check access_token
+      .patch(`/api/v3/custom_audiences/${event?.context?.personas?.external_audience_id}/users`, (body) => {
+        return isEqual(body, expectedPayloadAdd)
+      })
+      .reply(204, {})
+
+    const responses = await testDestination.testAction('syncAudience', {
+      event,
+      settings,
+      useDefaultMappings: true,
+      mapping
+    })
+
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(204)
+  })
+  it('will remove a user from an Audience when computation_class is journey_step', async () => {
+    const event = createTestEvent(segmentEventRemoveJourneyStep)
 
     nock('https://ads-api.reddit.com')
       .matchHeader('Authorization', 'Bearer undefined') // no need to check access_token

--- a/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/rokt-capi/send/__tests__/index.test.ts
@@ -5,7 +5,6 @@ import destination from '../../index'
 const testDestination = createTestIntegration(destination)
 
 describe('RoktCapi.send', () => {
-
   beforeEach(() => {
     jest.clearAllMocks()
     nock.cleanAll()
@@ -21,7 +20,7 @@ describe('RoktCapi.send', () => {
         properties: {
           order_id: 'order-123',
           revenue: 99.99,
-          currency: 'USD', 
+          currency: 'USD',
           email: 'test@example.com'
         },
         context: {
@@ -58,9 +57,7 @@ describe('RoktCapi.send', () => {
         ip: '192.168.1.1'
       }
 
-      nock('https://inbound.mparticle.com')
-        .post('/s2s/v2/events', expectedRoktPayload)
-        .reply(200, { success: true })
+      nock('https://inbound.mparticle.com').post('/s2s/v2/events', expectedRoktPayload).reply(200, { success: true })
 
       const responses = await testDestination.testAction('send', {
         event,
@@ -157,7 +154,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-789',
-          revenue: 150.00,
+          revenue: 150.0,
           currency: 'USD',
           email: 'test@example.com'
         },
@@ -197,7 +194,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-999',
-          revenue: 200.00,
+          revenue: 200.0,
           currency: 'USD',
           email: 'user@example.com',
           first_name: 'John',
@@ -258,7 +255,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-111',
-          revenue: 75.00,
+          revenue: 75.0,
           currency: 'USD',
           email: 'user2@example.com',
           first_name: 'Jane',
@@ -313,7 +310,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-222',
-          revenue: 120.00,
+          revenue: 120.0,
           currency: 'USD'
         },
         context: {
@@ -349,7 +346,7 @@ describe('RoktCapi.send', () => {
               custom_attributes: {
                 conversiontype: 'Order Completed',
                 confirmationref: 'order-222',
-                amount: 120.00,
+                amount: 120.0,
                 currency: 'USD'
               }
             }
@@ -357,9 +354,7 @@ describe('RoktCapi.send', () => {
         ]
       }
 
-      nock('https://inbound.mparticle.com')
-        .post('/s2s/v2/events', expectedRoktPayload)
-        .reply(200, { success: true })
+      nock('https://inbound.mparticle.com').post('/s2s/v2/events', expectedRoktPayload).reply(200, { success: true })
 
       const responses = await testDestination.testAction('send', {
         event,
@@ -378,7 +373,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-333',
-          revenue: 85.00,
+          revenue: 85.0,
           currency: 'USD'
         },
         context: {
@@ -414,7 +409,7 @@ describe('RoktCapi.send', () => {
               custom_attributes: {
                 conversiontype: 'Order Completed',
                 confirmationref: 'order-333',
-                amount: 85.00,
+                amount: 85.0,
                 currency: 'USD'
               }
             }
@@ -422,9 +417,7 @@ describe('RoktCapi.send', () => {
         ]
       }
 
-      nock('https://inbound.mparticle.com')
-        .post('/s2s/v2/events', expectedRoktPayload)
-        .reply(200, { success: true })
+      nock('https://inbound.mparticle.com').post('/s2s/v2/events', expectedRoktPayload).reply(200, { success: true })
 
       const responses = await testDestination.testAction('send', {
         event,
@@ -480,7 +473,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-555',
-          revenue: 300.00,
+          revenue: 300.0,
           currency: 'USD',
           product_name: 'Widget Pro',
           quantity: 3,
@@ -557,12 +550,67 @@ describe('RoktCapi.send', () => {
           eventDetails: {
             source_message_id: 'msg-011',
             timestamp_unixtime_ms: '2024-01-18T12:00:00.000Z'
-          },         
+          },
           engageAudienceName: 'premium_users',
           traitsOrProps: {
             premium_users: true
           },
           computationAction: 'audience'
+        }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
+
+    it('should send audience membership update for Engage Audience when computation_class is journey_step', async () => {
+      // journey_step (Journeys) should be treated identically to 'audience' (classic Engage) since
+      // the code only checks computationAction for truthiness, not for a specific string value.
+      const event = createTestEvent({
+        event: 'Audience Entered',
+        messageId: 'msg-011-journey',
+        timestamp: '2024-01-18T12:00:00.000Z',
+        type: 'track',
+        properties: {
+          premium_users: true,
+          email: 'premium@example.com'
+        },
+        context: {
+          personas: {
+            audience_key: 'premium_users',
+            computation_class: 'journey_step'
+          }
+        },
+        userId: 'user-666'
+      })
+
+      nock('https://inbound.mparticle.com')
+        .post('/s2s/v2/events', (body) => {
+          expect(body.events).toBeDefined()
+          expect(body.events.length).toBe(1)
+          expect(body.events[0].data.event_name).toBe('audiencemembershipupdate')
+          expect(body.events[0].data.custom_event_type).toBe('other')
+          expect(body.events[0].data.source_message_id).toBe('aud_msg-011-journey')
+          expect(body.events[0].data.custom_attributes.audience_name).toBe('premium_users')
+          expect(body.events[0].data.custom_attributes.status).toBe('add')
+          expect(body.user_attributes.segment_premium_users).toBe(true)
+          return true
+        })
+        .reply(200, { success: true })
+
+      const responses = await testDestination.testAction('send', {
+        event,
+        useDefaultMappings: true,
+        mapping: {
+          eventDetails: {
+            source_message_id: 'msg-011-journey',
+            timestamp_unixtime_ms: '2024-01-18T12:00:00.000Z'
+          },
+          engageAudienceName: 'premium_users',
+          traitsOrProps: {
+            premium_users: true
+          },
+          computationAction: 'journey_step'
         }
       })
 
@@ -578,7 +626,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           audience_name: 'high_value_customers',
-          audience_membership: true, 
+          audience_membership: true,
           email: 'highvalue@example.com'
         },
         userId: 'user-777'
@@ -621,7 +669,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-ws',
-          revenue: 50.00,
+          revenue: 50.0,
           currency: 'USD'
         },
         userId: 'user-ws'
@@ -700,7 +748,8 @@ describe('RoktCapi.send', () => {
       const expectedRoktPayload = {
         environment: 'production',
         device_info: {
-          http_header_user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
+          http_header_user_agent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1'
         },
         user_attributes: {
           segment_premium_users: true
@@ -739,9 +788,7 @@ describe('RoktCapi.send', () => {
         ip: '8.8.8.8'
       }
 
-      nock('https://inbound.mparticle.com')
-        .post('/s2s/v2/events', expectedRoktPayload)
-        .reply(200, { success: true })
+      nock('https://inbound.mparticle.com').post('/s2s/v2/events', expectedRoktPayload).reply(200, { success: true })
 
       const responses = await testDestination.testAction('send', {
         event,
@@ -772,7 +819,7 @@ describe('RoktCapi.send', () => {
         type: 'track',
         properties: {
           order_id: 'order-888',
-          revenue: 50.00,
+          revenue: 50.0,
           currency: 'USD'
         },
         context: {},
@@ -788,7 +835,9 @@ describe('RoktCapi.send', () => {
             device_info: {}
           }
         })
-      ).rejects.toThrow('At least one of the following is required: iOS Advertising ID, Android Advertising ID, iOS ID for Vendor, Android UUID, Email, Customer ID, RTID.')
+      ).rejects.toThrow(
+        'At least one of the following is required: iOS Advertising ID, Android Advertising ID, iOS ID for Vendor, Android UUID, Email, Customer ID, RTID.'
+      )
     })
   })
 
@@ -802,7 +851,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'batch-order-001',
-            revenue: 100.00,
+            revenue: 100.0,
             currency: 'USD',
             email: 'batch1@example.com'
           },
@@ -815,7 +864,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'batch-order-002',
-            revenue: 200.00,
+            revenue: 200.0,
             currency: 'USD',
             email: 'batch2@example.com'
           },
@@ -828,7 +877,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'batch-order-003',
-            revenue: 300.00,
+            revenue: 300.0,
             currency: 'USD',
             email: 'batch3@example.com'
           },
@@ -868,7 +917,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'mixed-order-001',
-            revenue: 100.00,
+            revenue: 100.0,
             currency: 'USD',
             email: 'valid1@example.com'
           },
@@ -882,7 +931,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'mixed-order-002',
-            revenue: 200.00,
+            revenue: 200.0,
             currency: 'USD'
           },
           context: {},
@@ -896,7 +945,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'mixed-order-003',
-            revenue: 300.00,
+            revenue: 300.0,
             currency: 'USD',
             email: 'valid2@example.com'
           },
@@ -910,7 +959,7 @@ describe('RoktCapi.send', () => {
           type: 'track',
           properties: {
             order_id: 'mixed-order-004',
-            revenue: 400.00,
+            revenue: 400.0,
             currency: 'USD'
           },
           context: {},
@@ -1012,9 +1061,7 @@ describe('RoktCapi.send', () => {
         })
       ]
 
-      nock('https://inbound.mparticle.com')
-        .post('/s2s/v2/bulkevents')
-        .reply(500, { error: 'Internal Server Error' })
+      nock('https://inbound.mparticle.com').post('/s2s/v2/bulkevents').reply(500, { error: 'Internal Server Error' })
 
       const responses = await testDestination.testBatchAction('send', {
         events,

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/dataExtensionV2.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/dataExtensionV2.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration, SegmentEvent, DynamicFieldResponse } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
 import Definition from '../index'
 import { Settings } from '../generated-types'
 
@@ -437,7 +437,7 @@ describe('Salesforce Marketing Cloud', () => {
             ]
           })
 
-        const response = (await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
+        const response = await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
           settings,
           payload: {
             onMappingSave: {
@@ -446,7 +446,7 @@ describe('Salesforce Marketing Cloud', () => {
               }
             }
           }
-        })) as DynamicFieldResponse
+        })
 
         expect(response.choices).toHaveLength(1)
         expect(response.choices).toEqual(expect.arrayContaining([{ value: 'id', label: 'id' }]))
@@ -472,7 +472,7 @@ describe('Salesforce Marketing Cloud', () => {
             ]
           })
 
-        const response = (await testDestination.testDynamicField('dataExtensionV2', 'values.__keys__', {
+        const response = await testDestination.testDynamicField('dataExtensionV2', 'values.__keys__', {
           settings,
           payload: {
             onMappingSave: {
@@ -481,7 +481,7 @@ describe('Salesforce Marketing Cloud', () => {
               }
             }
           }
-        })) as DynamicFieldResponse
+        })
 
         expect(response.choices).toHaveLength(2)
         expect(response.choices).toEqual(
@@ -493,10 +493,10 @@ describe('Salesforce Marketing Cloud', () => {
       })
 
       it('should return error when no data extension ID is provided', async () => {
-        const response = (await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
+        const response = await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
           settings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(response.choices).toHaveLength(0)
         expect(response.error).toEqual({
@@ -523,7 +523,7 @@ describe('Salesforce Marketing Cloud', () => {
             ]
           })
 
-        const response = (await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
+        const response = await testDestination.testDynamicField('dataExtensionV2', 'keys.__keys__', {
           settings,
           payload: {
             retlOnMappingSave: {
@@ -532,7 +532,7 @@ describe('Salesforce Marketing Cloud', () => {
               }
             }
           }
-        })) as DynamicFieldResponse
+        })
 
         expect(response.choices).toHaveLength(1)
         expect(response.choices).toEqual([{ value: 'subscriber_key', label: 'subscriber_key' }])
@@ -557,7 +557,7 @@ describe('Salesforce Marketing Cloud', () => {
             ]
           })
 
-        const response = (await testDestination.testDynamicField('dataExtensionV2', 'values.__keys__', {
+        const response = await testDestination.testDynamicField('dataExtensionV2', 'values.__keys__', {
           settings,
           payload: {
             retlOnMappingSave: {
@@ -566,7 +566,7 @@ describe('Salesforce Marketing Cloud', () => {
               }
             }
           }
-        })) as DynamicFieldResponse
+        })
 
         expect(response.choices).toHaveLength(2)
         expect(response.choices).toEqual(
@@ -575,6 +575,176 @@ describe('Salesforce Marketing Cloud', () => {
             { value: 'last_name', label: 'last_name' }
           ])
         )
+      })
+    })
+
+    describe('retlOnMappingSave hook (performHook / selectOrCreateDataExtension)', () => {
+      it('should create a new data extension when operation is "create"', async () => {
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`).post('/data/v1/customobjects').reply(201, {
+          id: 'new-de-id',
+          key: 'new-de-key'
+        })
+
+        const hookInputs = {
+          operation: 'create',
+          name: 'My New Data Extension',
+          categoryId: '12345',
+          columns: [
+            { name: 'id', type: 'Text', isNullable: false, isPrimaryKey: true },
+            { name: 'email', type: 'EmailAddress', isNullable: true, isPrimaryKey: false }
+          ]
+        }
+
+        const r = await testDestination.actions.dataExtensionV2.executeHook('retlOnMappingSave', {
+          settings,
+          hookInputs,
+          payload: {}
+        })
+
+        expect(r.savedData).toEqual({
+          id: 'new-de-id',
+          name: 'My New Data Extension'
+        })
+        expect(r.successMessage).toBe(
+          'Data Extension My New Data Extension created successfully with External Key new-de-key'
+        )
+      })
+
+      it('should select an existing data extension when operation is "select"', async () => {
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}`)
+          .reply(200, {
+            id: dataExtensionId,
+            name: 'Existing Data Extension'
+          })
+
+        const hookInputs = {
+          operation: 'select',
+          dataExtensionId
+        }
+
+        const r = await testDestination.actions.dataExtensionV2.executeHook('retlOnMappingSave', {
+          settings,
+          hookInputs,
+          payload: {}
+        })
+
+        expect(r.savedData).toEqual({
+          id: dataExtensionId,
+          name: 'Existing Data Extension'
+        })
+        expect(r.successMessage).toBe(
+          `Data Extension Existing Data Extension selected successfully with External ID ${dataExtensionId}`
+        )
+      })
+
+      it('should return an error when selecting a data extension that does not exist', async () => {
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}`)
+          .reply(404, {
+            message: 'Resource not found',
+            errorcode: 404
+          })
+
+        const hookInputs = {
+          operation: 'select',
+          dataExtensionId
+        }
+
+        const r = await testDestination.actions.dataExtensionV2.executeHook('retlOnMappingSave', {
+          settings,
+          hookInputs,
+          payload: {}
+        })
+
+        expect(r.savedData).toBeUndefined()
+        expect(r.error).toEqual({
+          message: 'Resource not found',
+          code: 'ERROR'
+        })
+      })
+
+      it('should surface savedData alongside the error when selection fails due to insufficient authentication (error code 20002)', async () => {
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}`)
+          .reply(401, {
+            message: 'Insufficient authentication',
+            errorcode: 20002
+          })
+
+        const hookInputs = {
+          operation: 'select',
+          dataExtensionId
+        }
+
+        const r = await testDestination.actions.dataExtensionV2.executeHook('retlOnMappingSave', {
+          settings,
+          hookInputs,
+          payload: {}
+        })
+
+        expect(r.savedData).toEqual({
+          id: dataExtensionId,
+          name: 'Unknown (Insufficient Authentication Error)'
+        })
+        expect(r.error?.message).toContain('Insufficient authentication')
+        expect(r.error?.code).toBe('Authentication Error')
+      })
+
+      it('should return an error when creating a data extension fails (e.g. duplicate name)', async () => {
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`).post('/data/v1/customobjects').reply(400, {
+          message: 'A Data Extension with this name already exists',
+          errorcode: 10001
+        })
+
+        const hookInputs = {
+          operation: 'create',
+          name: 'Duplicate DE',
+          categoryId: '12345',
+          columns: [{ name: 'id', type: 'Text', isNullable: false, isPrimaryKey: true }]
+        }
+
+        const r = await testDestination.actions.dataExtensionV2.executeHook('retlOnMappingSave', {
+          settings,
+          hookInputs,
+          payload: {}
+        })
+
+        expect(r.savedData).toBeUndefined()
+        expect(r.error).toEqual({
+          message: 'A Data Extension with this name already exists',
+          code: 'ERROR'
+        })
       })
     })
   })

--- a/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/the-trade-desk-crm/syncAudience/__tests__/index.test.ts
@@ -495,7 +495,7 @@ describe('TheTradeDeskCrm.syncAudience', () => {
 
       // Verify metadata structure
       const metadataCall = metadataCalls[metadataCalls.length - 1][0]
-      const metadata = JSON.parse(metadataCall.Body)
+      const metadata = JSON.parse(metadataCall.Body as string)
 
       expect(metadata).toMatchObject({
         TTDAuthToken: 'test-token',
@@ -513,6 +513,124 @@ describe('TheTradeDeskCrm.syncAudience', () => {
           subscriptionId: expect.any(String)
         })
       })
+    })
+
+    // NOTE: This destination has a single `syncAudience` action with no separate "remove" action,
+    // and `full_audience_sync: true` means Segment always re-uploads the complete current
+    // membership snapshot (MergeMode: 'Replace'). Neither `processPayload` nor `extractUsers`
+    // (see ../../functions.ts) ever read the membership boolean at `properties[computation_key]`,
+    // so there is no add-vs-remove branch to exercise here. `computation_class` is only read to
+    // pull `computation_id` through into `segmentInternal.audienceId` for observability. These two
+    // tests cover that native-contract field propagation for both `audience` and `journey_step`
+    // payloads, and confirm the sync is processed identically regardless of the membership value.
+    it('should propagate computation_id into segmentInternal.audienceId for a native "audience" computation_class payload', async () => {
+      const nativeAudienceEvent = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          personas_test_audience: true
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          },
+          traits: {
+            email: 'native-audience@testing.com'
+          },
+          personas: {
+            computation_class: 'audience',
+            computation_key: 'personas_test_audience',
+            computation_id: 'aud_native_12345',
+            external_audience_id: 'external_audience_id'
+          }
+        }
+      })
+
+      await testDestination.testBatchAction('syncAudience', {
+        events: [nativeAudienceEvent],
+        settings: {
+          advertiser_id: 'test-advertiser',
+          auth_token: 'test-token',
+          __segment_internal_engage_force_full_sync: true,
+          __segment_internal_engage_batch_sync: true
+        },
+        features: {}, // AWS flow
+        useDefaultMappings: true,
+        mapping: {
+          name: 'test_audience',
+          region: 'US',
+          pii_type: 'Email'
+        }
+      })
+
+      const metadataCalls = MockedPutObjectCommand.mock.calls.filter((call) => {
+        return call[0].ContentType === 'application/json'
+      })
+      const metadataCall = metadataCalls[metadataCalls.length - 1][0]
+      const metadata = JSON.parse(metadataCall.Body as string)
+
+      expect(metadata.segmentInternal.audienceId).toBe('aud_native_12345')
+
+      // The user is still uploaded (not filtered out) even though this is the "membership" shape -
+      // confirming there is no add/remove gating on the boolean at properties[computation_key].
+      const userDataCalls = MockedPutObjectCommand.mock.calls.filter((call) => call[0].ContentType === 'text/csv')
+      const userDataCall = userDataCalls[userDataCalls.length - 1][0]
+      expect(userDataCall.Body).toContain('native-audience@testing.com')
+    })
+
+    it('should propagate computation_id into segmentInternal.audienceId for a native "journey_step" computation_class payload, regardless of membership value', async () => {
+      const nativeJourneyStepEvent = createTestEvent({
+        event: 'Audience Entered',
+        type: 'track',
+        properties: {
+          personas_test_audience: false
+        },
+        context: {
+          device: {
+            advertisingId: '123'
+          },
+          traits: {
+            email: 'native-journey-step@testing.com'
+          },
+          personas: {
+            computation_class: 'journey_step',
+            computation_key: 'personas_test_audience',
+            computation_id: 'aud_native_67890',
+            external_audience_id: 'external_audience_id'
+          }
+        }
+      })
+
+      await testDestination.testBatchAction('syncAudience', {
+        events: [nativeJourneyStepEvent],
+        settings: {
+          advertiser_id: 'test-advertiser',
+          auth_token: 'test-token',
+          __segment_internal_engage_force_full_sync: true,
+          __segment_internal_engage_batch_sync: true
+        },
+        features: {}, // AWS flow
+        useDefaultMappings: true,
+        mapping: {
+          name: 'test_audience',
+          region: 'US',
+          pii_type: 'Email'
+        }
+      })
+
+      const metadataCalls = MockedPutObjectCommand.mock.calls.filter((call) => {
+        return call[0].ContentType === 'application/json'
+      })
+      const metadataCall = metadataCalls[metadataCalls.length - 1][0]
+      const metadata = JSON.parse(metadataCall.Body as string)
+
+      expect(metadata.segmentInternal.audienceId).toBe('aud_native_67890')
+
+      // Membership is `false` here (a "remove"), yet the user is still uploaded - there is no
+      // remove/delete action or code path in this destination to divert to.
+      const userDataCalls = MockedPutObjectCommand.mock.calls.filter((call) => call[0].ContentType === 'text/csv')
+      const userDataCall = userDataCalls[userDataCalls.length - 1][0]
+      expect(userDataCall.Body).toContain('native-journey-step@testing.com')
     })
 
     it('should handle EmailHashedUnifiedId2 in AWS flow', async () => {
@@ -563,7 +681,7 @@ describe('TheTradeDeskCrm.syncAudience', () => {
       })
 
       const metadataCall = metadataCalls[metadataCalls.length - 1][0]
-      const metadata = JSON.parse(metadataCall.Body)
+      const metadata = JSON.parse(metadataCall.Body as string)
 
       expect(metadata.DropOptions.PiiType).toBe('EmailHashedUnifiedId2')
     })

--- a/packages/destination-actions/src/destinations/tiktok-audiences/syncAudience/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/tiktok-audiences/syncAudience/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { BASE_URL } from '../../constants'
 import { TIKTOK_AUDIENCES_API_VERSION } from '../../versioning-info'
@@ -26,7 +26,11 @@ const defaultMapping = Object.fromEntries(
 const SUCCESS_RESPONSE = { code: 0, message: 'OK', request_id: 'test-request-id' }
 const ERROR_RESPONSE = { code: 40002, message: 'Parameter error: invalid audience ID', request_id: 'test-request-id' }
 
-function createAudienceEvent(membership: boolean, overrides: Record<string, unknown> = {}) {
+function createAudienceEvent(
+  membership: boolean,
+  computationClass: 'audience' | 'journey_step' = 'audience',
+  overrides: Record<string, unknown> = {}
+) {
   return createTestEvent({
     event: 'Audience Entered',
     type: 'track',
@@ -42,7 +46,7 @@ function createAudienceEvent(membership: boolean, overrides: Record<string, unkn
         phone: '1234567890'
       },
       personas: {
-        computation_class: 'audience',
+        computation_class: computationClass,
         computation_key: COMPUTATION_KEY,
         audience_settings: {
           advertiserId: ADVERTISER_ID
@@ -120,9 +124,7 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should send only email when only send_email is true', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
       const event = createAudienceEvent(true)
       const responses = await testDestination.testAction('syncAudience', {
@@ -139,15 +141,11 @@ describe('TiktokAudiences.syncAudience', () => {
       expect(responses.length).toBe(1)
       const requestBody = JSON.parse(responses[0].options.body as string)
       expect(requestBody.id_schema).toEqual(['EMAIL_SHA256'])
-      expect(requestBody.batch_data).toEqual([
-        [{ id: HASHED_EMAIL, audience_ids: [EXTERNAL_AUDIENCE_ID] }]
-      ])
+      expect(requestBody.batch_data).toEqual([[{ id: HASHED_EMAIL, audience_ids: [EXTERNAL_AUDIENCE_ID] }]])
     })
 
     it('should send only phone when only send_phone is true', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
       const event = createAudienceEvent(true)
       const responses = await testDestination.testAction('syncAudience', {
@@ -164,15 +162,11 @@ describe('TiktokAudiences.syncAudience', () => {
       expect(responses.length).toBe(1)
       const requestBody = JSON.parse(responses[0].options.body as string)
       expect(requestBody.id_schema).toEqual(['PHONE_SHA256'])
-      expect(requestBody.batch_data).toEqual([
-        [{ id: HASHED_PHONE, audience_ids: [EXTERNAL_AUDIENCE_ID] }]
-      ])
+      expect(requestBody.batch_data).toEqual([[{ id: HASHED_PHONE, audience_ids: [EXTERNAL_AUDIENCE_ID] }]])
     })
 
     it('should normalize and hash emails correctly', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
       const event = createTestEvent({
         event: 'Audience Entered',
@@ -212,9 +206,7 @@ describe('TiktokAudiences.syncAudience', () => {
 
     it('should not double-hash a pre-hashed email', async () => {
       const preHashedEmail = '584c4423c421df49955759498a71495aba49b8780eb9387dff333b6f0982c777'
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
       const event = createTestEvent({
         event: 'Audience Entered',
@@ -248,9 +240,7 @@ describe('TiktokAudiences.syncAudience', () => {
 
     it('should not double-hash a pre-hashed phone', async () => {
       const preHashedPhone = 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646'
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
       const event = createTestEvent({
         event: 'Audience Entered',
@@ -356,10 +346,59 @@ describe('TiktokAudiences.syncAudience', () => {
       ).rejects.toThrow('Bad Request: no audienceSettings found.')
     })
 
-    it('should throw when TikTok returns HTTP 200 with error code', async () => {
+    it('should add a user to the audience when membership is true (journey_step)', async () => {
       nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, ERROR_RESPONSE)
+        .post(/.*/, (body) => body.action === 'add')
+        .reply(200, SUCCESS_RESPONSE)
+
+      const event = createAudienceEvent(true, 'journey_step')
+      const responses = await testDestination.testAction('syncAudience', {
+        auth,
+        event,
+        settings: {},
+        useDefaultMappings: true,
+        mapping: {}
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      const requestBody = JSON.parse(responses[0].options.body as string)
+      expect(requestBody.action).toBe('add')
+      expect(requestBody.advertiser_ids).toEqual([ADVERTISER_ID])
+      expect(requestBody.id_schema).toEqual(['EMAIL_SHA256', 'PHONE_SHA256', 'IDFA_SHA256'])
+      expect(requestBody.batch_data).toEqual([
+        [
+          { id: HASHED_EMAIL, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_PHONE, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_ADVERTISING_ID, audience_ids: [EXTERNAL_AUDIENCE_ID] }
+        ]
+      ])
+    })
+
+    it('should remove a user from the audience when membership is false (journey_step)', async () => {
+      nock(SEGMENT_MAPPING_URL)
+        .post(/.*/, (body) => body.action === 'delete')
+        .reply(200, SUCCESS_RESPONSE)
+
+      const event = createAudienceEvent(false, 'journey_step')
+      const responses = await testDestination.testAction('syncAudience', {
+        auth,
+        event,
+        settings: {},
+        useDefaultMappings: true,
+        mapping: {}
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      const requestBody = JSON.parse(responses[0].options.body as string)
+      expect(requestBody.action).toBe('delete')
+    })
+
+    it('should throw when TikTok returns HTTP 200 with error code', async () => {
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, ERROR_RESPONSE)
 
       const event = createAudienceEvent(true)
 
@@ -375,9 +414,7 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should throw when TikTok returns HTTP 400', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(400, ERROR_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(400, ERROR_RESPONSE)
 
       const event = createAudienceEvent(true)
 
@@ -403,10 +440,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'delete')
         .reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(false) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(false)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -425,10 +459,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'add')
         .reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(true) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(true)]
 
       await testDestination.executeBatch('syncAudience', {
         events,
@@ -445,10 +476,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'delete')
         .reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(false) as SegmentEvent,
-        createAudienceEvent(false) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(false), createAudienceEvent(false)]
 
       await testDestination.executeBatch('syncAudience', {
         events,
@@ -461,14 +489,9 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should record success for all payloads when TikTok returns code 0', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(true) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(true)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -483,14 +506,9 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should record errors for all payloads when TikTok returns HTTP 200 with error code', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, ERROR_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, ERROR_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(true) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(true)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -506,14 +524,9 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should record errors for all payloads when TikTok returns HTTP 400', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(400, ERROR_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(400, ERROR_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(true) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(true)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -532,10 +545,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'add')
         .reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(true) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(true)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -581,10 +591,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'delete')
         .reply(200, ERROR_RESPONSE)
 
-      const events = [
-        createAudienceEvent(false) as SegmentEvent,
-        createAudienceEvent(false) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(false), createAudienceEvent(false)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -620,8 +627,22 @@ describe('TiktokAudiences.syncAudience', () => {
       }
 
       expect(responses).toEqual([
-        { status: 400, errortype: 'BAD_REQUEST', errormessage: 'Parameter error: invalid audience ID', errorreporter: 'DESTINATION', sent: expectedSent, body: expectedBody },
-        { status: 400, errortype: 'BAD_REQUEST', errormessage: 'Parameter error: invalid audience ID', errorreporter: 'DESTINATION', sent: expectedSent, body: expectedBody }
+        {
+          status: 400,
+          errortype: 'BAD_REQUEST',
+          errormessage: 'Parameter error: invalid audience ID',
+          errorreporter: 'DESTINATION',
+          sent: expectedSent,
+          body: expectedBody
+        },
+        {
+          status: 400,
+          errortype: 'BAD_REQUEST',
+          errormessage: 'Parameter error: invalid audience ID',
+          errorreporter: 'DESTINATION',
+          sent: expectedSent,
+          body: expectedBody
+        }
       ])
     })
 
@@ -634,10 +655,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'delete')
         .reply(200, SUCCESS_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(false) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(false)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -700,10 +718,7 @@ describe('TiktokAudiences.syncAudience', () => {
         .post(/.*/, (body) => body.action === 'delete')
         .reply(200, ERROR_RESPONSE)
 
-      const events = [
-        createAudienceEvent(true) as SegmentEvent,
-        createAudienceEvent(false) as SegmentEvent
-      ]
+      const events = [createAudienceEvent(true), createAudienceEvent(false)]
 
       const responses = await testDestination.executeBatch('syncAudience', {
         events,
@@ -761,11 +776,9 @@ describe('TiktokAudiences.syncAudience', () => {
     })
 
     it('should record validation errors per payload while succeeding for valid ones', async () => {
-      nock(SEGMENT_MAPPING_URL)
-        .post(/.*/)
-        .reply(200, SUCCESS_RESPONSE)
+      nock(SEGMENT_MAPPING_URL).post(/.*/).reply(200, SUCCESS_RESPONSE)
 
-      const validEvent = createAudienceEvent(true) as SegmentEvent
+      const validEvent = createAudienceEvent(true)
       const invalidEvent = createTestEvent({
         event: 'Audience Entered',
         type: 'track',
@@ -778,7 +791,7 @@ describe('TiktokAudiences.syncAudience', () => {
             external_audience_id: EXTERNAL_AUDIENCE_ID
           }
         }
-      }) as SegmentEvent
+      })
 
       const events = [validEvent, invalidEvent]
 
@@ -797,6 +810,93 @@ describe('TiktokAudiences.syncAudience', () => {
       expect(errorItems[0].errormessage).toBe(
         'At least one enabled identifier (Email, Phone, or Advertising ID) must have a value.'
       )
+    })
+  })
+
+  describe('presets', () => {
+    beforeEach(() => {
+      // The "batch (performBatch)" tests above call `testDestination.executeBatch(...)`
+      // directly (bypassing the `testBatchAction` wrapper), which never drains the shared
+      // `TestDestination.responses` accumulator. Reset it here so `testAction` below
+      // (which returns exactly that accumulator) only reflects requests made by this test.
+      testDestination.responses = []
+    })
+
+    it('should route the "Journey Step All Events" preset through syncAudience with an add when membership is true', async () => {
+      const preset = Destination.presets?.find((p) => p.name === 'Journey Step All Events')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+      expect(preset?.partnerAction).toBe('syncAudience')
+      expect(preset?.type).toBe('specificEvent')
+      expect((preset as { eventSlug?: string })?.eventSlug).toBe('journey_step_all_events_track')
+
+      nock(SEGMENT_MAPPING_URL)
+        .post(/.*/, (body) => body.action === 'add')
+        .reply(200, SUCCESS_RESPONSE)
+
+      // This preset has no FQL `subscribe` filter — it's matched purely by eventSlug — so build a
+      // realistic Journeys "step all events" track event carrying the fields the preset's
+      // (default) mapping reads from.
+      const event = createAudienceEvent(true, 'journey_step')
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        auth,
+        event,
+        settings: {},
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      const requestBody = JSON.parse(responses[0].options.body as string)
+      expect(requestBody.action).toBe('add')
+      expect(requestBody.advertiser_ids).toEqual([ADVERTISER_ID])
+      expect(requestBody.id_schema).toEqual(['EMAIL_SHA256', 'PHONE_SHA256', 'IDFA_SHA256'])
+      expect(requestBody.batch_data).toEqual([
+        [
+          { id: HASHED_EMAIL, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_PHONE, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_ADVERTISING_ID, audience_ids: [EXTERNAL_AUDIENCE_ID] }
+        ]
+      ])
+    })
+
+    it('should route the "Journey Step All Events" preset through syncAudience with a delete when membership is false', async () => {
+      const preset = Destination.presets?.find((p) => p.name === 'Journey Step All Events')
+      if (!preset) {
+        throw new Error('Expected to find preset')
+      }
+
+      nock(SEGMENT_MAPPING_URL)
+        .post(/.*/, (body) => body.action === 'delete')
+        .reply(200, SUCCESS_RESPONSE)
+
+      const event = createAudienceEvent(false, 'journey_step')
+
+      const responses = await testDestination.testAction(preset.partnerAction, {
+        auth,
+        event,
+        settings: {},
+        mapping: preset.mapping,
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+
+      const requestBody = JSON.parse(responses[0].options.body as string)
+      expect(requestBody.action).toBe('delete')
+      expect(requestBody.advertiser_ids).toEqual([ADVERTISER_ID])
+      expect(requestBody.batch_data).toEqual([
+        [
+          { id: HASHED_EMAIL, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_PHONE, audience_ids: [EXTERNAL_AUDIENCE_ID] },
+          { id: HASHED_ADVERTISING_ID, audience_ids: [EXTERNAL_AUDIENCE_ID] }
+        ]
+      ])
     })
   })
 })

--- a/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/yahoo-audiences/updateSegment/__tests__/index.test.ts
@@ -86,6 +86,50 @@ describe('YahooAudiences.updateSegment', () => {
       expect(responses.length).toBe(1)
       expect(responses[0].status).toBe(200)
     })
+
+    it('should not throw an error if event includes email / maid when computation_class is journey_step', async () => {
+      nock(`https://dataxonline.yahoo.com`).post('/online/audience/').reply(200)
+
+      const good_event = createTestEvent({
+        type: 'identify',
+        context: {
+          device: {
+            advertisingId: ADVERTISING_ID
+          },
+          personas: {
+            audience_settings: {
+              audience_id: AUDIENCE_ID,
+              audience_key: AUDIENCE_KEY
+            },
+            computation_id: AUDIENCE_ID,
+            computation_key: AUDIENCE_KEY,
+            computation_class: 'journey_step'
+          }
+        },
+        traits: {
+          email: 'testing@testing.com',
+          sneakers_buyers: true
+        }
+      })
+
+      const responses = await testDestination.testAction('updateSegment', {
+        auth,
+        event: good_event,
+        mapping: {
+          identifier: 'email_maid'
+        },
+        useDefaultMappings: true,
+        settings: {
+          engage_space_id: ENGAGE_SPACE_ID,
+          mdm_id: MDM_ID,
+          customer_desc: CUST_DESC
+        }
+      })
+
+      // Then
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(200)
+    })
   })
 
   describe('Failure cases', () => {


### PR DESCRIPTION
This PR adds Journeys specific unit tests for Tier 1/2 audience destinations.

## Testing

Testing not required, adding unit tests.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
