### PR TITLE
Release

### DIFF
--- a/packages/browser-destinations/destinations/moengage-web/package.json
+++ b/packages/browser-destinations/destinations/moengage-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-moengage-web",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/browser-destinations/destinations/wingify/package.json
+++ b/packages/browser-destinations/destinations/wingify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-wingify",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/destinations-manifest",
-  "version": "1.170.0",
+  "version": "1.171.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -43,7 +43,7 @@
     "@segment/analytics-browser-actions-jimo": "^1.98.0",
     "@segment/analytics-browser-actions-koala": "^1.109.0",
     "@segment/analytics-browser-actions-logrocket": "^1.108.0",
-    "@segment/analytics-browser-actions-moengage-web": "^1.16.0",
+    "@segment/analytics-browser-actions-moengage-web": "^1.17.0",
     "@segment/analytics-browser-actions-ms-bing-capi": "^1.21.0",
     "@segment/analytics-browser-actions-pendo-web-actions": "^1.98.0",
     "@segment/analytics-browser-actions-playerzero": "^1.107.0",
@@ -59,11 +59,11 @@
     "@segment/analytics-browser-actions-userpilot": "^1.108.0",
     "@segment/analytics-browser-actions-utils": "^1.107.0",
     "@segment/analytics-browser-actions-vwo": "^1.111.0",
+    "@segment/analytics-browser-actions-wingify": "^1.2.0",
     "@segment/analytics-browser-actions-wiseops": "^1.108.0",
     "@segment/analytics-browser-appcues-web-actions": "^1.15.0",
     "@segment/analytics-browser-hubble-web": "^1.93.0",
     "@segment/analytics-browser-mixpanel-web-actions": "^1.19.0",
-    "@segment/analytics-browser-actions-wingify": "^1.1.0",
     "@segment/browser-destination-runtime": "^1.106.0"
   }
 }


### PR DESCRIPTION
This PR was opened by action-cli's trigger-action-destinations-publish command.
Merging it bumps package versions ahead of an internal-only NPM Artifactory publish.

# Changed packages
- packages/browser-destinations/destinations/moengage-web/package.json
- packages/browser-destinations/destinations/wingify/package.json
- packages/destinations-manifest/package.json