### PR TITLE
STRATCONN-6937 [Braze] Fix ecommerce batch error index mismatch and sent/body population

### DIFF
--- a/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
@@ -978,6 +978,8 @@ describe('Braze.ecommerce', () => {
 
       // e1 filtered => events sent to Braze are [e2, e3] at sent-array indices 0 and 1.
       // Braze reports an error for sent-array index 1, which is e3 (original index 2).
+      // e3's JSON is valid; we're faking a failed Braze response for that item purely to
+      // verify the error is attributed back to the correct original payload.
       let sentJson: any
       nock(settings.endpoint)
         .post('/users/track', (body) => {

--- a/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerce/__tests__/index.test.ts
@@ -925,268 +925,24 @@ describe('Braze.ecommerce', () => {
       const responseJSON = [
         {
           status: 200,
-          sent: {
-            name: 'ecommerce.order_refunded',
-            external_id: 'userId1',
-            user_alias: {
-              alias_name: 'alias_name_1',
-              alias_label: 'alias_label_1'
-            },
-            email: 'email@email.com',
-            phone: '+14155551234',
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            time: '2024-06-10T12:00:00.000Z',
-            checkout_id: 'checkout_id_1',
-            order_id: 'order_id_1',
-            cart_id: 'cart_id_1',
-            total_value: 100,
-            total_discounts: 10,
-            discounts: [
-              {
-                code: 'SUMMER21',
-                amount: 5
-              },
-              {
-                code: 'VIPCUSTOMER',
-                amount: 5
-              }
-            ],
-            currency: 'USD',
-            source: 'test_source',
-            products: [
-              {
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                variant_id: 'Size M',
-                image_url: 'https://example.com/prod1.jpg',
-                quantity: 2,
-                price: 25,
-                color: 'red',
-                size: 'M'
-              },
-              {
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                variant_id: 'Size L',
-                image_url: 'https://example.com/prod2.jpg',
-                quantity: 1,
-                price: 50
-              }
-            ],
-            metadata: {
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: {
-                nested_key: 'nested_value'
-              },
-              checkout_url: 'https://example.com/checkout',
-              order_status_url: 'https://example.com/order/status'
-            },
-            enable_batching: true,
-            batch_size: 75,
-            index: 0
-          },
-          body: '{"external_id":"userId1","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.order_refunded","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"order_id":"order_id_1","total_discounts":10,"discounts":[{"code":"SUMMER21","amount":5},{"code":"VIPCUSTOMER","amount":5}]},"_update_existing_only":true}'
+          sent: json.events[0],
+          body: { success: true }
         },
         {
           status: 400,
           errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.',
-          sent: {
-            name: 'ecommerce.order_placed',
-            cancel_reason: "I didn't like it",
-            time: '2024-06-10T12:00:00.000Z',
-            checkout_id: 'checkout_id_1',
-            order_id: 'order_id_1',
-            cart_id: 'cart_id_1',
-            total_value: 100,
-            total_discounts: 10,
-            discounts: [
-              {
-                code: 'SUMMER21',
-                amount: 5
-              },
-              {
-                code: 'VIPCUSTOMER',
-                amount: 5
-              }
-            ],
-            currency: 'USD',
-            source: 'test_source',
-            products: [
-              {
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                variant_id: 'Size M',
-                image_url: 'https://example.com/prod1.jpg',
-                quantity: 2,
-                price: 25,
-                color: 'red',
-                size: 'M'
-              },
-              {
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                variant_id: 'Size L',
-                image_url: 'https://example.com/prod2.jpg',
-                quantity: 1,
-                price: 50
-              }
-            ],
-            metadata: {
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: {
-                nested_key: 'nested_value'
-              },
-              checkout_url: 'https://example.com/checkout',
-              order_status_url: 'https://example.com/order/status'
-            },
-            enable_batching: true,
-            batch_size: 75
-          },
           errortype: 'BAD_REQUEST',
-          errorreporter: 'DESTINATION'
+          errorreporter: 'INTEGRATIONS'
         },
         {
           status: 200,
-          sent: {
-            name: 'ecommerce.checkout_started',
-            external_id: 'userId3',
-            user_alias: {
-              alias_name: 'alias_name_1',
-              alias_label: 'alias_label_1'
-            },
-            email: 'email@email.com',
-            phone: '+14155551234',
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            time: '2024-06-10T12:00:00.000Z',
-            checkout_id: 'checkout_id_1',
-            order_id: 'order_id_1',
-            cart_id: 'cart_id_1',
-            total_value: 100,
-            total_discounts: 10,
-            discounts: [
-              {
-                code: 'SUMMER21',
-                amount: 5
-              },
-              {
-                code: 'VIPCUSTOMER',
-                amount: 5
-              }
-            ],
-            currency: 'USD',
-            source: 'test_source',
-            products: [
-              {
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                variant_id: 'Size M',
-                image_url: 'https://example.com/prod1.jpg',
-                quantity: 2,
-                price: 25,
-                color: 'red',
-                size: 'M'
-              },
-              {
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                variant_id: 'Size L',
-                image_url: 'https://example.com/prod2.jpg',
-                quantity: 1,
-                price: 50
-              }
-            ],
-            metadata: {
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: {
-                nested_key: 'nested_value'
-              },
-              checkout_url: 'https://example.com/checkout',
-              order_status_url: 'https://example.com/order/status'
-            },
-            enable_batching: true,
-            batch_size: 75,
-            index: 1
-          },
-          body: '{"external_id":"userId3","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.checkout_started","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"checkout_id":"checkout_id_1","cart_id":"cart_id_1"},"_update_existing_only":true}'
+          sent: json.events[1],
+          body: { success: true }
         },
         {
           status: 200,
-          sent: {
-            name: 'ecommerce.order_cancelled',
-            external_id: 'userId4',
-            user_alias: {
-              alias_name: 'alias_name_1',
-              alias_label: 'alias_label_1'
-            },
-            email: 'email@email.com',
-            phone: '+14155551234',
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            time: '2024-06-10T12:00:00.000Z',
-            checkout_id: 'checkout_id_1',
-            order_id: 'order_id_1',
-            cart_id: 'cart_id_1',
-            total_value: 100,
-            total_discounts: 10,
-            discounts: [
-              {
-                code: 'SUMMER21',
-                amount: 5
-              },
-              {
-                code: 'VIPCUSTOMER',
-                amount: 5
-              }
-            ],
-            currency: 'USD',
-            source: 'test_source',
-            products: [
-              {
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                variant_id: 'Size M',
-                image_url: 'https://example.com/prod1.jpg',
-                quantity: 2,
-                price: 25,
-                color: 'red',
-                size: 'M'
-              },
-              {
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                variant_id: 'Size L',
-                image_url: 'https://example.com/prod2.jpg',
-                quantity: 1,
-                price: 50
-              }
-            ],
-            metadata: {
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: {
-                nested_key: 'nested_value'
-              },
-              checkout_url: 'https://example.com/checkout',
-              order_status_url: 'https://example.com/order/status'
-            },
-            enable_batching: true,
-            batch_size: 75,
-            index: 2
-          },
-          body: '{"external_id":"userId4","braze_id":"braze_id_1","email":"email@email.com","phone":"+14155551234","user_alias":{"alias_name":"alias_name_1","alias_label":"alias_label_1"},"app_id":"test_app_id","name":"ecommerce.order_cancelled","time":"2024-06-10T12:00:00.000Z","properties":{"currency":"USD","source":"test_source","metadata":{"custom_field_1":"custom_value_1","custom_field_2":100,"custom_field_3":true,"custom_field_4":["a","b","c"],"custom_field_5":{"nested_key":"nested_value"},"checkout_url":"https://example.com/checkout","order_status_url":"https://example.com/order/status"},"products":[{"quantity":2,"product_id":"prod_1","product_name":"Product 1","variant_id":"Size M","price":25,"image_url":"https://example.com/prod1.jpg","metadata":{"color":"red","size":"M"}},{"quantity":1,"product_id":"prod_2","product_name":"Product 2","variant_id":"Size L","price":50,"image_url":"https://example.com/prod2.jpg"}],"total_value":100,"order_id":"order_id_1","cancel_reason":"I didn\'t like it","total_discounts":10,"discounts":[{"code":"SUMMER21","amount":5},{"code":"VIPCUSTOMER","amount":5}]},"_update_existing_only":true}'
+          sent: json.events[2],
+          body: { success: true }
         }
       ]
 
@@ -1199,6 +955,96 @@ describe('Braze.ecommerce', () => {
       })
 
       expect(response).toEqual(responseJSON)
+    })
+
+    it('should attribute Braze errors to the correct payload when an earlier payload is filtered by validate()', async () => {
+      const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      const deepCopy3: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+
+      // e1 is missing all identifiers, so validate() filters it out of the events array sent to Braze.
+      const e1 = createTestEvent({ ...deepCopy1, event: 'ecommerce.order_refunded' })
+      e1.userId = undefined
+      delete e1.properties?.email
+      delete e1.properties?.phone
+      delete e1.properties?.braze_id
+      delete e1.anonymousId
+      delete e1.properties?.user_alias
+
+      const e2 = createTestEvent({ ...deepCopy2, userId: 'userId2', event: 'ecommerce.checkout_started' })
+      const e3 = createTestEvent({ ...deepCopy3, userId: 'userId3', event: 'ecommerce.order_cancelled' })
+
+      const events = [e1, e2, e3]
+
+      // e1 filtered => events sent to Braze are [e2, e3] at sent-array indices 0 and 1.
+      // Braze reports an error for sent-array index 1, which is e3 (original index 2).
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200, { errors: [{ index: 1, type: 'a valid identifier is required' }] })
+
+      const response = await testDestination.executeBatch('ecommerce', {
+        events,
+        settings,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'update', name: { '@path': '$.event' } }
+      })
+
+      expect(response[0]).toEqual({
+        status: 400,
+        errortype: 'BAD_REQUEST',
+        errorreporter: 'INTEGRATIONS',
+        errormessage: 'One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.'
+      })
+      expect(response[1]).toEqual({
+        status: 200,
+        sent: sentJson.events[0],
+        body: { success: true }
+      })
+      expect(response[2]).toEqual({
+        status: 400,
+        errortype: 'BAD_REQUEST',
+        errorreporter: 'DESTINATION',
+        errormessage: 'a valid identifier is required',
+        sent: sentJson.events[1],
+        body: 'a valid identifier is required'
+      })
+    })
+
+    it('should populate sent and body correctly for a fully successful batch', async () => {
+      const deepCopy1: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+      const deepCopy2: Partial<SegmentEvent> = JSON.parse(JSON.stringify(payload))
+
+      const e1 = createTestEvent({ ...deepCopy1, userId: 'userId1', event: 'ecommerce.order_placed' })
+      const e2 = createTestEvent({ ...deepCopy2, userId: 'userId2', event: 'ecommerce.checkout_started' })
+      const events = [e1, e2]
+
+      let sentJson: any
+      nock(settings.endpoint)
+        .post('/users/track', (body) => {
+          sentJson = body
+          return true
+        })
+        .reply(200)
+
+      const response = await testDestination.executeBatch('ecommerce', {
+        events,
+        settings,
+        mapping: { ...mapping, __segment_internal_sync_mode: 'add', name: { '@path': '$.event' } }
+      })
+
+      expect(response[0]).toEqual({
+        status: 200,
+        sent: sentJson.events[0],
+        body: { success: true }
+      })
+      expect(response[1]).toEqual({
+        status: 200,
+        sent: sentJson.events[1],
+        body: { success: true }
+      })
     })
 
     it('should return correct multistatus response if there no SyncMode', async () => {
@@ -1381,244 +1227,14 @@ describe('Braze.ecommerce', () => {
         name: { '@path': '$.event' }
       }
 
-      const responseJSON = [
-        {
-          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          errorreporter: 'DESTINATION',
-          errortype: 'BAD_REQUEST',
-          sent: {
-            batch_size: 75,
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            cart_id: 'cart_id_1',
-            checkout_id: 'checkout_id_1',
-            currency: 'USD',
-            discounts: [
-              { amount: 5, code: 'SUMMER21' },
-              { amount: 5, code: 'VIPCUSTOMER' }
-            ],
-            email: 'email@email.com',
-            enable_batching: true,
-            external_id: 'userId1',
-            metadata: {
-              checkout_url: 'https://example.com/checkout',
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: { nested_key: 'nested_value' },
-              order_status_url: 'https://example.com/order/status'
-            },
-            name: 'ecommerce.order_refunded',
-            order_id: 'order_id_1',
-            phone: '+14155551234',
-            products: [
-              {
-                color: 'red',
-                image_url: 'https://example.com/prod1.jpg',
-                price: 25,
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                quantity: 2,
-                size: 'M',
-                variant_id: 'Size M'
-              },
-              {
-                image_url: 'https://example.com/prod2.jpg',
-                price: 50,
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                quantity: 1,
-                variant_id: 'Size L'
-              }
-            ],
-            source: 'test_source',
-            time: '2024-06-10T12:00:00.000Z',
-            total_discounts: 10,
-            total_value: 100,
-            user_alias: {
-              alias_label: 'alias_label_1',
-              alias_name: 'alias_name_1'
-            }
-          },
-          status: 400
-        },
-        {
-          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          errorreporter: 'DESTINATION',
-          errortype: 'BAD_REQUEST',
-          sent: {
-            batch_size: 75,
-            cancel_reason: "I didn't like it",
-            cart_id: 'cart_id_1',
-            checkout_id: 'checkout_id_1',
-            currency: 'USD',
-            discounts: [
-              { amount: 5, code: 'SUMMER21' },
-              { amount: 5, code: 'VIPCUSTOMER' }
-            ],
-            enable_batching: true,
-            metadata: {
-              checkout_url: 'https://example.com/checkout',
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: { nested_key: 'nested_value' },
-              order_status_url: 'https://example.com/order/status'
-            },
-            name: 'ecommerce.order_placed',
-            order_id: 'order_id_1',
-            products: [
-              {
-                color: 'red',
-                image_url: 'https://example.com/prod1.jpg',
-                price: 25,
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                quantity: 2,
-                size: 'M',
-                variant_id: 'Size M'
-              },
-              {
-                image_url: 'https://example.com/prod2.jpg',
-                price: 50,
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                quantity: 1,
-                variant_id: 'Size L'
-              }
-            ],
-            source: 'test_source',
-            time: '2024-06-10T12:00:00.000Z',
-            total_discounts: 10,
-            total_value: 100
-          },
-          status: 400
-        },
-        {
-          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          errorreporter: 'DESTINATION',
-          errortype: 'BAD_REQUEST',
-          sent: {
-            batch_size: 75,
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            cart_id: 'cart_id_1',
-            checkout_id: 'checkout_id_1',
-            currency: 'USD',
-            discounts: [
-              { amount: 5, code: 'SUMMER21' },
-              { amount: 5, code: 'VIPCUSTOMER' }
-            ],
-            email: 'email@email.com',
-            enable_batching: true,
-            external_id: 'userId3',
-            metadata: {
-              checkout_url: 'https://example.com/checkout',
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: { nested_key: 'nested_value' },
-              order_status_url: 'https://example.com/order/status'
-            },
-            name: 'ecommerce.checkout_started',
-            order_id: 'order_id_1',
-            phone: '+14155551234',
-            products: [
-              {
-                color: 'red',
-                image_url: 'https://example.com/prod1.jpg',
-                price: 25,
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                quantity: 2,
-                size: 'M',
-                variant_id: 'Size M'
-              },
-              {
-                image_url: 'https://example.com/prod2.jpg',
-                price: 50,
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                quantity: 1,
-                variant_id: 'Size L'
-              }
-            ],
-            source: 'test_source',
-            time: '2024-06-10T12:00:00.000Z',
-            total_discounts: 10,
-            total_value: 100,
-            user_alias: {
-              alias_label: 'alias_label_1',
-              alias_name: 'alias_name_1'
-            }
-          },
-          status: 400
-        },
-        {
-          errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
-          errorreporter: 'DESTINATION',
-          errortype: 'BAD_REQUEST',
-          sent: {
-            batch_size: 75,
-            braze_id: 'braze_id_1',
-            cancel_reason: "I didn't like it",
-            cart_id: 'cart_id_1',
-            checkout_id: 'checkout_id_1',
-            currency: 'USD',
-            discounts: [
-              { amount: 5, code: 'SUMMER21' },
-              { amount: 5, code: 'VIPCUSTOMER' }
-            ],
-            email: 'email@email.com',
-            enable_batching: true,
-            external_id: 'userId4',
-            metadata: {
-              checkout_url: 'https://example.com/checkout',
-              custom_field_1: 'custom_value_1',
-              custom_field_2: 100,
-              custom_field_3: true,
-              custom_field_4: ['a', 'b', 'c'],
-              custom_field_5: { nested_key: 'nested_value' },
-              order_status_url: 'https://example.com/order/status'
-            },
-            name: 'ecommerce.order_cancelled',
-            order_id: 'order_id_1',
-            phone: '+14155551234',
-            products: [
-              {
-                color: 'red',
-                image_url: 'https://example.com/prod1.jpg',
-                price: 25,
-                product_id: 'prod_1',
-                product_name: 'Product 1',
-                quantity: 2,
-                size: 'M',
-                variant_id: 'Size M'
-              },
-              {
-                image_url: 'https://example.com/prod2.jpg',
-                price: 50,
-                product_id: 'prod_2',
-                product_name: 'Product 2',
-                quantity: 1,
-                variant_id: 'Size L'
-              }
-            ],
-            source: 'test_source',
-            time: '2024-06-10T12:00:00.000Z',
-            total_discounts: 10,
-            total_value: 100,
-            user_alias: {
-              alias_label: 'alias_label_1',
-              alias_name: 'alias_name_1'
-            }
-          },
-          status: 400
-        }
-      ]
+      const invalidSyncModeError = {
+        status: 400,
+        errormessage: "Invalid syncMode: undefined. Supported sync modes are 'add' and 'update'.",
+        errortype: 'BAD_REQUEST',
+        errorreporter: 'INTEGRATIONS'
+      }
+
+      const responseJSON = [invalidSyncModeError, invalidSyncModeError, invalidSyncModeError, invalidSyncModeError]
 
       nock(settings.endpoint).post('/users/track', json).reply(200)
 

--- a/packages/destination-actions/src/destinations/braze/ecommerce/functions.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerce/functions.ts
@@ -2,20 +2,15 @@ import { Payload } from './generated-types'
 import { Payload as SingleProductPayload } from '../ecommerceSingleProduct/generated-types'
 import { Settings } from '../generated-types'
 import { BrazeTrackUserAPIResponse } from '../utils'
-import { 
-  JSONLikeObject,
-  RequestClient, 
-  PayloadValidationError, 
-  MultiStatusResponse 
-} from '@segment/actions-core'
+import { JSONLikeObject, RequestClient, PayloadValidationError, MultiStatusResponse } from '@segment/actions-core'
 import { SyncMode } from '@segment/actions-core/destination-kit/types'
-import type { 
+import type {
   SupportedSyncMode,
-  BaseEvent, 
-  EcommerceEvents, 
-  EcommerceEvent, 
-  MultiPropertyEventName, 
-  ProductViewedEventName, 
+  BaseEvent,
+  EcommerceEvents,
+  EcommerceEvent,
+  MultiPropertyEventName,
+  ProductViewedEventName,
   ProductViewedEvent,
   MultiProductBaseEvent,
   //CartUpdatedEvent,
@@ -23,29 +18,33 @@ import type {
   OrderPlacedEvent,
   OrderRefundedEvent,
   OrderCancelledEvent,
-  PayloadWithIndex, 
+  PayloadWithIndex,
   Product
 } from './types'
 import { EVENT_NAMES } from './constants'
 import dayjs from 'dayjs'
 
-export async function send(request: RequestClient, payloads: (Payload | SingleProductPayload)[], settings: Settings, isBatch: boolean, syncMode?: SyncMode) {
+export async function send(
+  request: RequestClient,
+  payloads: (Payload | SingleProductPayload)[],
+  settings: Settings,
+  isBatch: boolean,
+  syncMode?: SyncMode
+) {
   const msResponse = new MultiStatusResponse()
 
-  if(!['update', 'add'].includes(syncMode ?? '')) {
-    const message = `Invalid syncMode: ${syncMode}. Supported sync modes are 'add' and 'update'.`
-    if(isBatch){
-      payloads.forEach((payload, index) => {
+  if (!['update', 'add'].includes(syncMode ?? '')) {
+    const errormessage = `Invalid syncMode: ${syncMode}. Supported sync modes are 'add' and 'update'.`
+    if (isBatch) {
+      payloads.forEach((_, index) => {
         msResponse.setErrorResponseAtIndex(index, {
           status: 400,
-          errormessage: message,
-          sent: payload as object as JSONLikeObject
+          errormessage
         })
       })
       return msResponse
-    } 
-    else {
-      throw new PayloadValidationError(message)
+    } else {
+      throw new PayloadValidationError(errormessage)
     }
   }
 
@@ -55,54 +54,58 @@ export async function send(request: RequestClient, payloads: (Payload | SinglePr
 
   const response = await request<BrazeTrackUserAPIResponse>(url, {
     method: 'POST',
-     ...(isBatch ? { headers: { 'X-Braze-Batch': 'true' } } : undefined),
+    ...(isBatch ? { headers: { 'X-Braze-Batch': 'true' } } : undefined),
     json
   })
 
   const errors = Array.isArray(response.data.errors) ? response.data.errors : []
 
   payloadsWithIndexes.forEach((payload, index) => {
-    
-    const error = errors.find(e => e.index === index)
+    const sentIndex = payload.index
+    if (sentIndex === undefined) {
+      return
+    }
 
-    if(error){
+    const error = errors.find((e) => e.index === sentIndex)
+
+    if (error) {
       msResponse.setErrorResponseAtIndex(index, {
         status: 400,
         errortype: 'BAD_REQUEST',
         errormessage: error.type,
-        sent: payload as object as JSONLikeObject,
-        body: JSON.stringify(json.events[index])
+        sent: json.events[sentIndex] as object as JSONLikeObject,
+        body: error.type
       })
     }
   })
-  return isBatch ? msResponse : response 
+  return isBatch ? msResponse : response
 }
 
-function getJSON(payloads: (Payload | SingleProductPayload)[], settings: Settings, isBatch: boolean, syncMode: SupportedSyncMode, msResponse: MultiStatusResponse): { json: EcommerceEvents, payloadsWithIndexes: PayloadWithIndex[] } {  
-  const payloadsWithIndexes: PayloadWithIndex[] = [ ...payloads ]
+function getJSON(
+  payloads: (Payload | SingleProductPayload)[],
+  settings: Settings,
+  isBatch: boolean,
+  syncMode: SupportedSyncMode,
+  msResponse: MultiStatusResponse
+): { json: EcommerceEvents; payloadsWithIndexes: PayloadWithIndex[] } {
+  const payloadsWithIndexes: PayloadWithIndex[] = [...payloads]
   const events: EcommerceEvent[] = []
   payloadsWithIndexes.forEach((payload, index) => {
-    const message = validate(payload, isBatch)  
-    if(message) {
+    const message = validate(payload, isBatch)
+    if (message) {
       payload.index = undefined
-      msResponse.setErrorResponseAtIndex(
-        index, 
-        { 
-          status: 400,
-          errormessage: message,
-          sent: payload as object as JSONLikeObject
-        }
-      )
-    } 
-    else {  
-      // assume valid payload - we'll overwrite later if Braze responds with an error for this index
+      msResponse.setErrorResponseAtIndex(index, {
+        status: 400,
+        errormessage: message
+      })
+    } else {
       const event = getJSONItem(payload, settings, syncMode)
       payload.index = events.length
       events.push(event)
       msResponse.setSuccessResponseAtIndex(index, {
         status: 200,
-        sent: payload as object as JSONLikeObject,
-        body: JSON.stringify(event)
+        sent: event as object as JSONLikeObject,
+        body: { success: true }
       })
     }
   })
@@ -110,11 +113,14 @@ function getJSON(payloads: (Payload | SingleProductPayload)[], settings: Setting
   return { json: { events }, payloadsWithIndexes }
 }
 
-function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings, syncMode: SupportedSyncMode): EcommerceEvent {
-    
+function getJSONItem(
+  payload: Payload | SingleProductPayload,
+  settings: Settings,
+  syncMode: SupportedSyncMode
+): EcommerceEvent {
   const { app_id } = settings
 
-  const { 
+  const {
     external_id,
     braze_id,
     email,
@@ -130,37 +136,35 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
   const time = dayjs(payloadTime).toISOString()
 
   const updateExistingOnly = (() => {
-    if ( user_alias?.alias_label && user_alias?.alias_name ) { 
-      return true 
+    if (user_alias?.alias_label && user_alias?.alias_name) {
+      return true
     }
-    if ( syncMode === 'update' ) { 
+    if (syncMode === 'update') {
       return true
     }
     return undefined
   })()
 
   const baseEvent: BaseEvent = {
-    ...(external_id? { external_id } : {} ),
-    ...(braze_id? { braze_id } : {} ),
-    ...(email? { email } : {} ),
-    ...(phone? { phone } : {} ),
-    ...(user_alias? { user_alias } : {} ),
-    ...(app_id ? { app_id } : {} ),
+    ...(external_id ? { external_id } : {}),
+    ...(braze_id ? { braze_id } : {}),
+    ...(email ? { email } : {}),
+    ...(phone ? { phone } : {}),
+    ...(user_alias ? { user_alias } : {}),
+    ...(app_id ? { app_id } : {}),
     name: name as ProductViewedEventName | MultiPropertyEventName,
     time,
     properties: {
       currency,
       source,
-        ...(metadata ? { metadata } : {})
+      ...(metadata ? { metadata } : {})
     },
-    ...(typeof updateExistingOnly === 'boolean' ? { _update_existing_only: updateExistingOnly } : {} )
+    ...(typeof updateExistingOnly === 'boolean' ? { _update_existing_only: updateExistingOnly } : {})
   }
 
-  switch(name) {
+  switch (name) {
     case EVENT_NAMES.PRODUCT_VIEWED: {
-      const {
-        product
-      } = payload as SingleProductPayload
+      const { product } = payload as SingleProductPayload
 
       const event: ProductViewedEvent = {
         ...baseEvent,
@@ -171,27 +175,25 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
         }
       }
       return event
-    } 
+    }
     // case EVENT_NAMES.CART_UPDATED:
     case EVENT_NAMES.CHECKOUT_STARTED:
     case EVENT_NAMES.ORDER_PLACED:
     case EVENT_NAMES.ORDER_CANCELLED:
     case EVENT_NAMES.ORDER_REFUNDED: {
-      const {
-        total_value
-      } = payload as Payload
+      const { total_value } = payload as Payload
 
       const multiProductEvent: MultiProductBaseEvent = {
         ...baseEvent,
         name: name as MultiPropertyEventName,
         properties: {
           ...baseEvent.properties,
-          products: getProductAndMetadataJSON( payload as Payload ),
+          products: getProductAndMetadataJSON(payload as Payload),
           total_value: total_value as number
         }
       }
 
-      switch(name) {
+      switch (name) {
         // case EVENT_NAMES.CART_UPDATED: {
         //   const { cart_id } = payload
 
@@ -207,11 +209,8 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
         // }
 
         case EVENT_NAMES.CHECKOUT_STARTED: {
-          const { 
-            checkout_id, 
-            cart_id
-          } = payload
-          
+          const { checkout_id, cart_id } = payload
+
           const event: CheckoutStartedEvent = {
             ...multiProductEvent,
             name: EVENT_NAMES.CHECKOUT_STARTED,
@@ -225,13 +224,8 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
         }
 
         case EVENT_NAMES.ORDER_PLACED: {
-          const { 
-            order_id,
-            cart_id, 
-            total_discounts, 
-            discounts
-          } = payload
-          
+          const { order_id, cart_id, total_discounts, discounts } = payload
+
           const event: OrderPlacedEvent = {
             ...multiProductEvent,
             name: EVENT_NAMES.ORDER_PLACED,
@@ -247,12 +241,8 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
         }
 
         case EVENT_NAMES.ORDER_REFUNDED: {
-          const { 
-            order_id,
-            total_discounts, 
-            discounts
-          } = payload
-          
+          const { order_id, total_discounts, discounts } = payload
+
           const event: OrderRefundedEvent = {
             ...multiProductEvent,
             name: EVENT_NAMES.ORDER_REFUNDED,
@@ -267,13 +257,8 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
         }
 
         case EVENT_NAMES.ORDER_CANCELLED: {
-          const { 
-            order_id,
-            cancel_reason,
-            total_discounts, 
-            discounts
-          } = payload
-          
+          const { order_id, cancel_reason, total_discounts, discounts } = payload
+
           const event: OrderCancelledEvent = {
             ...multiProductEvent,
             name: EVENT_NAMES.ORDER_CANCELLED,
@@ -300,21 +285,12 @@ function getJSONItem(payload: Payload | SingleProductPayload, settings: Settings
 }
 
 function getProductAndMetadataJSON(payload: Payload): Product[] {
-  return payload.products.map(product => {
-    const {
-      quantity,
-      product_id,  
-      product_name,
-      variant_id,
-      price,
-      image_url,
-      product_url,
-      ...metadata
-    } = product
+  return payload.products.map((product) => {
+    const { quantity, product_id, product_name, variant_id, price, image_url, product_url, ...metadata } = product
 
     return {
       quantity,
-      product_id,  
+      product_id,
       product_name,
       variant_id,
       price,
@@ -324,15 +300,14 @@ function getProductAndMetadataJSON(payload: Payload): Product[] {
     }
   })
 }
-  
+
 function validate(payload: Payload | SingleProductPayload, isBatch: boolean): string | void {
   const { braze_id, user_alias, external_id, email, phone } = payload
   if (!braze_id && !user_alias && !external_id && !email && !phone) {
     const message = 'One of "external_id" or "user_alias" or "braze_id" or "email" or "phone" is required.'
-    if(!isBatch) {
-      throw new PayloadValidationError(message)    
-    } 
-    else {
+    if (!isBatch) {
+      throw new PayloadValidationError(message)
+    } else {
       return message
     }
   }
@@ -340,34 +315,278 @@ function validate(payload: Payload | SingleProductPayload, isBatch: boolean): st
 
 export function currencies() {
   const codes = [
-    "AFN","EUR","ALL","DZD","USD","EUR","AOA","XCD","XCD","XAD","ARS","AMD",
-    "AWG","AUD","EUR","AZN","BSD","BHD","BDT","BBD","BYN","EUR","BZD","XOF",
-    "BMD","INR","BTN","BOB","BOV","USD","BAM","BWP","NOK","BRL","USD","BND",
-    "BGN","XOF","BIF","CVE","KHR","XAF","CAD","KYD","XAF","XAF","CLP","CLF",
-    "CNY","AUD","AUD","COP","COU","KMF","CDF","XAF","NZD","CRC","XOF","EUR",
-    "CUP","XCG","EUR","CZK","DKK","DJF","XCD","DOP","USD","EGP","SVC","USD",
-    "XAF","ERN","EUR","SZL","ETB","EUR","FKP","DKK","FJD","EUR","EUR","EUR",
-    "XPF","EUR","XAF","GMD","GEL","EUR","GHS","GIP","EUR","DKK","XCD","EUR",
-    "USD","GTQ","GBP","GNF","XOF","GYD","HTG","USD","AUD","EUR","HNL","HKD",
-    "HUF","ISK","INR","IDR","XDR","IRR","IQD","EUR","GBP","ILS","EUR","JMD",
-    "JPY","GBP","JOD","KZT","KES","AUD","KPW","KRW","KWD","KGS","LAK","EUR",
-    "LBP","LSL","ZAR","LRD","LYD","CHF","EUR","EUR","MOP","MGA","MWK","MYR",
-    "MVR","XOF","EUR","USD","EUR","MRU","MUR","EUR","XUA","MXN","MXV","USD",
-    "MDL","EUR","MNT","EUR","XCD","MAD","MZN","MMK","NAD","ZAR","AUD","NPR",
-    "EUR","XPF","NZD","NIO","XOF","NGN","NZD","AUD","MKD","USD","NOK","OMR",
-    "PKR","USD","PAB","USD","PGK","PYG","PEN","PHP","NZD","PLN","EUR","USD",
-    "QAR","EUR","RON","RUB","RWF","EUR","SHP","XCD","XCD","EUR","EUR","XCD",
-    "WST","EUR","STN","SAR","XOF","RSD","SCR","SLE","SGD","XCG","XSU","EUR",
-    "EUR","SBD","SOS","ZAR","SSP","EUR","LKR","SDG","SRD","NOK","SEK","CHF",
-    "CHE","CHW","SYP","TWD","TJS","TZS","THB","USD","XOF","NZD","TOP","TTD",
-    "TND","TRY","TMT","USD","AUD","UGX","UAH","AED","GBP","USD","USD","USN",
-    "UYU","UYI","UYW","UZS","VUV","VES","VED","VND","USD","USD","XPF","MAD",
-    "YER","ZMW","ZWG"
+    'AFN',
+    'EUR',
+    'ALL',
+    'DZD',
+    'USD',
+    'EUR',
+    'AOA',
+    'XCD',
+    'XCD',
+    'XAD',
+    'ARS',
+    'AMD',
+    'AWG',
+    'AUD',
+    'EUR',
+    'AZN',
+    'BSD',
+    'BHD',
+    'BDT',
+    'BBD',
+    'BYN',
+    'EUR',
+    'BZD',
+    'XOF',
+    'BMD',
+    'INR',
+    'BTN',
+    'BOB',
+    'BOV',
+    'USD',
+    'BAM',
+    'BWP',
+    'NOK',
+    'BRL',
+    'USD',
+    'BND',
+    'BGN',
+    'XOF',
+    'BIF',
+    'CVE',
+    'KHR',
+    'XAF',
+    'CAD',
+    'KYD',
+    'XAF',
+    'XAF',
+    'CLP',
+    'CLF',
+    'CNY',
+    'AUD',
+    'AUD',
+    'COP',
+    'COU',
+    'KMF',
+    'CDF',
+    'XAF',
+    'NZD',
+    'CRC',
+    'XOF',
+    'EUR',
+    'CUP',
+    'XCG',
+    'EUR',
+    'CZK',
+    'DKK',
+    'DJF',
+    'XCD',
+    'DOP',
+    'USD',
+    'EGP',
+    'SVC',
+    'USD',
+    'XAF',
+    'ERN',
+    'EUR',
+    'SZL',
+    'ETB',
+    'EUR',
+    'FKP',
+    'DKK',
+    'FJD',
+    'EUR',
+    'EUR',
+    'EUR',
+    'XPF',
+    'EUR',
+    'XAF',
+    'GMD',
+    'GEL',
+    'EUR',
+    'GHS',
+    'GIP',
+    'EUR',
+    'DKK',
+    'XCD',
+    'EUR',
+    'USD',
+    'GTQ',
+    'GBP',
+    'GNF',
+    'XOF',
+    'GYD',
+    'HTG',
+    'USD',
+    'AUD',
+    'EUR',
+    'HNL',
+    'HKD',
+    'HUF',
+    'ISK',
+    'INR',
+    'IDR',
+    'XDR',
+    'IRR',
+    'IQD',
+    'EUR',
+    'GBP',
+    'ILS',
+    'EUR',
+    'JMD',
+    'JPY',
+    'GBP',
+    'JOD',
+    'KZT',
+    'KES',
+    'AUD',
+    'KPW',
+    'KRW',
+    'KWD',
+    'KGS',
+    'LAK',
+    'EUR',
+    'LBP',
+    'LSL',
+    'ZAR',
+    'LRD',
+    'LYD',
+    'CHF',
+    'EUR',
+    'EUR',
+    'MOP',
+    'MGA',
+    'MWK',
+    'MYR',
+    'MVR',
+    'XOF',
+    'EUR',
+    'USD',
+    'EUR',
+    'MRU',
+    'MUR',
+    'EUR',
+    'XUA',
+    'MXN',
+    'MXV',
+    'USD',
+    'MDL',
+    'EUR',
+    'MNT',
+    'EUR',
+    'XCD',
+    'MAD',
+    'MZN',
+    'MMK',
+    'NAD',
+    'ZAR',
+    'AUD',
+    'NPR',
+    'EUR',
+    'XPF',
+    'NZD',
+    'NIO',
+    'XOF',
+    'NGN',
+    'NZD',
+    'AUD',
+    'MKD',
+    'USD',
+    'NOK',
+    'OMR',
+    'PKR',
+    'USD',
+    'PAB',
+    'USD',
+    'PGK',
+    'PYG',
+    'PEN',
+    'PHP',
+    'NZD',
+    'PLN',
+    'EUR',
+    'USD',
+    'QAR',
+    'EUR',
+    'RON',
+    'RUB',
+    'RWF',
+    'EUR',
+    'SHP',
+    'XCD',
+    'XCD',
+    'EUR',
+    'EUR',
+    'XCD',
+    'WST',
+    'EUR',
+    'STN',
+    'SAR',
+    'XOF',
+    'RSD',
+    'SCR',
+    'SLE',
+    'SGD',
+    'XCG',
+    'XSU',
+    'EUR',
+    'EUR',
+    'SBD',
+    'SOS',
+    'ZAR',
+    'SSP',
+    'EUR',
+    'LKR',
+    'SDG',
+    'SRD',
+    'NOK',
+    'SEK',
+    'CHF',
+    'CHE',
+    'CHW',
+    'SYP',
+    'TWD',
+    'TJS',
+    'TZS',
+    'THB',
+    'USD',
+    'XOF',
+    'NZD',
+    'TOP',
+    'TTD',
+    'TND',
+    'TRY',
+    'TMT',
+    'USD',
+    'AUD',
+    'UGX',
+    'UAH',
+    'AED',
+    'GBP',
+    'USD',
+    'USD',
+    'USN',
+    'UYU',
+    'UYI',
+    'UYW',
+    'UZS',
+    'VUV',
+    'VES',
+    'VED',
+    'VND',
+    'USD',
+    'USD',
+    'XPF',
+    'MAD',
+    'YER',
+    'ZMW',
+    'ZWG'
   ]
 
   const unique = Array.from(new Set(codes))
 
-  return unique.map(code => ({
+  return unique.map((code) => ({
     label: code,
     value: code
   }))

--- a/packages/destination-actions/src/destinations/braze/ecommerce/functions.ts
+++ b/packages/destination-actions/src/destinations/braze/ecommerce/functions.ts
@@ -34,17 +34,17 @@ export async function send(
   const msResponse = new MultiStatusResponse()
 
   if (!['update', 'add'].includes(syncMode ?? '')) {
-    const errormessage = `Invalid syncMode: ${syncMode}. Supported sync modes are 'add' and 'update'.`
+    const errorMessage = `Invalid syncMode: ${syncMode}. Supported sync modes are 'add' and 'update'.`
     if (isBatch) {
       payloads.forEach((_, index) => {
         msResponse.setErrorResponseAtIndex(index, {
           status: 400,
-          errormessage
+          errormessage: errorMessage
         })
       })
       return msResponse
     } else {
-      throw new PayloadValidationError(errormessage)
+      throw new PayloadValidationError(errorMessage)
     }
   }
 
@@ -58,7 +58,7 @@ export async function send(
     json
   })
 
-  const errors = Array.isArray(response.data.errors) ? response.data.errors : []
+  const errors = Array.isArray(response.data?.errors) ? response.data.errors : []
 
   payloadsWithIndexes.forEach((payload, index) => {
     const sentIndex = payload.index


### PR DESCRIPTION
## Summary

Fixes [STRATCONN-6937](https://twilio-engineering.atlassian.net/browse/STRATCONN-6937). Two related fixes in `braze/ecommerce/functions.ts` `send()` (shared by both the `ecommerce` and `ecommerceSingleProduct` actions):

### 1. Batch error index mismatch
Batch-mode error matching used the original loop `index` to look up Braze's `errors[].index`, but Braze's index refers to the position within the `events` array actually **sent** (which excludes payloads filtered out by `validate()`). When an earlier payload failed validation, the indices diverged and Braze errors were attributed to the wrong payload.

Now matches on the sent-array index (`payload.index`, already tracked in `getJSON()`), while still recording the MultiStatus response at the original payload position.

### 2. MultiStatusResponse `sent` / `body` population
- **`sent`** — only set when JSON was actually sent to Braze, populated with the per-item JSON that was sent. Omitted when nothing was sent.
- **`body`** — only set when a response exists: `{ success: true }` for 2XX, error details for non-2XX. Omitted when nothing was sent.
- Payloads never sent (filtered by `validate()`, or an invalid syncMode batch) now carry neither `sent` nor `body` — so core correctly classifies them as `INTEGRATIONS` (pre-send validation) rather than `DESTINATION` errors.

## Testing
- Updated two batch multi-status tests whose expectations depended on the old `sent`/`body` shapes.
- Strengthened the index-mismatch test to assert `sent`/`body` on both the Braze-rejected and successful items.
- Added a "fully successful batch" test asserting `sent` + `{ success: true }`.
- All 21 `braze/ecommerce` tests pass; lint + typecheck clean.

Stage testing. 
1. All events in batch are good. 
 
<img width="2520" height="1191" alt="image" src="https://github.com/user-attachments/assets/19f3f057-b469-4e09-90ce-007f313a171c" />

2. Some events in batch fail. 
<img width="2373" height="1056" alt="Screenshot 2026-08-10 at 10 46 09" src="https://github.com/user-attachments/assets/f948e764-80b3-44ae-9e9b-c83bfda8312e" />

Showing successful events from the mixed batch delivered to braze. 
<img width="1481" height="910" alt="image" src="https://github.com/user-attachments/assets/ab2af123-2ab6-4e52-8e85-9ef88dd2158a" />


[STRATCONN-6937]: https://twilio-engineering.atlassian.net/browse/STRATCONN-6937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