### PR TITLE
fix(snap-conversions): send event_time in seconds behind feature flag

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
@@ -838,4 +838,56 @@ describe('Snap Conversions API ', () => {
       expect(user_data.sc_cookie1).toEqual((testEvent.integrations?.['Snap Conversions Api'] as any)?.uuid_c1)
     })
   })
+
+  describe('event_time normalization (snap-capi-event-time-in-seconds flag)', () => {
+    const FLAG = 'snap-capi-event-time-in-seconds'
+
+    it('emits milliseconds (13 digits) when the flag is OFF (default, unchanged behavior)', async () => {
+      const { data } = await reportConversionEvent({
+        mapping: { event_type: 'PURCHASE', event_conversion_type: 'WEB' }
+      })
+
+      // Date.parse('2022-05-12T15:21:15.449Z') === 1652368875449 (milliseconds)
+      expect(data.event_time).toEqual(1652368875449)
+    })
+
+    it('converts an ISO8601 timestamp to Unix seconds (10 digits) when the flag is ON', async () => {
+      const { data } = await reportConversionEvent({
+        features: { [FLAG]: true },
+        mapping: { event_type: 'PURCHASE', event_conversion_type: 'WEB' }
+      })
+
+      // 1652368875449 ms -> 1652368875 s
+      expect(data.event_time).toEqual(1652368875)
+    })
+
+    it('reproduces STRATCONN-6951: offline lead ms timestamp becomes valid seconds when ON', async () => {
+      const { data } = await reportConversionEvent({
+        event: { ...testEvent, timestamp: '2026-05-20T19:29:22.702Z' },
+        features: { [FLAG]: true },
+        mapping: { event_name: 'SIGN_UP', event_conversion_type: 'OFFLINE' }
+      })
+
+      // 1779305362702 ms (rejected by Snap as invalid) -> 1779305362 s (valid)
+      expect(data.event_time).toEqual(1779305362)
+    })
+
+    it('divides a numeric millisecond event_time (13 digits) to seconds when ON', async () => {
+      const { data } = await reportConversionEvent({
+        features: { [FLAG]: true },
+        mapping: { event_type: 'PURCHASE', event_conversion_type: 'WEB', event_time: '1652368875449' }
+      })
+
+      expect(data.event_time).toEqual(1652368875)
+    })
+
+    it('leaves a numeric second event_time (10 digits) untouched when ON', async () => {
+      const { data } = await reportConversionEvent({
+        features: { [FLAG]: true },
+        mapping: { event_type: 'PURCHASE', event_conversion_type: 'WEB', event_time: '1652368875' }
+      })
+
+      expect(data.event_time).toEqual(1652368875)
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 import { smartHash } from '../reportConversionEvent/utils'
+import { FLAGON_EVENT_TIME_IN_SECONDS } from '../reportConversionEvent/snap-capi-v3'
 
 const testDestination = createTestIntegration(Definition)
 
@@ -840,7 +841,7 @@ describe('Snap Conversions API ', () => {
   })
 
   describe('event_time normalization (snap-capi-event-time-in-seconds flag)', () => {
-    const FLAG = 'snap-capi-event-time-in-seconds'
+    const FLAG = FLAGON_EVENT_TIME_IN_SECONDS
 
     it('emits milliseconds (13 digits) when the flag is OFF (default, unchanged behavior)', async () => {
       const { data } = await reportConversionEvent({

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -1,4 +1,4 @@
-import { ExecuteInput, ModifiedResponse, RequestClient } from '@segment/actions-core'
+import { ExecuteInput, Features, ModifiedResponse, RequestClient } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import {
@@ -11,10 +11,16 @@ import {
   emptyStringToUndefined,
   parseNumberSafe,
   parseDateSafe,
+  normalizeToUnixSeconds,
   smartHash
 } from './utils'
 import { processHashing } from '../../../lib/hashing-utils'
 import { SNAP_CONVERSIONS_API_VERSION } from '../versioning-info'
+
+// When enabled, `event_time` is normalized to a Unix timestamp in seconds (10 digits) as
+// required by Snap's Conversions API, instead of the milliseconds (13 digits) produced by
+// `Date.parse`. Gated for safe rollout on this high-volume destination.
+export const FLAGON_EVENT_TIME_IN_SECONDS = 'snap-capi-event-time-in-seconds'
 
 const CURRENCY_ISO_4217_CODES = new Set([
   'USD',
@@ -607,7 +613,7 @@ const getSupportedActionSource = (action_source: string | undefined): string | u
     : undefined
 }
 
-const buildPayloadData = (payload: Payload, settings: Settings) => {
+const buildPayloadData = (payload: Payload, settings: Settings, features?: Features) => {
   // event_conversion_type is a required parameter whose value is enforced as
   // always OFFLINE, WEB, or MOBILE_APP, so in practice action_source will always have a value.
   const action_source =
@@ -624,7 +630,13 @@ const buildPayloadData = (payload: Payload, settings: Settings) => {
   // Handle the case where a number is passed instead of an ISO8601 timestamp
   const event_time_number = parseNumberSafe(payload_event_time ?? '')
   const event_time_date_time = parseDateSafe(payload_event_time ?? '')
-  const event_time = event_time_date_time ?? event_time_number
+  const event_time_raw = event_time_date_time ?? event_time_number
+  // Snap's Conversions API expects `event_time` in seconds. `Date.parse` yields milliseconds,
+  // which Snap rejects as an invalid Unix timestamp. Normalize to seconds when the flag is on.
+  const event_time =
+    features?.[FLAGON_EVENT_TIME_IN_SECONDS] && event_time_raw != null
+      ? normalizeToUnixSeconds(event_time_raw)
+      : event_time_raw
 
   const app_data = action_source === 'app' ? buildAppData(payload, settings) : undefined
   const user_data = buildUserData(payload)
@@ -733,9 +745,9 @@ export const performSnapCAPIv3 = async (
   request: RequestClient,
   data: ExecuteInput<Settings, Payload>
 ): Promise<ModifiedResponse<unknown>> => {
-  const { payload, settings } = data
+  const { payload, settings, features } = data
 
-  const payloadData = buildPayloadData(payload, settings)
+  const payloadData = buildPayloadData(payload, settings, features)
 
   validatePayload(payloadData)
   validateSettingsConfig(settings, payloadData.action_source)

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
@@ -70,8 +70,8 @@ export const parseDateSafe = (v: string | undefined): number | undefined => {
   return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
-// Snap's Conversions API expects `event_time` as a Unix timestamp in SECONDS (10 digits).
-// `Date.parse` (and some upstream sources) produce MILLISECONDS (13 digits), which Snap's
+// Snap's Conversions API expects `event_time` as a Unix timestamp in seconds (e.g. 1777819609).
+// `Date.parse` (and some upstream sources) produce milliseconds (e.g. 1777819609520), which Snap's
 // offline endpoint interprets as seconds far in the future and rejects with
 // "Param data['event_time'] is an invalid Unix timestamp." Normalize milliseconds to seconds
 // while leaving values already in seconds untouched.

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/utils.ts
@@ -70,6 +70,20 @@ export const parseDateSafe = (v: string | undefined): number | undefined => {
   return Number.isSafeInteger(parsed) ? parsed : undefined
 }
 
+// Snap's Conversions API expects `event_time` as a Unix timestamp in SECONDS (10 digits).
+// `Date.parse` (and some upstream sources) produce MILLISECONDS (13 digits), which Snap's
+// offline endpoint interprets as seconds far in the future and rejects with
+// "Param data['event_time'] is an invalid Unix timestamp." Normalize milliseconds to seconds
+// while leaving values already in seconds untouched.
+//
+// Any value >= 1e12 is treated as milliseconds: 1e12 ms is 2001-09-09, whereas a seconds
+// timestamp does not reach 1e12 until the year 33658 — so modern seconds and milliseconds
+// timestamps never overlap this threshold.
+const MILLISECONDS_THRESHOLD = 1e12
+
+export const normalizeToUnixSeconds = (timestamp: number): number =>
+  timestamp >= MILLISECONDS_THRESHOLD ? Math.floor(timestamp / 1000) : Math.floor(timestamp)
+
 export const smartHash = (
   value: string | undefined,
   cleaningFunction?: (value: string) => string


### PR DESCRIPTION
## Summary

Fixes **STRATCONN-6951**. Events from `crunchfitness` / `offline_leads_prod` to the Snapchat Conversions API (`actions-snap-conversions`) fail delivery with:

```
400 { "status": "INVALID", "error_msgs": ["Param data['event_time'] is an invalid Unix timestamp."] }
```

**Root cause:** `event_time` defaults to the event `timestamp` (ISO‑8601), which the destination parses with `Date.parse()` → **milliseconds** (13 digits, e.g. `1779305362702`). Snap's **OFFLINE** endpoint interprets `event_time` as **seconds** (10 digits), so a millisecond value resolves to a year far in the future and is rejected. Verified against a real failing payload: `Date.parse("2026-05-20T19:29:22.702Z")` = `1779305362702`; the valid value is `1779305362`.

The millisecond behavior has existed since the v3 implementation (Apr 2024). It only surfaces as a hard 400 on the offline (RETL) path — the web/app pixel path tolerates milliseconds — which is why it presented as a single-customer issue rather than a fleet-wide regression (the downstream Snap‑400 metric is flat over the last 45 days).

## Change

- New `normalizeToUnixSeconds()` in `reportConversionEvent/utils.ts`: divides by 1000 only when the value is `>= 1e12` (milliseconds), leaving values already in seconds untouched (no double‑division for customers who pass a 10‑digit numeric `event_time`).
- `buildPayloadData()` applies it, gated behind the feature flag **`snap-capi-event-time-in-seconds`** (default **off**), threaded through from `performSnapCAPIv3` via `data.features`.
- Flag **off** preserves current behavior — no change for existing customers. Gated for safe rollout on this high‑volume destination.

## Note for the customer / rollout

These are **backfilled** offline leads (the sampled event is ~90 days old). Snap's offline attribution window is ~37 days, so months‑old events may still be rejected after this fix — but with a **different** error (out‑of‑window), not "invalid Unix timestamp." This PR resolves the timestamp‑format rejection only.

## Testing

- [x] Added unit tests for new functionality
- [ ] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.

Unit tests added in `_tests_/index.test.ts` covering: flag off (milliseconds, regression guard), flag on (ISO → seconds), the STRATCONN‑6951 offline repro (`1779305362702` → `1779305362`), and both numeric paths (13‑digit → converted, 10‑digit → untouched). All 25 snap‑conversions tests pass. No new/changed fields, so no breaking change.

### Stage testing

#### Failure case

#### Success case
```
{
  "body": {
    "data": [
      {
        "action_source": "website",
        "event_id": "022bb90c-bbac-11e4-8dfc-aa07a5b093db",
        "event_name": "PURCHASE",
        "event_source_url": "https://segment.com/docs/connections/spec/common/",
        "event_time": 1786334911,
        "integration": "segment",
        "user_data": {
          "client_ip_address": "8.8.8.8",
          "client_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
          "external_id": [
            "f676a029005e48e2e87a1dfaa2c01b8d51d2d021978228decbf19fe152d21c73"
          ]
        }
      }
    ]
  },
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip,deflate",
    "Authorization": "REDACTED",
    "Connection": "close",
    "Content-Length": "502",
    "Content-Type": "application/json",
    "Host": "tr.snapchat.com",
    "User-Agent": "REDACTED"
  }
}

{
  "body": {
    "reason": "Events have been processed successfully.",
    "status": "VALID"
  },
  "headers": {
    "Alt-Svc": "h3=\":443\"; ma=2592000",
    "Connection": "close",
    "Content-Length": "70",
    "Content-Type": "application/json",
    "Date": "Mon, 24 Aug 2026 09:09:53 GMT",
    "Server": "API Gateway",
    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload, max-age=31536000; includeSubDomains",
    "Via": "1.1 google",
    "X-Envoy-Upstream-Service-Time": "3"
  }
}
```
<img width="1805" height="794" alt="Screenshot 2026-08-24 at 2 41 29 PM" src="https://github.com/user-attachments/assets/6b4f58e8-1eff-4ab5-a898-f0f477a944b8" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)