### PR TITLE
[GEC] Upgrade Base API Version to V22

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/metadata.json
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/metadata.json
@@ -1466,7 +1466,7 @@
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
-          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -1503,7 +1503,7 @@
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
-          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -1775,7 +1775,7 @@
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
-          "description": "This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -1812,7 +1812,7 @@
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
-          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -4109,7 +4109,7 @@
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
-          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -4146,7 +4146,7 @@
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
-          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -4428,7 +4428,7 @@
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
-          "description": "This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -4465,7 +4465,7 @@
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
-          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": false,
           "multiple": false,
@@ -5046,7 +5046,7 @@
         },
         "ad_user_data_consent_state": {
           "label": "Ad User Data Consent State",
-          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": true,
           "multiple": false,
@@ -5083,7 +5083,7 @@
         },
         "ad_personalization_consent_state": {
           "label": "Ad Personalization Consent State",
-          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).",
+          "description": "This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).",
           "type": "string",
           "required": true,
           "multiple": false,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/generated-types.ts
@@ -32,11 +32,11 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_user_data_consent_state?: string
   /**
-   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_personalization_consent_state?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion/index.ts
@@ -76,7 +76,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Ad Personalization Consent State',
       type: 'string',
       description:
-        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
         { label: 'DENIED', value: 'DENIED' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/generated-types.ts
@@ -32,11 +32,11 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_user_data_consent_state?: string
   /**
-   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_personalization_consent_state?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadCallConversion2/index.ts
@@ -88,7 +88,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad user data. For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -100,7 +100,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Ad Personalization Consent State',
       type: 'string',
       description:
-        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
         { label: 'DENIED', value: 'DENIED' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/generated-types.ts
@@ -126,11 +126,11 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_user_data_consent_state?: string
   /**
-   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_personalization_consent_state?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -102,7 +102,7 @@ const action: ActionDefinition<Settings, Payload> = {
         session_start_time_usec: {
           label: 'Session Start Time',
           description:
-            "The timestamp of when the user's session began on your website. This helps track the duration of user visits. The format should be a full ISO 8601 string. For example \"2025-11-18T08:52:17.023Z\".",
+            'The timestamp of when the user\'s session began on your website. This helps track the duration of user visits. The format should be a full ISO 8601 string. For example "2025-11-18T08:52:17.023Z".',
           type: 'string',
           format: 'date-time'
         },
@@ -293,7 +293,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -305,7 +305,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Ad Personalization Consent State',
       type: 'string',
       description:
-        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
         { label: 'DENIED', value: 'DENIED' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/generated-types.ts
@@ -126,11 +126,11 @@ export interface Payload {
     [k: string]: unknown
   }
   /**
-   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_user_data_consent_state?: string
   /**
-   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_personalization_consent_state?: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -300,7 +300,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -312,7 +312,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Ad Personalization Consent State',
       type: 'string',
       description:
-        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
         { label: 'DENIED', value: 'DENIED' },

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/generated-types.ts
@@ -38,11 +38,11 @@ export interface Payload {
    */
   mobile_advertising_id?: string
   /**
-   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_user_data_consent_state: string
   /**
-   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).
+   * This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).
    */
   ad_personalization_consent_state: string
   /**

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -110,7 +110,7 @@ const action: ActionDefinition<Settings, Payload> = {
     ad_user_data_consent_state: {
       label: 'Ad User Data Consent State',
       description:
-        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad user data.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       type: 'string',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
@@ -123,7 +123,7 @@ const action: ActionDefinition<Settings, Payload> = {
       label: 'Ad Personalization Consent State',
       type: 'string',
       description:
-        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v21/Consent).',
+        'This represents consent for ad personalization. This can only be set for OfflineUserDataJobService and UserDataService.For more information on consent, refer to [Google Ads API Consent](https://developers.google.com/google-ads/api/rest/reference/rest/v22/Consent).',
       choices: [
         { label: 'GRANTED', value: 'GRANTED' },
         { label: 'DENIED', value: 'DENIED' },
@@ -303,7 +303,10 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     }
   },
-  perform: async (request, { settings, audienceSettings, payload, hookOutputs, statsContext, syncMode, features, audienceMembership }) => {
+  perform: async (
+    request,
+    { settings, audienceSettings, payload, hookOutputs, statsContext, syncMode, features, audienceMembership }
+  ) => {
     settings.customerId = verifyCustomerId(settings.customerId)
 
     return await handleUpdate(

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
@@ -2,7 +2,7 @@
  * Google Ads API version for enhanced conversions.
  * API reference: https://developers.google.com/google-ads/api/docs/upgrade
  */
-export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v21'
+export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v22'
 export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v22'
 
 /** GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION


### PR DESCRIPTION
This is a followup PR to https://github.com/segmentio/action-destinations/pull/3924
It upgrades the base version to V22.

## Testing

Testes locally and on prod with Canary.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
