### PR TITLE
Release

### DIFF
--- a/packages/browser-destinations/destinations/mixpanel-web/package.json
+++ b/packages/browser-destinations/destinations/mixpanel-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-mixpanel-web-actions",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.516.0",
+  "version": "3.517.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/destinations-manifest",
-  "version": "1.171.0",
+  "version": "1.172.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -63,7 +63,7 @@
     "@segment/analytics-browser-actions-wiseops": "^1.108.0",
     "@segment/analytics-browser-appcues-web-actions": "^1.15.0",
     "@segment/analytics-browser-hubble-web": "^1.93.0",
-    "@segment/analytics-browser-mixpanel-web-actions": "^1.19.0",
+    "@segment/analytics-browser-mixpanel-web-actions": "^1.20.0",
     "@segment/browser-destination-runtime": "^1.106.0"
   }
 }


### PR DESCRIPTION
This PR was opened by action-cli's trigger-action-destinations-publish command.
Merging it bumps package versions ahead of an internal-only NPM Artifactory publish.

# Changed packages
- packages/browser-destinations/destinations/mixpanel-web/package.json
- packages/destination-actions/package.json
- packages/destinations-manifest/package.json