### PR TITLE
STRATCONN-4121 - [Customerio] - Support ISO timestamps with >3 fractional second digits

### DIFF
--- a/packages/destination-actions/src/destinations/customerio/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/customerio/__tests__/utils.test.ts
@@ -85,3 +85,25 @@ describe('convertValidTimestamp', () => {
     expect(convertValidTimestamp('1712345678.123')).toBe('1712345678.123')
   })
 })
+
+describe('convertAttributeTimestamps — fractional second variants', () => {
+  it('converts a 7-digit fractional second ISO timestamp to unix', () => {
+    const result = convertAttributeTimestamps({ createdat: '2024-08-14T20:36:48.6527521Z' })
+    expect(result.createdat).toBe(1723667808)
+  })
+
+  it('converts a 9-digit fractional second ISO timestamp to unix', () => {
+    const result = convertAttributeTimestamps({ createdat: '2024-08-14T20:36:48.652752100Z' })
+    expect(result.createdat).toBe(1723667808)
+  })
+
+  it('does not regress on 3-digit millisecond timestamps', () => {
+    const result = convertAttributeTimestamps({ createdat: '2024-08-14T20:36:48.652Z' })
+    expect(result.createdat).toBe(1723667808)
+  })
+
+  it('does not convert non-date strings', () => {
+    const result = convertAttributeTimestamps({ name: 'hello' })
+    expect(result.name).toBe('hello')
+  })
+})

--- a/packages/destination-actions/src/destinations/customerio/utils.ts
+++ b/packages/destination-actions/src/destinations/customerio/utils.ts
@@ -37,6 +37,12 @@ export enum AccountRegion {
   EU = 'EU 🇪🇺'
 }
 
+// Normalize ISO timestamp fractional seconds to 3 digits so dayjs parses reliably.
+// dayjs only handles millisecond precision; sub-millisecond digits cause silent
+// misparse. Unix timestamps are second-level anyway so no precision is lost.
+const normalizeIsoFractionalSeconds = (value: string): string =>
+  value.replace(/(\.\d{3})\d+(Z|[+-]\d{2}:?\d{2}|$)/, '$1$2')
+
 export const convertValidTimestamp = <Value = unknown>(value: Value): Value | number => {
   // Timestamps may be on a `string` field, so check if the string is only
   // digits (optionally with a fractional part). If it is, ignore it since
@@ -47,7 +53,7 @@ export const convertValidTimestamp = <Value = unknown>(value: Value): Value | nu
     return value
   }
 
-  const maybeDate = dayjs.utc(value)
+  const maybeDate = dayjs.utc(normalizeIsoFractionalSeconds(value))
 
   if (maybeDate.isValid()) {
     return maybeDate.unix()
@@ -67,10 +73,8 @@ export const convertAttributeTimestamps = <Payload extends {}>(payload: Payload)
 
     if (typeof value === 'string') {
       // Parse only ISO 8601 date formats in strict mode
-      const maybeDate = dayjs(value)
-
       if (isIsoDate(value)) {
-        ;(clone[key] as unknown) = maybeDate.unix()
+        ;(clone[key] as unknown) = dayjs(normalizeIsoFractionalSeconds(value)).unix()
         return
       }
     }


### PR DESCRIPTION
## Problem

The `convertAttributeTimestamps` and `convertValidTimestamp` functions pass ISO timestamp strings directly to `dayjs` for parsing. dayjs only reliably handles up to 3 fractional second digits (milliseconds). Timestamps with 7+ fractional digits (e.g. `2024-08-14T20:36:48.6527521Z`) are silently not converted to Unix format, causing the raw string to be sent downstream instead of the expected integer.

Reported via STRATCONN-4121 by a Twilio partner customer.

## Fix

Add `normalizeIsoFractionalSeconds()` — a one-liner that trims fractional seconds to 3 digits before passing to dayjs. Applied in both conversion functions. No precision is lost since Unix timestamps are second-level.

## Tests

Added test cases covering:
- 7-digit fractional seconds (the reported case)
- 9-digit fractional seconds (nanoseconds)
- 3-digit regression (existing behavior preserved)
- Non-date string passthrough (no regression)