### PR TITLE
[Async Batch] Add Async Action for SFMC.

### DIFF
--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/asyncDataExtension.async.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/asyncDataExtension.async.test.ts
@@ -10,7 +10,7 @@ import Definition from '../index'
 import { Settings } from '../generated-types'
 
 const testDestination = createTestIntegration(Definition)
-const timestamp = '2025-10-13T4:00:00.449Z'
+const timestamp = '2025-10-13T04:00:00.449Z'
 const settings: Settings = {
   subdomain: 'test123',
   client_id: 'test123',

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/asyncDataExtension.async.test.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/_tests_/asyncDataExtension.async.test.ts
@@ -1,0 +1,884 @@
+import nock from 'nock'
+import {
+  createTestEvent,
+  createTestIntegration,
+  SegmentEvent,
+  DynamicFieldResponse,
+  ActionDestinationErrorResponse
+} from '@segment/actions-core'
+import Definition from '../index'
+import { Settings } from '../generated-types'
+
+const testDestination = createTestIntegration(Definition)
+const timestamp = '2025-10-13T4:00:00.449Z'
+const settings: Settings = {
+  subdomain: 'test123',
+  client_id: 'test123',
+  client_secret: 'test123',
+  account_id: 'test123'
+}
+
+const dataExtensionId = '1234567890'
+
+const event = createTestEvent({
+  timestamp: timestamp,
+  type: 'track',
+  userId: 'TonyStark001',
+  properties: {
+    id: 'ily3000'
+  }
+})
+
+const payload = {
+  keys: {
+    id: 'version'
+  },
+  values: {
+    name: 'MARK42'
+  },
+  onMappingSave: {
+    inputs: {},
+    outputs: {
+      id: dataExtensionId
+    }
+  }
+}
+
+const retlPayload = {
+  keys: {
+    id: 'version'
+  },
+  values: {
+    name: 'MARK42'
+  },
+  retlOnMappingSave: {
+    inputs: {},
+    outputs: {
+      id: dataExtensionId
+    }
+  }
+}
+
+describe('Salesforce Marketing Cloud - Async', () => {
+  describe('Async Data Extension Action for Async Pipeline', () => {
+    beforeAll(() => {
+      nock.cleanAll()
+    })
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    describe('Dynamic Fields Hooks', () => {
+      it('should throw error when no dataExtensionId is provided in hook outputs', async () => {
+        const hookResponse: DynamicFieldResponse = await testDestination.testDynamicField(
+          'asyncDataExtension',
+          'keys.__keys__',
+          {
+            settings,
+            payload: {}
+          }
+        )
+
+        expect(hookResponse.choices.length).toBe(0)
+        expect(hookResponse.error).toEqual({
+          message: 'No Data Extension ID provided',
+          code: 'BAD_REQUEST'
+        })
+      })
+
+      it('should work with retlOnMappingSave for keys.__keys__', async () => {
+        // Mock auth token request
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        // Mock data extension fields request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}/fields`)
+          .reply(200, {
+            fields: [
+              { name: 'subscriber_key', isPrimaryKey: true },
+              { name: 'first_name', isPrimaryKey: false }
+            ]
+          })
+
+        const response = await testDestination.testDynamicField('asyncDataExtension', 'keys.__keys__', {
+          settings,
+          payload: {
+            retlOnMappingSave: {
+              outputs: {
+                id: dataExtensionId
+              }
+            }
+          }
+        })
+
+        expect(response.choices).toHaveLength(1)
+        expect(response.choices).toEqual([{ value: 'subscriber_key', label: 'subscriber_key' }])
+      })
+
+      it('should return primary key fields for keys.__keys__', async () => {
+        // Mock auth token request
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        // Mock data extension fields request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}/fields`)
+          .reply(200, {
+            fields: [
+              { name: 'id', isPrimaryKey: true },
+              { name: 'email', isPrimaryKey: false },
+              { name: 'name', isPrimaryKey: false },
+              { name: 'age', isPrimaryKey: false }
+            ]
+          })
+
+        const response = await testDestination.testDynamicField('asyncDataExtension', 'keys.__keys__', {
+          settings,
+          payload: {
+            onMappingSave: {
+              outputs: {
+                id: dataExtensionId
+              }
+            }
+          }
+        })
+
+        expect(response.choices).toHaveLength(1)
+        expect(response.choices).toEqual(expect.arrayContaining([{ value: 'id', label: 'id' }]))
+      })
+
+      it('should return non-primary key fields for values.__keys__', async () => {
+        // Mock auth token request
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        // Mock data extension fields request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/customobjects/${dataExtensionId}/fields`)
+          .reply(200, {
+            fields: [
+              { name: 'id', isPrimaryKey: true },
+              { name: 'email', isPrimaryKey: true },
+              { name: 'name', isPrimaryKey: false },
+              { name: 'age', isPrimaryKey: false }
+            ]
+          })
+
+        const response = await testDestination.testDynamicField('asyncDataExtension', 'values.__keys__', {
+          settings,
+          payload: {
+            onMappingSave: {
+              outputs: {
+                id: dataExtensionId
+              }
+            }
+          }
+        })
+
+        expect(response.choices).toHaveLength(2)
+        expect(response.choices).toEqual(
+          expect.arrayContaining([
+            { value: 'name', label: 'name' },
+            { value: 'age', label: 'age' }
+          ])
+        )
+      })
+    })
+
+    describe('performBatch', () => {
+      it('should submit batch with retlOnMappingSave hook outputs and returns jobId', async () => {
+        // Mock auth token request
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        // Mock async batch request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(200, {
+            requestId: 'test-job-id',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events: [event],
+          settings,
+          mapping: retlPayload
+        })
+
+        expect(response.jobId).toBe('test-job-id')
+        expect(response.multiStatusResponse.getResponseAtIndex(0).value().status).toBe(200)
+      })
+
+      it('should throw an error if no data extension is connected', async () => {
+        const events: SegmentEvent[] = [
+          createTestEvent({
+            type: 'track',
+            userId: 'user1',
+            properties: {
+              keys: { id: 'v1' },
+              values: { name: 'User 1' }
+            }
+          })
+        ]
+
+        const mappingWithoutId = {
+          keys: { '@path': '$.properties.keys' },
+          values: { '@path': '$.properties.values' }
+        }
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events,
+          settings,
+          mapping: mappingWithoutId
+        })
+
+        const errResponse0a = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse0a.value().status).toBe(400)
+        expect(errResponse0a instanceof ActionDestinationErrorResponse && errResponse0a.value().errormessage).toEqual(
+          'No Data Extension Connected'
+        )
+      })
+
+      it('should submit batch to SFMC and returns jobId', async () => {
+        // Mock auth token request
+        nock(`https://${settings.subdomain}.auth.marketingcloudapis.com`).post('/v2/token').reply(200, {
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600
+        })
+
+        // Mock async batch request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(200, {
+            requestId: 'test-job-id',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events: [event],
+          settings,
+          mapping: payload
+        })
+
+        expect(response.jobId).toBe('test-job-id')
+        expect(response.multiStatusResponse.getResponseAtIndex(0).value().status).toBe(200)
+      })
+
+      it('should handle non-OK errors with resultMessages', async () => {
+        const events: SegmentEvent[] = [
+          createTestEvent({
+            type: 'track',
+            userId: 'user1',
+            properties: {
+              keys: { id: 'v1' },
+              values: { name: 'User 1' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user2',
+            properties: {
+              keys: { id: 'v2' },
+              values: { name: 'User 2' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user3',
+            properties: {
+              keys: { id: 'v3' },
+              values: { name: 'User 3' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user4',
+            properties: {
+              keys: { id: 'v4' },
+              values: { name: 'User 4' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user5',
+            properties: {
+              keys: { id: 'v5' },
+              values: { name: 'User 5' }
+            }
+          })
+        ]
+
+        // Mock async batch request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(400, {
+            requestId: 'test-job-id',
+            resultMessages: [
+              {
+                resultType: 'Validation',
+                resultClass: 'Error',
+                resultCode: 'CustomObjectNotFound',
+                message:
+                  'Failed to resolve the Custom Object from the provided ObjectReferenceIdentifier [Id: a52c65d8-8938-f111-a5ab-d4f5ef4cd471, Key: ].'
+              }
+            ]
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events,
+          settings,
+          mapping: payload
+        })
+
+        expect(response.jobId).toBe('test-job-id')
+        const errResponse0b = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse0b.value().status).toBe(400)
+        expect(errResponse0b instanceof ActionDestinationErrorResponse && errResponse0b.value().errormessage).toEqual(
+          'Failed to resolve the Custom Object from the provided ObjectReferenceIdentifier [Id: a52c65d8-8938-f111-a5ab-d4f5ef4cd471, Key: ].'
+        )
+      })
+
+      it('should handle non-OK errors with empty resultMessages', async () => {
+        const events: SegmentEvent[] = [
+          createTestEvent({
+            type: 'track',
+            userId: 'user1',
+            properties: {
+              keys: { id: 'v1' },
+              values: { name: 'User 1' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user2',
+            properties: {
+              keys: { id: 'v2' },
+              values: { name: 'User 2' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user3',
+            properties: {
+              keys: { id: 'v3' },
+              values: { name: 'User 3' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user4',
+            properties: {
+              keys: { id: 'v4' },
+              values: { name: 'User 4' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user5',
+            properties: {
+              keys: { id: 'v5' },
+              values: { name: 'User 5' }
+            }
+          })
+        ]
+
+        // Mock async batch request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(400, {
+            requestId: undefined,
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events,
+          settings,
+          mapping: payload
+        })
+        expect(response.jobId).toBeUndefined()
+        const errResponse0c = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse0c.value().status).toBe(400)
+        expect(errResponse0c instanceof ActionDestinationErrorResponse && errResponse0c.value().errormessage).toEqual(
+          'SFMC API responded with {"resultMessages":[]}.'
+        )
+      })
+
+      it('should surface 401 status code in multi-status response', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(401, {
+            message: 'Not Authorized',
+            errorcode: 1,
+            documentation: ''
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events: [event],
+          settings,
+          mapping: payload
+        })
+
+        expect(response.jobId).toBeUndefined()
+        const errResponse = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse.value().status).toBe(401)
+        expect(errResponse instanceof ActionDestinationErrorResponse && errResponse.value().errormessage).toEqual(
+          'Not Authorized'
+        )
+      })
+
+      it('should surface 403 status code in multi-status response', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(403, {
+            message: 'Forbidden',
+            errorcode: 3,
+            documentation: ''
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events: [event],
+          settings,
+          mapping: payload
+        })
+
+        expect(response.jobId).toBeUndefined()
+        const errResponse = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse.value().status).toBe(403)
+        expect(errResponse instanceof ActionDestinationErrorResponse && errResponse.value().errormessage).toEqual(
+          'Forbidden'
+        )
+      })
+
+      it('should surface 500 status code in multi-status response', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(500, {
+            message: 'Internal Server Error',
+            documentation: ''
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events: [event],
+          settings,
+          mapping: payload
+        })
+
+        expect(response.jobId).toBeUndefined()
+        const errResponse = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse.value().status).toBe(500)
+        expect(errResponse instanceof ActionDestinationErrorResponse && errResponse.value().errormessage).toEqual(
+          'Internal Server Error'
+        )
+      })
+
+      it('should handle non-OK errors without resultMessages', async () => {
+        const events: SegmentEvent[] = [
+          createTestEvent({
+            type: 'track',
+            userId: 'user1',
+            properties: {
+              keys: { id: 'v1' },
+              values: { name: 'User 1' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user2',
+            properties: {
+              keys: { id: 'v2' },
+              values: { name: 'User 2' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user3',
+            properties: {
+              keys: { id: 'v3' },
+              values: { name: 'User 3' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user4',
+            properties: {
+              keys: { id: 'v4' },
+              values: { name: 'User 4' }
+            }
+          }),
+          createTestEvent({
+            type: 'track',
+            userId: 'user5',
+            properties: {
+              keys: { id: 'v5' },
+              values: { name: 'User 5' }
+            }
+          })
+        ]
+
+        // Mock async batch request
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .put(`/data/v1/async/dataextensions/${dataExtensionId}/rows`)
+          .reply(400, {
+            message: 'Parameter {id} is invalid.',
+            errorcode: 10001,
+            documentation: ''
+          })
+
+        const response = await testDestination.testAsyncBatchAction('asyncDataExtension', {
+          events,
+          settings,
+          mapping: payload
+        })
+        expect(response.jobId).toBeUndefined()
+        const errResponse0d = response.multiStatusResponse.getResponseAtIndex(0)
+        expect(errResponse0d.value().status).toBe(400)
+        expect(errResponse0d instanceof ActionDestinationErrorResponse && errResponse0d.value().errormessage).toEqual(
+          'Parameter {id} is invalid.'
+        )
+      })
+    })
+
+    describe('performPoll', () => {
+      const jobId = 'test-job-id'
+      const pollPayload = {
+        jobId,
+        uploadCount: 5
+      }
+
+      it('should return IN_PROGRESS when requestStatus is Pending', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: jobId,
+            status: { requestStatus: 'Pending', resultStatus: 'OK' },
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobId).toBe(jobId)
+        expect(response.jobStatus).toBe('IN_PROGRESS')
+      })
+
+      it('should return IN_PROGRESS when requestStatus is Executing', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: jobId,
+            status: { requestStatus: 'Executing', resultStatus: 'OK' },
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobId).toBe(jobId)
+        expect(response.jobStatus).toBe('IN_PROGRESS')
+      })
+
+      it('should return RETRYABLE_ERROR on 429 rate limit error', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(429, 'Too Many Requests')
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobStatus).toBe('RETRYABLE_ERROR')
+        expect(response.status).toBe(429)
+      })
+
+      it('should return RETRYABLE_ERROR on 500 server error', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(500, 'Internal Server Error')
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobStatus).toBe('RETRYABLE_ERROR')
+        expect(response.status).toBe(500)
+      })
+
+      it('should return SUCCEEDED with success count from uploadCount when Complete and OK', async () => {
+        // Only the lightweight status API is mocked. The heavyweight results API is intentionally
+        // not mocked, so if the destination were to call it the request would fail and this test would break.
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            status: {
+              callDateTime: '2024-07-11T22:19:02.04',
+              completionDateTime: '2024-07-11T22:19:03.97',
+              hasErrors: false,
+              pickupDateTime: '2024-07-11T22:19:03.567',
+              requestStatus: 'Complete',
+              resultStatus: 'OK',
+              requestId: '12260e92-b8cb-41ec-8c5a-116fb9d23eb4'
+            },
+            requestId: '615f178b-d380-440c-a650-defd99b1efde',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobId).toBe(jobId)
+        expect(response.jobStatus).toBe('SUCCEEDED')
+        expect(response.status).toBe(200)
+        // Success count is derived from the uploadCount passed into the poll payload, without
+        // calling the results API.
+        expect(response.multiStatusResponse).toBeDefined()
+        expect(response.multiStatusResponse?.successCount).toBe(pollPayload.uploadCount)
+        expect(response.multiStatusResponse?.errorCount).toBe(0)
+      })
+
+      it('should return SUCCEEDED with multiStatusResponse when Complete but Has Errors', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: jobId,
+            status: { requestStatus: 'Complete', resultStatus: 'Has Errors' },
+            resultMessages: []
+          })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/results`)
+          .reply(200, {
+            page: 1,
+            pageSize: 50,
+            count: 5,
+            items: [
+              {
+                errorCode: 2,
+                errors: [
+                  {
+                    errorMessage: 'Column [contactkey] does not allow null value.',
+                    name: 'contactkey',
+                    errorCode: 70001
+                  }
+                ],
+                message: 'Cannot locate the existing record. Required keys are missing.',
+                status: 'Error'
+              },
+              {
+                message: 'Upserted DataExtensionObject',
+                status: 'OK'
+              },
+              {
+                message: 'Upserted DataExtensionObject',
+                status: 'OK'
+              },
+              {
+                errorCode: 2,
+                errors: [
+                  {
+                    errorMessage: 'Column [contactkey] does not allow null value.',
+                    name: 'contactkey',
+                    errorCode: 70001
+                  }
+                ],
+                message: 'Cannot locate the existing record. Required keys are missing.',
+                status: 'Error'
+              }
+            ],
+            requestId: '424b760c-7410-4598-b977-ebf1d01b3555',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobStatus).toBe('SUCCEEDED')
+        expect(response.multiStatusResponse).toBeDefined()
+        expect(response.multiStatusResponse?.isErrorResponseAtIndex(0)).toBe(true)
+        expect(response.multiStatusResponse?.isSuccessResponseAtIndex(1)).toBe(true)
+        expect(response.multiStatusResponse?.isSuccessResponseAtIndex(2)).toBe(true)
+        expect(response.multiStatusResponse?.errorCount).toBe(2)
+        expect(response.multiStatusResponse?.successCount).toBe(2)
+      })
+
+      it('should return FAILED (not SUCCEEDED) when Complete but every record errored', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: jobId,
+            status: { requestStatus: 'Complete', resultStatus: 'Has Errors' },
+            resultMessages: []
+          })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/results`)
+          .reply(200, {
+            page: 1,
+            pageSize: 50,
+            count: 2,
+            items: [
+              {
+                errorCode: 2,
+                errors: [
+                  {
+                    errorMessage: 'Column [contactkey] does not allow null value.',
+                    name: 'contactkey',
+                    errorCode: 70001
+                  }
+                ],
+                message: 'Cannot locate the existing record. Required keys are missing.',
+                status: 'Error'
+              },
+              {
+                errorCode: 2,
+                errors: [
+                  {
+                    errorMessage: 'Column [contactkey] does not allow null value.',
+                    name: 'contactkey',
+                    errorCode: 70001
+                  }
+                ],
+                message: 'Cannot locate the existing record. Required keys are missing.',
+                status: 'Error'
+              }
+            ],
+            requestId: '424b760c-7410-4598-b977-ebf1d01b3555',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        // Regression test: jobStatus used to be hardcoded SUCCEEDED here even
+        // when every record failed, contradicting a successCount of 0.
+        expect(response.jobStatus).toBe('FAILED')
+        expect(response.multiStatusResponse?.errorCount).toBe(2)
+        expect(response.multiStatusResponse?.successCount).toBe(0)
+      })
+
+      // Regression test for the response-clone deadlock. The results payload carries one item
+      // per record, so a realistically-sized batch pushes it past the 16KB highWaterMark of the
+      // tee that response.clone() sets up in prepare-response. Without skipResponseCloning on
+      // the /results request, clone.text() never resolves and this test times out rather than
+      // failing an assertion -- which is exactly how it manifests in production, as a poll that
+      // hangs until the caller's deadline expires. A small fixture (like the test above) stays
+      // under the threshold and passes either way, so the large body here is load-bearing.
+      it('should not hang when the results payload is larger than the clone buffer', async () => {
+        const itemCount = 1640
+        const items = Array.from({ length: itemCount }, (_, i) =>
+          i % 2 === 0
+            ? {
+                errorCode: 2,
+                errors: [
+                  {
+                    errorMessage: 'Column [contactkey] does not allow null value.',
+                    name: 'contactkey',
+                    errorCode: 70001
+                  }
+                ],
+                message: 'Cannot locate the existing record. Required keys are missing.',
+                status: 'Error'
+              }
+            : { message: 'Upserted DataExtensionObject', status: 'OK' }
+        )
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: jobId,
+            status: { requestStatus: 'Complete', resultStatus: 'Has Errors' },
+            resultMessages: []
+          })
+
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/results`)
+          .reply(200, {
+            page: 1,
+            pageSize: itemCount,
+            count: itemCount,
+            items,
+            requestId: jobId,
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobStatus).toBe('SUCCEEDED')
+        expect(response.multiStatusResponse?.errorCount).toBe(itemCount / 2)
+        expect(response.multiStatusResponse?.successCount).toBe(itemCount / 2)
+      })
+
+      it('should return FAILED when requestStatus is Error', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            status: {
+              callDateTime: '2024-07-11T22:19:02.04',
+              completionDateTime: '2024-07-11T22:19:03.97',
+              hasErrors: false,
+              pickupDateTime: '2024-07-11T22:19:03.567',
+              requestStatus: 'Error',
+              resultStatus: 'OK',
+              requestId: '12260e92-b8cb-41ec-8c5a-116fb9d23eb4'
+            },
+            requestId: '615f178b-d380-440c-a650-defd99b1efde',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobId).toBe(jobId)
+        expect(response.jobStatus).toBe('FAILED')
+        expect(response.status).toBe(200)
+      })
+
+      it('should return FAILED when status object is missing in response', async () => {
+        nock(`https://${settings.subdomain}.rest.marketingcloudapis.com`)
+          .get(`/data/v1/async/${jobId}/status`)
+          .reply(200, {
+            requestId: '615f178b-d380-440c-a650-defd99b1efde',
+            resultMessages: []
+          })
+
+        const response = await testDestination.testAsyncPollAction('asyncDataExtension', {
+          pollPayload,
+          settings
+        })
+
+        expect(response.jobStatus).toBe('FAILED')
+        expect(response.status).toBe(200)
+      })
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/fields.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/fields.ts
@@ -31,6 +31,18 @@ export const fields = {
     default: 28000,
     maximum: 30000,
     unsafe_hidden: true
+  },
+  subscription_type: {
+    label: 'Subscription Type',
+    description: 'The type of subscription. Flag for enabling Async Pipeline.',
+    type: 'string' as const,
+    choices: [
+      { label: 'Sync', value: 'sync' },
+      { label: 'Async', value: 'async' }
+    ],
+    default: 'async',
+    required: false,
+    unsafe_hidden: true
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/generated-types.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/generated-types.ts
@@ -25,6 +25,10 @@ export interface Payload {
    * Maximum number of events to include in each batch. Actual batch sizes may be lower.
    */
   batch_size?: number
+  /**
+   * The type of subscription. Flag for enabling Async Pipeline.
+   */
+  subscription_type?: string
 }
 // Generated file. DO NOT MODIFY IT BY HAND.
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
@@ -73,7 +73,9 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
     try {
       const asyncUpsertResponse = await asyncUpsertRowsV2(request, settings.subdomain, payload, dataExtensionId, false)
 
-      // Set Job ID and HTTP status from API response. requestId is not guaranteed on error responses.
+      // Surface whatever requestId SFMC returns, regardless of HTTP status - SFMC can assign a
+      // requestId even on a rejected submission (e.g. a 400 with row-level validation messages),
+      // and callers rely on seeing it when present.
       response.jobId = asyncUpsertResponse.data.requestId
       response.status = asyncUpsertResponse.status
 
@@ -221,8 +223,9 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
         `https://${settings.subdomain}.rest.marketingcloudapis.com/data/v1/async/${payload.jobId}/results`,
         {
           method: 'GET',
-          // The results payload carries one item per failed record and routinely exceeds the
-          // 16KB highWaterMark of the tee that `response.clone()` sets up in prepare-response.
+          // The results payload carries one item per uploaded record (both 'OK' and 'Error'
+          // entries, in submission order), and routinely exceeds the 16KB highWaterMark of the
+          // tee that `response.clone()` sets up in prepare-response.
           // Reading only the clone while the original body goes unread deadlocks that tee, so
           // the request never settles and the caller's poll deadline expires instead. Same fix
           // and same root cause as the Iterable Lists hang (PR #2461).

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
@@ -3,10 +3,13 @@ import {
   AsyncActionDefinition,
   AsyncBatchResponse,
   IntegrationError,
+  APIError,
+  RetryableError,
   PollResponse,
-  HTTPError
+  HTTPError,
+  JSONLikeObject
 } from '@segment/actions-core'
-import { asyncUpsertRowsV2 } from '../sfmc-operations'
+import { asyncUpsertRowsV2, isAsyncUpsertRowsV2ErrorResponse } from '../sfmc-operations'
 import { fields, dynamicFields, hooks } from './fields'
 
 import type { Settings } from '../generated-types'
@@ -46,12 +49,6 @@ type AsyncUpsertRowsPollResultsResponse = {
   resultMessages: AsyncUpsertRowsPollResultMessage[]
 }
 
-type GenericAPIErrorResponse = {
-  documentation: string
-  errorcode: number
-  message: string
-}
-
 const asyncAction: AsyncActionDefinition<Settings, Payload> = {
   title: 'Send Event asynchronously to Data Extension',
   description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.`,
@@ -76,7 +73,7 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
     try {
       const asyncUpsertResponse = await asyncUpsertRowsV2(request, settings.subdomain, payload, dataExtensionId, false)
 
-      // Set Job ID and HTTP status from API response
+      // Set Job ID and HTTP status from API response. requestId is not guaranteed on error responses.
       response.jobId = asyncUpsertResponse.data.requestId
       response.status = asyncUpsertResponse.status
 
@@ -93,13 +90,13 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
         return response
       }
       // Handle batch level errors where the entire batch is rejected due to an error (401, 403, 500, etc)
-      else if ((asyncUpsertResponse.data as unknown as GenericAPIErrorResponse).message) {
+      else if (isAsyncUpsertRowsV2ErrorResponse(asyncUpsertResponse.data)) {
         for (let i = 0; i < payload.length; i++) {
           response.multiStatusResponse.setErrorResponseAtIndex(i, {
             status: asyncUpsertResponse.status,
-            errormessage: (asyncUpsertResponse.data as unknown as GenericAPIErrorResponse).message,
+            errormessage: asyncUpsertResponse.data.message,
             sent: JSON.stringify(payload[i]),
-            body: asyncUpsertResponse.data as unknown as GenericAPIErrorResponse
+            body: asyncUpsertResponse.data as Object as JSONLikeObject
           })
         }
 
@@ -130,12 +127,30 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
         }
         return response
       }
-    } catch (error) {
-      // Throw a generic non-retryable integration error for non HTTPError types
-      throw new IntegrationError(`Failed to upsert rows asynchronously: ${error.message}`, 'BAD_REQUEST', 400)
-    }
+    } catch (error: unknown) {
+      // Preserve the upstream status so 429/5xx get retried and other 4xx don't.
+      if (error instanceof HTTPError) {
+        const status = error.response?.status ?? 500
+        throw new APIError(`Failed to upsert rows asynchronously: ${error.message}`, status)
+      }
 
-    return response
+      // Network-level failures (timeouts, connection resets, DNS issues) are transient - retry them.
+      const code = error instanceof Error ? (error as Error & { code?: string }).code : undefined
+      const isRetryableNetworkError =
+        code === 'ETIMEDOUT' ||
+        code === 'ECONNRESET' ||
+        code === 'ECONNREFUSED' ||
+        code === 'EAI_AGAIN' ||
+        code === 'ENOTFOUND'
+      if (isRetryableNetworkError) {
+        throw new RetryableError(`Failed to upsert rows asynchronously: ${(error as Error).message}`)
+      }
+
+      // Anything else (unexpected/unclassified errors) is treated as non-retryable to avoid
+      // retrying deterministic bugs indefinitely.
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      throw new IntegrationError(`Failed to upsert rows asynchronously: ${message}`, 'BAD_REQUEST', 400)
+    }
   },
 
   performPoll: async (request, { settings, payload }) => {
@@ -246,7 +261,7 @@ const asyncAction: AsyncActionDefinition<Settings, Payload> = {
         return response
       }
 
-      // For 429 or 500 errors, set jobStatus to IN_PROGRESS as these errors typically indicate a temporary issue on SFMC's end
+      // For 429 or 500 errors, set jobStatus to RETRYABLE_ERROR as these errors typically indicate a temporary issue on SFMC's end
       if (error.response.status === 429 || error.response.status === 500) {
         response.status = error.response.status
         response.jobStatus = 'RETRYABLE_ERROR'

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/asyncDataExtension/index.async.ts
@@ -1,0 +1,264 @@
+import {
+  MultiStatusResponse,
+  AsyncActionDefinition,
+  AsyncBatchResponse,
+  IntegrationError,
+  PollResponse,
+  HTTPError
+} from '@segment/actions-core'
+import { asyncUpsertRowsV2 } from '../sfmc-operations'
+import { fields, dynamicFields, hooks } from './fields'
+
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+type AsyncUpsertRowsPollResultMessage = {
+  resultType: string
+  resultClass: string
+  resultCode: string
+  message: string
+}
+
+type AsyncUpsertRowsJobStatusResponse = {
+  status: {
+    callDateTime: string
+    completionDateTime: string
+    hasErrors: boolean
+    pickupDateTime: string
+    requestStatus: 'Complete' | 'Error' | 'Executing' | 'Pending'
+    resultStatus: 'OK' | 'Has Errors'
+    requestId: string
+  }
+  requestId: string
+  resultMessages: AsyncUpsertRowsPollResultMessage[]
+}
+
+type AsyncUpsertRowsPollResultsResponse = {
+  page: number
+  pageSize: number
+  count: number
+  items: {
+    errorCode?: number
+    message: string
+    status: 'OK' | 'Error'
+  }[]
+  requestId: string
+  resultMessages: AsyncUpsertRowsPollResultMessage[]
+}
+
+type GenericAPIErrorResponse = {
+  documentation: string
+  errorcode: number
+  message: string
+}
+
+const asyncAction: AsyncActionDefinition<Settings, Payload> = {
+  title: 'Send Event asynchronously to Data Extension',
+  description: `Upsert event records asynchronously as rows into a data extension in Salesforce Marketing Cloud.`,
+  fields,
+  dynamicFields,
+  hooks,
+
+  performBatch: async (request, { settings, payload, hookOutputs }) => {
+    const response: AsyncBatchResponse = {
+      multiStatusResponse: new MultiStatusResponse(),
+      jobId: undefined,
+      status: 200
+    }
+
+    const dataExtensionId: string =
+      hookOutputs?.onMappingSave?.outputs?.id || hookOutputs?.retlOnMappingSave?.outputs?.id
+
+    if (!dataExtensionId) {
+      throw new IntegrationError('No Data Extension Connected', 'INVALID_CONFIGURATION', 400)
+    }
+
+    try {
+      const asyncUpsertResponse = await asyncUpsertRowsV2(request, settings.subdomain, payload, dataExtensionId, false)
+
+      // Set Job ID and HTTP status from API response
+      response.jobId = asyncUpsertResponse.data.requestId
+      response.status = asyncUpsertResponse.status
+
+      // No HTTP errors, consider all rows as accepted for processing by SFMC
+      if (asyncUpsertResponse.ok) {
+        // Set MultiStatus Response as success
+        for (let i = 0; i < payload.length; i++) {
+          response.multiStatusResponse.setSuccessResponseAtIndex(i, {
+            status: 200,
+            sent: JSON.stringify(payload[i]),
+            body: {}
+          })
+        }
+        return response
+      }
+      // Handle batch level errors where the entire batch is rejected due to an error (401, 403, 500, etc)
+      else if ((asyncUpsertResponse.data as unknown as GenericAPIErrorResponse).message) {
+        for (let i = 0; i < payload.length; i++) {
+          response.multiStatusResponse.setErrorResponseAtIndex(i, {
+            status: asyncUpsertResponse.status,
+            errormessage: (asyncUpsertResponse.data as unknown as GenericAPIErrorResponse).message,
+            sent: JSON.stringify(payload[i]),
+            body: asyncUpsertResponse.data as unknown as GenericAPIErrorResponse
+          })
+        }
+
+        return response
+      }
+      // For other errors, check if SFMC returned any result messages in the response body
+      else if (asyncUpsertResponse.data.resultMessages && asyncUpsertResponse.data.resultMessages.length > 0) {
+        for (let i = 0; i < payload.length; i++) {
+          response.multiStatusResponse.setErrorResponseAtIndex(i, {
+            status: asyncUpsertResponse.status,
+            errormessage: asyncUpsertResponse?.data?.resultMessages[0]?.message ?? 'Unknown error',
+            sent: JSON.stringify(payload[i]),
+            body: {}
+          })
+        }
+
+        return response
+      } else {
+        // If no result messages are returned in the response body, surface the real HTTP status code
+        const errormessage = `SFMC API responded with ${JSON.stringify(asyncUpsertResponse.data)}.`
+        for (let i = 0; i < payload.length; i++) {
+          response.multiStatusResponse.setErrorResponseAtIndex(i, {
+            status: asyncUpsertResponse.status,
+            errormessage,
+            sent: JSON.stringify(payload[i]),
+            body: {}
+          })
+        }
+        return response
+      }
+    } catch (error) {
+      // Throw a generic non-retryable integration error for non HTTPError types
+      throw new IntegrationError(`Failed to upsert rows asynchronously: ${error.message}`, 'BAD_REQUEST', 400)
+    }
+
+    return response
+  },
+
+  performPoll: async (request, { settings, payload }) => {
+    const response: PollResponse = {
+      jobId: payload.jobId,
+      status: 200,
+      jobStatus: 'IN_PROGRESS'
+    }
+
+    try {
+      const statusResponse = await request<AsyncUpsertRowsJobStatusResponse>(
+        `https://${settings.subdomain}.rest.marketingcloudapis.com/data/v1/async/${payload.jobId}/status`,
+        {
+          method: 'GET',
+          // resultMessages is unbounded, so this response can cross the same clone-tee
+          // threshold as /results below and deadlock identically.
+          skipResponseCloning: true
+        }
+      )
+
+      // Set HTTP status from API response
+      response.status = statusResponse.status
+
+      // If the status object is not present in the response, this typically indicates an operation failure, eg: AsyncRequestStatusNotFound
+      if (!statusResponse.data.status) {
+        response.jobStatus = 'FAILED'
+        return response
+      }
+
+      // Return IN_PROGRESS status if SFMC indicates that the request is still being processed
+      if (
+        statusResponse.data.status.requestStatus === 'Pending' ||
+        statusResponse.data.status.requestStatus === 'Executing'
+      ) {
+        response.jobStatus = 'IN_PROGRESS'
+        return response
+      }
+
+      // Return FAILED status if SFMC indicates that the request has failed
+      if (statusResponse.data.status.requestStatus === 'Error') {
+        response.jobStatus = 'FAILED'
+        return response
+      }
+
+      // Check if the request is complete without any errors
+      if (statusResponse.data.status.requestStatus === 'Complete' && statusResponse.data.status.resultStatus === 'OK') {
+        response.jobStatus = 'SUCCEEDED'
+
+        // The lightweight status API confirms every uploaded record succeeded, so we avoid calling
+        // the heavyweight results API. Report the success count using the uploadCount passed into the poll.
+        response.multiStatusResponse = new MultiStatusResponse()
+        for (let i = 0; i < payload.uploadCount; i++) {
+          response.multiStatusResponse.setSuccessResponseAtIndex(i, {
+            status: 200,
+            sent: {},
+            body: 'OK'
+          })
+        }
+
+        return response
+      }
+
+      // If the control reaches here, it means the request is complete but has errors
+      // Fetch the results to get the granular error messages for failed records
+      response.multiStatusResponse = new MultiStatusResponse()
+
+      const resultsResponse = await request<AsyncUpsertRowsPollResultsResponse>(
+        `https://${settings.subdomain}.rest.marketingcloudapis.com/data/v1/async/${payload.jobId}/results`,
+        {
+          method: 'GET',
+          // The results payload carries one item per failed record and routinely exceeds the
+          // 16KB highWaterMark of the tee that `response.clone()` sets up in prepare-response.
+          // Reading only the clone while the original body goes unread deadlocks that tee, so
+          // the request never settles and the caller's poll deadline expires instead. Same fix
+          // and same root cause as the Iterable Lists hang (PR #2461).
+          skipResponseCloning: true
+        }
+      )
+
+      let successCount = 0
+      for (let i = 0; i < resultsResponse.data.items.length; i++) {
+        // If an individual record has an 'OK' status, consider it a success, otherwise consider it a failure and set the error message from the API response
+        if (resultsResponse.data.items[i].status === 'OK') {
+          successCount++
+          response.multiStatusResponse.setSuccessResponseAtIndex(i, {
+            status: 200,
+            sent: {},
+            body: 'OK'
+          })
+        } else {
+          response.multiStatusResponse.setErrorResponseAtIndex(i, {
+            status: 400,
+            errormessage: resultsResponse.data.items[i].message,
+            body: {}
+          })
+        }
+      }
+
+      // Only report SUCCEEDED if at least one record actually succeeded --
+      // otherwise this contradicts a success_count of 0 downstream.
+      response.jobStatus = successCount > 0 ? 'SUCCEEDED' : 'FAILED'
+
+      return response
+    } catch (error) {
+      if (!(error instanceof HTTPError)) {
+        response.status = 400
+        response.jobStatus = 'FAILED'
+        return response
+      }
+
+      // For 429 or 500 errors, set jobStatus to IN_PROGRESS as these errors typically indicate a temporary issue on SFMC's end
+      if (error.response.status === 429 || error.response.status === 500) {
+        response.status = error.response.status
+        response.jobStatus = 'RETRYABLE_ERROR'
+        return response
+      }
+
+      // For other HTTP errors, set jobStatus to FAILED
+      response.status = error.response.status
+      response.jobStatus = 'FAILED'
+      return response
+    }
+  }
+}
+
+export default asyncAction

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/index.ts
@@ -8,8 +8,15 @@ import apiEvent from './apiEvent'
 // These actions include an actions hook which handles configuring the connected
 // data extension. They are independent from the original actions to support a slow rollout.
 import dataExtensionV2 from './dataExtensionV2'
