### PR TITLE
STRATCONN-6834 - [Mixpanel] - correcting a bug with token fallback

### DIFF
--- a/packages/destination-actions/src/destinations/mixpanel/common/__test__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/common/__test__/utils.test.ts
@@ -1,4 +1,5 @@
-import { getBrowser, getBrowserVersion } from '../utils'
+import { getBrowser, getBrowserVersion, getImportApiCredential, FLAGS } from '../utils'
+import { Settings } from '../../generated-types'
 
 const userAgentToBrowserTestCase = [
   {
@@ -50,5 +51,30 @@ describe('Mixpanel Browser Utility Functions', () => {
     it(`return undefined for unknown browser`, () => {
       expect(getBrowserVersion(`unknown userAgent Version/118.0`)).toBeUndefined()
     })
+  })
+})
+
+describe('getImportApiCredential', () => {
+  const settings: Settings = {
+    projectToken: 'my-project-token',
+    apiSecret: 'my-api-secret'
+  }
+
+  it('returns projectToken when the PROJECT_TOKEN_AUTH flag is on, even if apiSecret is set', () => {
+    expect(getImportApiCredential(settings, { [FLAGS.PROJECT_TOKEN_AUTH]: true })).toEqual('my-project-token')
+  })
+
+  it('returns apiSecret when the flag is off and apiSecret is set', () => {
+    expect(getImportApiCredential(settings)).toEqual('my-api-secret')
+  })
+
+  it('falls back to projectToken when apiSecret is undefined', () => {
+    const noSecretSettings: Settings = { projectToken: 'my-project-token' }
+    expect(getImportApiCredential(noSecretSettings)).toEqual('my-project-token')
+  })
+
+  it('falls back to projectToken when apiSecret is an empty string', () => {
+    const emptySecretSettings: Settings = { projectToken: 'my-project-token', apiSecret: '' }
+    expect(getImportApiCredential(emptySecretSettings)).toEqual('my-project-token')
   })
 })

--- a/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
@@ -20,7 +20,11 @@ export function getImportApiCredential(settings: Settings, features?: Features):
   if (features && features[FLAGS.PROJECT_TOKEN_AUTH]) {
     return settings.projectToken
   }
-  return settings.apiSecret || settings.projectToken
+  // Settings may provide an empty string for apiSecret; treat that as missing and fall back to
+  // the project token. This is intentionally more specific than `??`.
+  return typeof settings.apiSecret === 'string' && settings.apiSecret.length > 0
+    ? settings.apiSecret
+    : settings.projectToken
 }
 
 export enum StrictMode {

--- a/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
+++ b/packages/destination-actions/src/destinations/mixpanel/common/utils.ts
@@ -20,7 +20,7 @@ export function getImportApiCredential(settings: Settings, features?: Features):
   if (features && features[FLAGS.PROJECT_TOKEN_AUTH]) {
     return settings.projectToken
   }
-  return settings.apiSecret ?? settings.projectToken
+  return settings.apiSecret || settings.projectToken
 }
 
 export enum StrictMode {


### PR DESCRIPTION
Fixes a bug with Mixpanel where lack of a apiSecret is not falling back properly to project token. 
This affects 0 customers as all customers have apiSecret values, but it will become a problem as we start to migrate customers over to using only project tokens. 

## Testing

Tested locally with Mixpanel team on a video call. 
- `settings.apiSecret ?? settings.projectToken` failed when apiSecret was not present but projectToken was present. 
- `settings.apiSecret || settings.projectToken` passed when apiSecret was not present but projectToken was present.  

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
