### PR TITLE
Release

### DIFF
--- a/packages/actions-shared/package.json
+++ b/packages/actions-shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/actions-shared",
   "description": "Shared destination action methods and definitions.",
-  "version": "1.162.0",
+  "version": "1.163.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/browser-destinations/destinations/friendbuy/package.json
+++ b/packages/browser-destinations/destinations/friendbuy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-friendbuy",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -21,7 +21,7 @@
   "typings": "./dist/esm",
   "dependencies": {
     "@segment/actions-core": "^3.176.0",
-    "@segment/actions-shared": "^1.162.0",
+    "@segment/actions-shared": "^1.163.0",
     "@segment/browser-destination-runtime": "^1.105.0"
   },
   "peerDependencies": {

--- a/packages/browser-destinations/destinations/intercom/package.json
+++ b/packages/browser-destinations/destinations/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-intercom",
-  "version": "1.117.0",
+  "version": "1.118.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -21,7 +21,7 @@
   "typings": "./dist/esm",
   "dependencies": {
     "@segment/actions-core": "^3.176.0",
-    "@segment/actions-shared": "^1.162.0",
+    "@segment/actions-shared": "^1.163.0",
     "@segment/browser-destination-runtime": "^1.105.0"
   },
   "peerDependencies": {

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.509.0",
+  "version": "3.510.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -48,7 +48,7 @@
     "@bufbuild/protobuf": "^2.2.3",
     "@segment/a1-notation": "^2.1.4",
     "@segment/actions-core": "^3.176.0",
-    "@segment/actions-shared": "^1.162.0",
+    "@segment/actions-shared": "^1.163.0",
     "@types/node": "^22.13.1",
     "ajv-formats": "^2.1.1",
     "aws4": "^1.12.0",

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/destinations-manifest",
-  "version": "1.167.0",
+  "version": "1.168.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -30,7 +30,7 @@
     "@segment/analytics-browser-actions-contentstack-web": "^1.49.0",
     "@segment/analytics-browser-actions-devrev": "^1.93.0",
     "@segment/analytics-browser-actions-facebook-conversions-api-web": "^1.23.0",
-    "@segment/analytics-browser-actions-friendbuy": "^1.112.0",
+    "@segment/analytics-browser-actions-friendbuy": "^1.113.0",
     "@segment/analytics-browser-actions-fullsession": "^1.18.0",
     "@segment/analytics-browser-actions-fullstory": "^1.108.0",
     "@segment/analytics-browser-actions-google-analytics-4": "^1.117.0",
@@ -38,7 +38,7 @@
     "@segment/analytics-browser-actions-google-ec-plugins": "^1.15.0",
     "@segment/analytics-browser-actions-heap": "^1.106.0",
     "@segment/analytics-browser-actions-hubspot": "^1.106.0",
-    "@segment/analytics-browser-actions-intercom": "^1.117.0",
+    "@segment/analytics-browser-actions-intercom": "^1.118.0",
     "@segment/analytics-browser-actions-iterate": "^1.107.0",
     "@segment/analytics-browser-actions-jimo": "^1.97.0",
     "@segment/analytics-browser-actions-koala": "^1.108.0",


### PR DESCRIPTION
This PR was opened by action-cli's trigger-action-destinations-publish command.
Merging it bumps package versions ahead of an internal-only NPM Artifactory publish.

# Changed packages
- packages/actions-shared/package.json
- packages/browser-destinations/destinations/friendbuy/package.json
- packages/browser-destinations/destinations/intercom/package.json
- packages/destination-actions/package.json
- packages/destinations-manifest/package.json