-import asyncDataExtension from './asyncDataExtension'
 import contactDataExtensionV2 from './contactDataExtensionV2'
+
+// Async Data Extension for standard centrifuge pipeline
+import asyncDataExtension from './asyncDataExtension/index'
+
+// Async Data Extension for async batch pipeline
+// IMPORTANT! Both versions have the exact same fields, so an explicit action-cli push is not required.
+import asyncDataExtensionAsyncPipeline from './asyncDataExtension/index.async'
+
 import { SALESFORCE_MARKETING_CLOUD_AUTH_API_VERSION } from './versioning-info'
 import { validateSubdomain } from './sfmc-operations'
 
@@ -88,6 +95,9 @@ const destination: DestinationDefinition<Settings> = {
     dataExtensionV2,
     contactDataExtensionV2,
     asyncDataExtension
+  },
+  asyncActions: {
+    asyncDataExtension: asyncDataExtensionAsyncPipeline
   }
 }
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/metadata.json
@@ -4573,6 +4573,39 @@
           "displayMode": null,
           "format": null,
           "additionalProperties": false
+        },
+        "subscription_type": {
+          "label": "Subscription Type",
+          "description": "The type of subscription. Flag for enabling Async Pipeline.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "async",
+          "choices": [
+            {
+              "label": "Sync",
+              "value": "sync"
+            },
+            {
+              "label": "Async",
+              "value": "async"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": null,
+          "hidden": true,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
         }
       }
     }

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -84,11 +84,22 @@ function isRetryableError(errData: ErrorData, status: number): boolean {
   )
 }
 
