### PR TITLE
SFMC - Refactor asyncDataExtension fields

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/fields.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/fields.ts
@@ -1,0 +1,67 @@
+import { RequestClient, DynamicFieldResponse } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { keys, values_dataExtensionFields, dataExtensionHook } from '../sfmc-properties'
+import { getDataExtensionFields } from '../sfmc-operations'
+
+export const fields = {
+  keys: { ...keys, required: true, dynamic: true },
+  values: { ...values_dataExtensionFields, dynamic: true },
+  enable_batching: {
+    label: 'Batch data to SFMC',
+    description: 'If true, data is batched before sending to the SFMC Data Extension.',
+    type: 'boolean' as const,
+    default: true,
+    unsafe_hidden: true
+  },
+  batch_bytes: {
+    label: 'Batch Bytes',
+    description: 'The maximum size of a batch in bytes.',
+    type: 'number' as const,
+    required: false,
+    default: 5000000, // 5 MB
+    unsafe_hidden: true
+  },
+  batch_size: {
+    label: 'Batch Size',
+    description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+    type: 'number' as const,
+    required: false,
+    minimum: 1000,
+    default: 28000,
+    maximum: 30000,
+    unsafe_hidden: true
+  }
+}
+
+export const dynamicFields = {
+  keys: {
+    __keys__: async (
+      request: RequestClient,
+      { settings, payload }: { settings: Settings; payload: Payload }
+    ): Promise<DynamicFieldResponse> => {
+      const dataExtensionId =
+        (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+      return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, true)
+    }
+  },
+  values: {
+    __keys__: async (
+      request: RequestClient,
+      { settings, payload }: { settings: Settings; payload: Payload }
+    ): Promise<DynamicFieldResponse> => {
+      const dataExtensionId =
+        (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
+      return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, false)
+    }
+  }
+}
+
+export const hooks = {
+  retlOnMappingSave: {
+    ...dataExtensionHook
+  },
+  onMappingSave: {
+    ...dataExtensionHook
+  }
+}

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.ts
@@ -1,65 +1,15 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { keys, values_dataExtensionFields, dataExtensionHook } from '../sfmc-properties'
-import { getDataExtensionFields, asyncUpsertRowsV2 } from '../sfmc-operations'
+import { asyncUpsertRowsV2 } from '../sfmc-operations'
+import { fields, dynamicFields, hooks } from './fields'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Send Event asynchronously to Data Extension',
-  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud. Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future`,
-  fields: {
-    keys: { ...keys, required: true, dynamic: true },
-    values: { ...values_dataExtensionFields, dynamic: true },
-    enable_batching: {
-      label: 'Batch data to SFMC',
-      description: 'If true, data is batched before sending to the SFMC Data Extension.',
-      type: 'boolean',
-      default: true,
-      unsafe_hidden: true
-    },
-    batch_bytes: {
-      label: 'Batch Bytes',
-      description: 'The maximum size of a batch in bytes.',
-      type: 'number',
-      required: false,
-      default: 5000000, // 5 MB
-      unsafe_hidden: true
-    },
-    batch_size: {
-      label: 'Batch Size',
-      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
-      type: 'number',
-      required: false,
-      minimum: 1000,
-      default: 28000,
-      maximum: 30000,
-      unsafe_hidden: true
-    }
-  },
-  dynamicFields: {
-    keys: {
-      __keys__: async (request, { settings, payload }) => {
-        const dataExtensionId =
-          (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
-        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, true)
-      }
-    },
-    values: {
-      __keys__: async (request, { settings, payload }) => {
-        const dataExtensionId =
-          (payload as any).onMappingSave?.outputs?.id || (payload as any).retlOnMappingSave?.outputs?.id || ''
-        return await getDataExtensionFields(request, settings.subdomain, settings, dataExtensionId, false)
-      }
-    }
-  },
-  hooks: {
-    retlOnMappingSave: {
-      ...dataExtensionHook
-    },
-    onMappingSave: {
-      ...dataExtensionHook
-    }
-  },
+  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.`,
+  fields,
+  dynamicFields,
+  hooks,
   perform: async (request, { settings, payload, hookOutputs }) => {
     const dataExtensionId: string =
       hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
@@ -3219,7 +3219,7 @@
     },
     "asyncDataExtension": {
       "title": "Send Event asynchronously to Data Extension",
-      "description": "Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud. Note that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action- That will come in near future",
+      "description": "Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.",
       "platform": "cloud",
       "defaultSubscription": null,
       "hidden": false,


### PR DESCRIPTION
This PR refactors fields of SFMC's asyncDataExtension into an independent file.
The async variant of this action will be added in a future PR.

## Testing

This change is part of a larger change which was tested successfully in staging for 30+ days.

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
