### PR TITLE
STRATCONN : fixed the failing testcases in main branch

### DIFF
--- a/packages/destination-actions/src/destinations/first-party-dv360/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/_tests_/index.test.ts
@@ -131,6 +131,10 @@ describe('Audience Destination', () => {
       }
     })
 
+    const payloadContactInfo = {
+      email: 'test@gmail.com'
+    }
+
     // Journeys sends computation_class: 'journey_step' instead of 'audience'. The perform() functions for
     // addToAudContactInfo/removeFromAudContactInfo never read computation_class (add vs remove is determined
     // solely by which action is invoked), so behavior must be identical to the tests above.
@@ -138,6 +142,13 @@ describe('Audience Destination', () => {
       event: 'Audience Entered',
       type: 'track',
       properties: {},
+      traits: {
+        phone: '1234567890',
+        zipCodes: '12345',
+        firstName: 'John',
+        lastName: 'Doe',
+        countryCode: '+1'
+      },
       context: {
         traits: payloadContactInfo,
         personas: {

--- a/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/first-party-dv360/addToAudContactInfo/_tests_/index.test.ts
@@ -202,6 +202,13 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
           step_name: 'test-step-name'
         }
       },
+      traits: {
+        phone: '+19876543210',
+        zipCodes: '54321',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        countryCode: 'US'
+      },
       context: {
         personas: {
           external_audience_id: '9876543210',
@@ -210,12 +217,7 @@ describe('First-Party-dv360.addToAudContactInfo', () => {
           }
         },
         traits: {
-          emails: 'journeys@testing.com',
-          phoneNumbers: '+19876543210',
-          zipCodes: '54321',
-          firstName: 'Jane',
-          lastName: 'Doe',
-          countryCode: 'US'
+          email: 'journeys@testing.com'
         }
       }
     })


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. The PR fixes the testcases which are failing in the main branch .
2. The testcases were failing due to conflicted changes in first party dv-360 repo .

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [x] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