+type AsyncUpsertRowsV2Response = {
+  requestId: string
+  resultMessages: {
+    resultType: string
+    resultClass: string
+    resultCode: string
+    message: string
+  }[]
+}
+
 export async function asyncUpsertRowsV2(
   request: RequestClient,
   subdomain: String,
   payloads: payload_dataExtension[] | payload_contactDataExtension[],
-  dataExtensionId?: string
+  dataExtensionId?: string,
+  throwHttpErrors = true
 ) {
   if (!dataExtensionId) {
     throw new IntegrationError(
@@ -99,11 +110,12 @@ export async function asyncUpsertRowsV2(
   }
   // Use flattened rows for async API
   const rows = generateFlattenedRows(payloads)
-  const response = await request(
+  const response = await request<AsyncUpsertRowsV2Response>(
     `https://${subdomain}.rest.marketingcloudapis.com/data/v1/async/dataextensions/${dataExtensionId}/rows`,
     {
       method: 'PUT',
-      json: { items: rows }
+      json: { items: rows },
+      throwHttpErrors
     }
   )
 

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -84,19 +84,39 @@ function isRetryableError(errData: ErrorData, status: number): boolean {
   )
 }
 
-type AsyncUpsertRowsV2Response = {
-  requestId: string
-  resultMessages: {
-    resultType: string
-    resultClass: string
-    resultCode: string
-    message: string
-  }[]
+type AsyncUpsertRowsV2ResultMessage = {
+  resultType: string
+  resultClass: string
+  resultCode: string
+  message: string
+}
+
+// requestId is not guaranteed here: SFMC can reply with a resultMessages-shaped body
+// (no `message`) on a non-2xx status while still omitting requestId, e.g. AsyncRequestStatusNotFound.
+export type AsyncUpsertRowsV2SuccessResponse = {
+  requestId?: string
+  resultMessages: AsyncUpsertRowsV2ResultMessage[]
+}
+
+// Batch-level failures (401, 403, 500, etc) return this shape instead - a top-level
+// `message` and no (or empty) resultMessages.
+export type AsyncUpsertRowsV2ErrorResponse = {
+  requestId?: string
+  message: string
+  resultMessages?: AsyncUpsertRowsV2ResultMessage[]
+}
+
+export type AsyncUpsertRowsV2Response = AsyncUpsertRowsV2SuccessResponse | AsyncUpsertRowsV2ErrorResponse
+
+export function isAsyncUpsertRowsV2ErrorResponse(
+  data: AsyncUpsertRowsV2Response
+): data is AsyncUpsertRowsV2ErrorResponse {
+  return typeof (data as AsyncUpsertRowsV2ErrorResponse)?.message === 'string'
 }
 
 export async function asyncUpsertRowsV2(
   request: RequestClient,
-  subdomain: String,
+  subdomain: string,
   payloads: payload_dataExtension[] | payload_contactDataExtension[],
   dataExtensionId?: string,
   throwHttpErrors = true

--- a/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
+++ b/packages/destination-actions/src/destinations/salesforce-marketing-cloud/sfmc-operations.ts
@@ -135,7 +135,11 @@ export async function asyncUpsertRowsV2(
     {
       method: 'PUT',
       json: { items: rows },
-      throwHttpErrors
+      throwHttpErrors,
+      // The submission ack is small today (requestId + a short resultMessages array), but skip
+      // response cloning here too as insurance against the same clone-tee deadlock handled for
+      // /status and /results in index.async.ts, in case SFMC ever returns per-row detail here.
+      skipResponseCloning: true
     }
   )
 


### PR DESCRIPTION
This PR adds a new Async Action for SFMC.

## Testing

Testing completed successfully in staging.
Regression testing doc: https://docs.google.com/document/d/1xoKgX-sBfcpmfxwFGoMJFVc0s_hMHjgDJTnuZOlDchg/edit?tab=t.0#heading=h.cybsjpn3v09v

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
