### PR TITLE
feat(aws-kinesis): flag-gated diagnostic latency logging (STRATCONN-6690)

### DIFF
--- a/packages/destination-actions/src/destinations/aws-kinesis/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/aws-kinesis/__tests__/utils.test.ts
@@ -73,7 +73,8 @@ const mockSend = jest.fn()
 const mockLogger: Partial<Logger> = {
   crit: jest.fn(),
   info: jest.fn(),
-  warn: jest.fn()
+  warn: jest.fn(),
+  error: jest.fn()
 }
 
 describe('Kinesis send', () => {
@@ -114,7 +115,12 @@ describe('Kinesis send', () => {
 
     await send(mockSettings, mockPayloads, undefined, mockLogger as Logger)
 
-    expect(assumeRole).toHaveBeenCalledWith(mockSettings.iamRoleArn, mockSettings.iamExternalId, expect.any(String))
+    expect(assumeRole).toHaveBeenCalledWith(
+      mockSettings.iamRoleArn,
+      mockSettings.iamExternalId,
+      expect.any(String),
+      expect.objectContaining({ advancedLogging: false })
+    )
 
     expect(KinesisClient).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -267,6 +273,93 @@ describe('Kinesis send', () => {
       status: 200,
       body: { ShardId: 'shard-1', SequenceNumber: 'seq-1' },
       sent: mockPayloads[0] as unknown as JSONLikeObject
+    })
+  })
+
+  describe('advanced logging (actions-aws-kinesis-advanced-logging flag)', () => {
+    it('should not emit diagnostic metrics or logs when the flag is off', async () => {
+      const mockStatsClient = { histogram: jest.fn(), incr: jest.fn() }
+      const statsContext: StatsContext = { statsClient: mockStatsClient as any, tags: ['tag1'] }
+      mockSend.mockResolvedValueOnce({ FailedRecordCount: 0, Records: [{}] })
+
+      // advancedLogging defaults to false
+      await send(mockSettings, mockPayloads, statsContext, mockLogger as Logger)
+
+      expect(mockStatsClient.histogram).not.toHaveBeenCalledWith(
+        'actions_kinesis.sts_assume_role_ms',
+        expect.any(Number),
+        expect.anything()
+      )
+      expect(mockStatsClient.histogram).not.toHaveBeenCalledWith(
+        'actions_kinesis.kinesis_put_records_ms',
+        expect.any(Number),
+        expect.anything()
+      )
+      expect(mockStatsClient.incr).not.toHaveBeenCalledWith('actions_kinesis.request_timeout', 1, expect.anything())
+      expect(mockLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('should emit phase latency metrics and an info log on success when the flag is on', async () => {
+      const mockStatsClient = { histogram: jest.fn(), incr: jest.fn() }
+      const statsContext: StatsContext = { statsClient: mockStatsClient as any, tags: ['tag1'] }
+      mockSend.mockResolvedValueOnce({ FailedRecordCount: 0, Records: [{}] })
+
+      await send(mockSettings, mockPayloads, statsContext, mockLogger as Logger, undefined, true)
+
+      expect(mockStatsClient.histogram).toHaveBeenCalledWith(
+        'actions_kinesis.sts_assume_role_ms',
+        expect.any(Number),
+        statsContext.tags
+      )
+      expect(mockStatsClient.histogram).toHaveBeenCalledWith(
+        'actions_kinesis.kinesis_put_records_ms',
+        expect.any(Number),
+        statsContext.tags
+      )
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('[aws-kinesis] put_records ok'))
+    })
+
+    it('should forward the logging context to assumeRole when the flag is on', async () => {
+      mockSend.mockResolvedValueOnce({ FailedRecordCount: 0, Records: [{}] })
+
+      await send(mockSettings, mockPayloads, undefined, mockLogger as Logger, undefined, true)
+
+      expect(assumeRole).toHaveBeenCalledWith(
+        mockSettings.iamRoleArn,
+        mockSettings.iamExternalId,
+        expect.any(String),
+        expect.objectContaining({ advancedLogging: true })
+      )
+    })
+
+    it('should emit a timeout metric and error log on AbortError when the flag is on, and still throw RequestTimeoutError', async () => {
+      const mockStatsClient = { histogram: jest.fn(), incr: jest.fn() }
+      const statsContext: StatsContext = { statsClient: mockStatsClient as any, tags: ['tag1'] }
+      const abortError: any = new Error('Aborted')
+      abortError.name = 'AbortError'
+      mockSend.mockRejectedValueOnce(abortError)
+
+      await expect(
+        send(mockSettings, mockPayloads, statsContext, mockLogger as Logger, undefined, true)
+      ).rejects.toThrow(RequestTimeoutError)
+
+      expect(mockStatsClient.incr).toHaveBeenCalledWith('actions_kinesis.request_timeout', 1, statsContext.tags)
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('phase=kinesis'))
+    })
+
+    it('should not emit a timeout metric on AbortError when the flag is off, but still throw RequestTimeoutError', async () => {
+      const mockStatsClient = { histogram: jest.fn(), incr: jest.fn() }
+      const statsContext: StatsContext = { statsClient: mockStatsClient as any, tags: ['tag1'] }
+      const abortError: any = new Error('Aborted')
+      abortError.name = 'AbortError'
+      mockSend.mockRejectedValueOnce(abortError)
+
+      await expect(send(mockSettings, mockPayloads, statsContext, mockLogger as Logger)).rejects.toThrow(
+        RequestTimeoutError
+      )
+
+      expect(mockStatsClient.incr).not.toHaveBeenCalledWith('actions_kinesis.request_timeout', 1, expect.anything())
+      expect(mockLogger.error).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/destination-actions/src/destinations/aws-kinesis/send/index.ts
+++ b/packages/destination-actions/src/destinations/aws-kinesis/send/index.ts
@@ -83,11 +83,13 @@ const action: ActionDefinition<Settings, Payload> = {
       unsafe_hidden: true
     }
   },
-  perform: async (_requests, { settings, payload, statsContext, logger, signal }) => {
-    await send(settings, [payload], statsContext, logger, signal)
+  perform: async (_requests, { settings, payload, features, statsContext, logger, signal }) => {
+    const advancedLogging = Boolean(features?.['actions-aws-kinesis-advanced-logging'])
+    await send(settings, [payload], statsContext, logger, signal, advancedLogging)
   },
-  performBatch: async (_requests, { settings, payload, statsContext, logger, signal }) => {
-    await send(settings, payload, statsContext, logger, signal)
+  performBatch: async (_requests, { settings, payload, features, statsContext, logger, signal }) => {
+    const advancedLogging = Boolean(features?.['actions-aws-kinesis-advanced-logging'])
+    await send(settings, payload, statsContext, logger, signal, advancedLogging)
   }
 }
 

--- a/packages/destination-actions/src/destinations/aws-kinesis/utils.ts
+++ b/packages/destination-actions/src/destinations/aws-kinesis/utils.ts
@@ -7,7 +7,7 @@ import {
   PutRecordsRequestEntry,
   PutRecordsCommandOutput
 } from '@aws-sdk/client-kinesis'
-import { assumeRole } from '../../lib/AWS/sts'
+import { assumeRole, StsLogging } from '../../lib/AWS/sts'
 import { APP_AWS_REGION } from '../../lib/AWS/utils'
 import { RequestTimeoutError, MultiStatusResponse, IntegrationError, JSONLikeObject } from '@segment/actions-core'
 
@@ -26,9 +26,10 @@ const transformPayloads = (payloads: Payload[]): PutRecordsRequestEntry[] => {
 const createKinesisClient = async (
   iamRoleArn: string,
   iamExternalId: string,
-  awsRegion: string
+  awsRegion: string,
+  logging?: StsLogging
 ): Promise<KinesisClient> => {
-  const credentials = await assumeRole(iamRoleArn, iamExternalId, APP_AWS_REGION)
+  const credentials = await assumeRole(iamRoleArn, iamExternalId, APP_AWS_REGION, logging)
   return new KinesisClient({
     region: awsRegion,
     credentials: credentials
@@ -40,29 +41,63 @@ export const send = async (
   payloads: Payload[],
   statsContext: StatsContext | undefined,
   logger: Logger | undefined,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  advancedLogging = false
 ): Promise<MultiStatusResponse> => {
   const { iamRoleArn, iamExternalId } = settings
   const { streamName, awsRegion } = payloads[0]
   const entries = transformPayloads(payloads)
+  const tags = statsContext?.tags
 
-  statsContext?.statsClient?.histogram('actions_kinesis.batch_size', entries?.length, statsContext?.tags)
-  statsContext?.statsClient?.incr('actions_kinesis.request_hit', 1, statsContext?.tags)
+  statsContext?.statsClient?.histogram('actions_kinesis.batch_size', entries?.length, tags)
+  statsContext?.statsClient?.incr('actions_kinesis.request_hit', 1, tags)
 
+  // Track the in-flight phase so we can attribute an execution-deadline abort to the STS
+  // assume-role step vs. the Kinesis PutRecords call. See STRATCONN-6690.
+  const start = Date.now()
+  let phase: 'sts' | 'kinesis' = 'sts'
   try {
-    const client = await createKinesisClient(iamRoleArn, iamExternalId, awsRegion)
+    const client = await createKinesisClient(iamRoleArn, iamExternalId, awsRegion, {
+      advancedLogging,
+      logger,
+      statsContext
+    })
+    if (advancedLogging) {
+      statsContext?.statsClient?.histogram('actions_kinesis.sts_assume_role_ms', Date.now() - start, tags)
+    }
+
+    phase = 'kinesis'
+    const putRecordsStart = Date.now()
     const command = new PutRecordsCommand({
       StreamName: streamName,
       Records: entries
     })
 
     const response = await client.send(command, { abortSignal: signal })
+    if (advancedLogging) {
+      const durationMs = Date.now() - putRecordsStart
+      statsContext?.statsClient?.histogram('actions_kinesis.kinesis_put_records_ms', durationMs, tags)
+      logger?.info(
+        `[aws-kinesis] put_records ok durationMs=${durationMs} totalMs=${
+          Date.now() - start
+        } stream=${streamName} region=${awsRegion} batch=${entries.length}`
+      )
+    }
     const multiResp = handleMultiStatusResponse(response, statsContext, payloads)
     return multiResp
   } catch (error) {
     // Handle abort signal error: https://aws.amazon.com/blogs/developer/abortcontroller-in-modular-aws-sdk-for-javascript/
     if ((error as Error).name === 'AbortError') {
-      // Handle abort error
+      // Handle abort error. This is the 504 / execution-deadline case, which was previously
+      // silent (thrown before any log or metric) — hence no signal in Grafana. See STRATCONN-6690.
+      if (advancedLogging) {
+        statsContext?.statsClient?.incr('actions_kinesis.request_timeout', 1, tags)
+        logger?.error(
+          `[aws-kinesis] aborted (execution deadline exceeded) phase=${phase} elapsedMs=${
+            Date.now() - start
+          } stream=${streamName} region=${awsRegion} batch=${entries.length}`
+        )
+      }
       throw new RequestTimeoutError()
     }
 

--- a/packages/destination-actions/src/lib/AWS/__test__/index.test.ts
+++ b/packages/destination-actions/src/lib/AWS/__test__/index.test.ts
@@ -76,6 +76,67 @@ describe('assumeRole', () => {
     })
   })
 
+  it('should emit per-call latency metrics when advanced logging is enabled', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Credentials: {
+          AccessKeyId: 'AKIA_INTER',
+          SecretAccessKey: 'SECRET_INTER',
+          SessionToken: 'TOKEN_INTER'
+        }
+      })
+      .mockResolvedValueOnce({
+        Credentials: {
+          AccessKeyId: 'AKIA_FINAL',
+          SecretAccessKey: 'SECRET_FINAL',
+          SessionToken: 'TOKEN_FINAL'
+        }
+      })
+
+    const histogram = jest.fn()
+    const logger = { info: jest.fn() }
+    const logging = {
+      advancedLogging: true,
+      logger: logger as any,
+      statsContext: { statsClient: { histogram } as any, tags: ['tag1'] } as any
+    }
+
+    await assumeRole('arn:aws:iam::222222222222:role/TargetRole', 'external-id-final', 'us-east-1', logging)
+
+    expect(histogram).toHaveBeenCalledWith('actions_kinesis.sts_intermediary_ms', expect.any(Number), ['tag1'])
+    expect(histogram).toHaveBeenCalledWith('actions_kinesis.sts_customer_ms', expect.any(Number), ['tag1'])
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('phase=sts_intermediary_ms'))
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('phase=sts_customer_ms'))
+  })
+
+  it('should not emit latency metrics when advanced logging is disabled', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        Credentials: {
+          AccessKeyId: 'AKIA_INTER',
+          SecretAccessKey: 'SECRET_INTER',
+          SessionToken: 'TOKEN_INTER'
+        }
+      })
+      .mockResolvedValueOnce({
+        Credentials: {
+          AccessKeyId: 'AKIA_FINAL',
+          SecretAccessKey: 'SECRET_FINAL',
+          SessionToken: 'TOKEN_FINAL'
+        }
+      })
+
+    const histogram = jest.fn()
+    const logging = {
+      advancedLogging: false,
+      statsContext: { statsClient: { histogram } as any, tags: ['tag1'] } as any
+    }
+
+    await assumeRole('arn:aws:iam::222222222222:role/TargetRole', 'external-id-final', 'us-east-1', logging)
+
+    expect(histogram).not.toHaveBeenCalled()
+  })
+
   it('should pass intermediary credentials to second STS call', async () => {
     mockSend
       .mockResolvedValueOnce({

--- a/packages/destination-actions/src/lib/AWS/sts.ts
+++ b/packages/destination-actions/src/lib/AWS/sts.ts
@@ -2,12 +2,21 @@ import { readFileSync } from 'fs'
 import { RequestClient } from '@segment/actions-core'
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts'
 import { IntegrationError, ErrorCodes } from '@segment/actions-core'
+import { Logger, StatsContext } from '@segment/actions-core/destination-kit'
 import { v4 as uuidv4 } from '@lukeed/uuid'
 
 export type AWSCredentials = {
   accessKeyId: string
   secretAccessKey: string
   sessionToken: string
+}
+
+// Optional diagnostic instrumentation for the Kinesis assume-role path.
+// Gated by the `actions-aws-kinesis-advanced-logging` Flagon flag (see aws-kinesis/send/index.ts).
+export type StsLogging = {
+  advancedLogging: boolean
+  logger?: Logger
+  statsContext?: StatsContext
 }
 
 type K8sApiServiceAccountResponse = {
@@ -132,14 +141,33 @@ export async function getAWSCredentialsFromEKS(request: RequestClient): Promise<
   return credentials
 }
 
-export const assumeRole = async (roleArn: string, externalId: string, region: string): Promise<AWSCredentials> => {
+export const assumeRole = async (
+  roleArn: string,
+  externalId: string,
+  region: string,
+  logging?: StsLogging
+): Promise<AWSCredentials> => {
   const intermediaryARN = process.env.AMAZON_KINESIS_ACTIONS_ROLE_ADDRESS as string
   const intermediaryExternalId = process.env.AMAZON_KINESIS_ACTIONS_EXTERNAL_ID as string
-  const intermediaryCreds = await getSTSCredentials(intermediaryARN, intermediaryExternalId, region)
-  return getSTSCredentials(roleArn, externalId, region, intermediaryCreds)
+  const intermediaryCreds = await getSTSCredentials(
+    intermediaryARN,
+    intermediaryExternalId,
+    region,
+    undefined,
+    logging,
+    'sts_intermediary_ms'
+  )
+  return getSTSCredentials(roleArn, externalId, region, intermediaryCreds, logging, 'sts_customer_ms')
 }
 
-const getSTSCredentials = async (roleId: string, externalId: string, region: string, credentials?: AWSCredentials) => {
+const getSTSCredentials = async (
+  roleId: string,
+  externalId: string,
+  region: string,
+  credentials?: AWSCredentials,
+  logging?: StsLogging,
+  metric?: string
+) => {
   const options = { credentials, region: region }
   const stsClient = new STSClient(options)
   const roleSessionName: string = uuidv4()
@@ -148,7 +176,13 @@ const getSTSCredentials = async (roleId: string, externalId: string, region: str
     RoleSessionName: roleSessionName,
     ExternalId: externalId
   })
+  const start = Date.now()
   const result = await stsClient.send(command)
+  if (logging?.advancedLogging && metric) {
+    const durationMs = Date.now() - start
+    logging.statsContext?.statsClient?.histogram(`actions_kinesis.${metric}`, durationMs, logging.statsContext?.tags)
+    logging.logger?.info(`[aws-kinesis] assume_role phase=${metric} durationMs=${durationMs} region=${region}`)
+  }
   if (
     !result.Credentials ||
     !result.Credentials.AccessKeyId ||


### PR DESCRIPTION
## Summary

Customer **Whatnot** (STRATCONN-6690) sees intermittent **504 Gateway Timeout** on the Amazon Kinesis destination. The 504 is **not** the AWS API Gateway 29s integration timeout — it's Segment's **internal execution deadline** aborting the request. Two things made this un-diagnosable:

1. The delivery path makes **3 sequential calls per batch with no credential caching** — 2× STS `AssumeRole` (intermediary role, then customer role) + 1 Kinesis `PutRecords`. Their cumulative tail latency breaches the deadline.
2. The abort branch threw `RequestTimeoutError` **before any log or metric**, so the failure was completely invisible in Grafana/Loki — which is why the investigation stalled.

This PR adds diagnostic instrumentation to attribute the timeout to a specific phase (STS#1 / STS#2 / PutRecords), gated behind a Flagon flag so there's zero footprint until enabled.

## Changes

All emits are gated on `features['actions-aws-kinesis-advanced-logging']` (nothing logs/emits when the flag is off — no behavior change). Follows the existing `salesforce-advanced-logging` precedent.

Flagon gate: https://flagon.segment.com/families/centrifuge-destinations/gates/actions-aws-kinesis-advanced-logging

- **`aws-kinesis/send/index.ts`** — read the flag off `features`, pass a boolean into `send`.
- **`aws-kinesis/utils.ts`** — time the STS-total and PutRecords phases; track the in-flight `phase`; on `AbortError` emit `actions_kinesis.request_timeout` + an error log with the phase/elapsed **before** throwing (closes the silent-failure gap).
- **`lib/AWS/sts.ts`** — split the two assume-role calls into `sts_intermediary_ms` vs `sts_customer_ms` (optional `StsLogging` arg; `assumeRole` is Kinesis-only, `testAuthentication` unaffected).

### New metrics
`actions_kinesis.sts_intermediary_ms`, `sts_customer_ms`, `sts_assume_role_ms`, `kinesis_put_records_ms` (histograms), and `actions_kinesis.request_timeout` (counter).

### Sample log lines
```
[aws-kinesis] assume_role phase=sts_intermediary_ms durationMs=142 region=us-east-1
[aws-kinesis] assume_role phase=sts_customer_ms durationMs=118 region=us-east-1
[aws-kinesis] put_records ok durationMs=87 totalMs=352 stream=<streamName> region=us-east-1 batch=340
[aws-kinesis] aborted (execution deadline exceeded) phase=kinesis elapsedMs=9800 stream=<streamName> region=us-east-1 batch=340
```

## PII
None. Logs contain only durations, stream name, AWS region, batch size (a count), and phase label — no payload, partition keys, or credentials.

## Testing
- 5 new cases in `aws-kinesis/__tests__/utils.test.ts` (flag off = silent; flag on success = metrics + log; logging context forwarded; abort-with-flag = timeout metric + error log + still throws; abort-without-flag = silent + still throws).
- 2 new cases in `lib/AWS/__test__/index.test.ts` (per-call latency metrics on/off).
- Typecheck clean; lint 0 errors.

## Rollout
1. Gate already exists in Flagon (default off): [`actions-aws-kinesis-advanced-logging`](https://flagon.segment.com/families/centrifuge-destinations/gates/actions-aws-kinesis-advanced-logging).
2. Enable scoped to Whatnot's source `6421c0a60cc41c0c431f13d9`.
3. Read the per-phase metrics to identify which call breaches the deadline. Expected follow-up (separate PR): **cache assumed credentials on the Kinesis path** so 2 of the 3 calls disappear in steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
