### PR TITLE
[GEC] Upgrade Canary to V22

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
@@ -1,7 +1,13 @@
-import { createTestIntegration, DynamicFieldResponse } from '@segment/actions-core'
+import { createTestIntegration } from '@segment/actions-core'
 import { Features } from '@segment/actions-core/mapping-kit'
 import nock from 'nock'
-import { CANARY_API_VERSION, formatToE164, commonEmailValidation, convertTimestamp, timestampToEpochMicroseconds } from '../functions'
+import {
+  CANARY_API_VERSION,
+  formatToE164,
+  commonEmailValidation,
+  convertTimestamp,
+  timestampToEpochMicroseconds
+} from '../functions'
 import destination from '../index'
 
 const testDestination = createTestIntegration(destination)
@@ -17,11 +23,11 @@ describe('.getConversionActionId', () => {
       customerId: '12345678'
     }
     const payload = {}
-    const responses = (await testDestination.testDynamicField('uploadClickConversion', 'conversion_action', {
+    const responses = await testDestination.testDynamicField('uploadClickConversion', 'conversion_action', {
       settings,
       payload,
       auth
-    })) as DynamicFieldResponse
+    })
 
     expect(responses.choices.length).toBeGreaterThanOrEqual(0)
   })
@@ -33,11 +39,11 @@ describe('.getConversionActionId', () => {
       customerId: '12345678'
     }
     const payload = {}
-    const responses = (await testDestination.testDynamicField('uploadCallConversion', 'conversion_action', {
+    const responses = await testDestination.testDynamicField('uploadCallConversion', 'conversion_action', {
       settings,
       payload,
       auth
-    })) as DynamicFieldResponse
+    })
 
     expect(responses.choices.length).toBeGreaterThanOrEqual(0)
   })
@@ -49,11 +55,11 @@ describe('.getConversionActionId', () => {
       customerId: '12345678'
     }
     const payload = {}
-    const responses = (await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
+    const responses = await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
       settings,
       payload,
       auth
-    })) as DynamicFieldResponse
+    })
 
     expect(responses.choices.length).toBeGreaterThanOrEqual(0)
   })
@@ -97,12 +103,12 @@ describe('.getConversionActionId', () => {
       ])
 
     const payload = {}
-    const responses = (await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
+    const responses = await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
       settings,
       payload,
       auth,
       features
-    })) as DynamicFieldResponse
+    })
 
     expect(responses.choices.length).toBe(3)
     expect(responses.choices).toStrictEqual([
@@ -125,16 +131,16 @@ describe('.getConversionActionId', () => {
       }
     }
     nock(`https://googleads.googleapis.com`)
-      .post(`/v21/customers/${settings.customerId}/googleAds:searchStream`)
+      .post(`/v22/customers/${settings.customerId}/googleAds:searchStream`)
       .reply(401, errorResponse)
 
     const payload = {}
-    const responses = (await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
+    const responses = await testDestination.testDynamicField('uploadConversionAdjustment', 'conversion_action', {
       settings,
       payload,
       auth,
       features
-    })) as DynamicFieldResponse
+    })
 
     expect(responses.choices.length).toBe(0)
     expect(responses.error?.message).toEqual(errorResponse.response.statusText)
@@ -206,4 +212,3 @@ describe('timestampToEpochMicroseconds', () => {
     expect(result).toEqual(undefined)
   })
 })
-

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
@@ -3,7 +3,7 @@
  * API reference: https://developers.google.com/google-ads/api/docs/upgrade
  */
 export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v21'
-export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v21'
+export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v22'
 
 /** GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION
  * Google Ads event API version.


### PR DESCRIPTION
This PR upgrades GEC API Version in canary from V21 to V22.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
