### PR TITLE
fix: run browser artifact detect job on ubuntu-latest-large

### DIFF
--- a/.github/workflows/publish-browser-destinations.yml
+++ b/.github/workflows/publish-browser-destinations.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   detect-browser-destination-changes:
     if: startsWith(github.event.head_commit.message, 'Publish') == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Problem

The `detect-browser-destination-changes` job in `publish-browser-destinations.yml` requests `runs-on: ubuntu-latest`, a runner label this org does not serve. As a result the job hangs in the queue indefinitely and the browser artifact is **never built**.

Verified on `staging`: a `Publish` commit's run sat **~1h13m** with the detect job unassigned ("Waiting for a runner to pick up this job") while `ubuntu-latest-large` jobs (CI, etc.) completed normally. After switching the label to `ubuntu-latest-large`, the detect job was picked up immediately and the build produced the artifact.

## Fix

Change the detect job to `ubuntu-latest-large`, matching this workflow's own `build-browser-destinations` job (line 75) and every other job in the repo. This targets the #3787 branch so the fix lands with the workflow when it merges to `main`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>