### PR TITLE
Change browser destination publish trigger from Publish to Release

### DIFF
--- a/.github/workflows/publish-browser-destinations.yml
+++ b/.github/workflows/publish-browser-destinations.yml
@@ -1,5 +1,5 @@
 # Short-term workflow for producing browser destination artifacts independently
-# from npm package publishing. Both workflows start concurrently on Publish pushes.
+# from npm package publishing. Both workflows start concurrently on Release pushes.
 name: Publish Browser Destination Workflow
 
 on:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   detect-browser-destination-changes:
-    if: startsWith(github.event.head_commit.message, 'Publish') == true
+    if: startsWith(github.event.head_commit.message, 'Release') == true
     runs-on: ubuntu-latest-large
     permissions:
       actions: read
@@ -33,7 +33,7 @@ jobs:
         run: |
           previous_publish=''
           while IFS=$'\t' read -r commit subject; do
-            if [[ "$subject" == Publish* ]]; then
+            if [[ "$subject" == Release* ]]; then
               previous_publish="$commit"
               break
             fi


### PR DESCRIPTION
## Summary
Changes the commit-message trigger for the browser destination publish workflow from `Publish` to `Release`.

In `.github/workflows/publish-browser-destinations.yml`:
- Job `if` guard: `startsWith(..., 'Publish')` → `startsWith(..., 'Release')`
- Previous-publish detection in the change-detection script: `Publish*` → `Release*` (kept consistent so diff detection still finds the prior release commit)
- Header comment updated to match

## Testing
No functional code changed — workflow YAML only. Triggers now fire on commit messages starting with `Release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)