### PR TITLE
Update merchant authentication to handle multiple merchants on one Segment instance

### DIFF
--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
@@ -1,9 +1,16 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-import type { DecoratedResponse } from '@segment/actions-core'
+import type { DecoratedResponse, RequestClient } from '@segment/actions-core'
 import Destination from '../index'
 
-import { defaultMapiBaseUrl, resetAuthCache } from '../cloudUtil'
+import {
+  AUTH_CACHE_MAX_ENTRIES,
+  AUTH_CACHE_MAX_ENTRY_LENGTH,
+  authCacheSize,
+  defaultMapiBaseUrl,
+  getAuthToken,
+  resetAuthCache
+} from '../cloudUtil'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -65,7 +72,7 @@ function trackPurchase(
     event: purchaseEvent(orderId),
     settings,
     useDefaultMappings: true
-  }) as Promise<DecoratedResponse[]>
+  })
 }
 
 describe('Friendbuy cloud auth token cache', () => {
@@ -141,5 +148,84 @@ describe('Friendbuy cloud auth token cache', () => {
     await expect(trackPurchase('order-x', merchantB)).rejects.toThrowError(
       'Friendbuy MAPI authorization did not return a token.'
     )
+  })
+})
+
+function stubAuthRequest(token = 'stub-token') {
+  const keys: string[] = []
+  const request = ((_url: string, options: { json: { key: string } }) => {
+    keys.push(options.json.key)
+    return Promise.resolve({ data: { token, expires: expires() } })
+  }) as unknown as RequestClient
+  return { request, keys }
+}
+
+describe('Friendbuy cloud auth cache bounds', () => {
+  beforeEach(() => {
+    resetAuthCache()
+  })
+
+  test('never grows beyond 1000 entries', async () => {
+    const { request } = stubAuthRequest()
+
+    for (let i = 0; i < AUTH_CACHE_MAX_ENTRIES + 500; i++) {
+      await getAuthToken(request, defaultMapiBaseUrl, `key-${i}`, 'secret')
+    }
+
+    expect(authCacheSize()).toBeLessThanOrEqual(1000)
+  })
+
+  test('evicts the oldest entry rather than the newest', async () => {
+    const { request, keys } = stubAuthRequest()
+
+    for (let i = 0; i <= AUTH_CACHE_MAX_ENTRIES; i++) {
+      await getAuthToken(request, defaultMapiBaseUrl, `key-${i}`, 'secret')
+    }
+    const authCalls = keys.length
+
+    // key-0 was pushed out, so it has to re-authenticate.
+    await getAuthToken(request, defaultMapiBaseUrl, 'key-0', 'secret')
+    expect(keys.length).toBe(authCalls + 1)
+
+    // The most recent entry is still cached.
+    await getAuthToken(request, defaultMapiBaseUrl, `key-${AUTH_CACHE_MAX_ENTRIES}`, 'secret')
+    expect(keys.length).toBe(authCalls + 1)
+  })
+
+  test('does not cache a key longer than the maximum entry length', async () => {
+    const { request, keys } = stubAuthRequest()
+    const longBaseUrl = `https://mapi.fbot-${'e'.repeat(AUTH_CACHE_MAX_ENTRY_LENGTH)}.me`
+
+    const token = await getAuthToken(request, longBaseUrl, 'key-long', 'secret')
+    await getAuthToken(request, longBaseUrl, 'key-long', 'secret')
+
+    // Still authenticates and returns a usable token; it just isn't retained.
+    expect(token).toBe('stub-token')
+    expect(keys.length).toBe(2)
+    expect(authCacheSize()).toBe(0)
+  })
+
+  test('does not cache a token longer than the maximum entry length', async () => {
+    const oversizedToken = 't'.repeat(AUTH_CACHE_MAX_ENTRY_LENGTH + 1)
+    const { request, keys } = stubAuthRequest(oversizedToken)
+
+    const token = await getAuthToken(request, defaultMapiBaseUrl, merchantA.authKey, merchantA.authSecret)
+    await getAuthToken(request, defaultMapiBaseUrl, merchantA.authKey, merchantA.authSecret)
+
+    expect(token).toBe(oversizedToken)
+    expect(keys.length).toBe(2)
+    expect(authCacheSize()).toBe(0)
+  })
+
+  test('caches an entry at exactly the maximum length', async () => {
+    const { request, keys } = stubAuthRequest()
+    // Boundary is inclusive, so a key of exactly the limit is still kept.
+    const authKey = 'k'.repeat(AUTH_CACHE_MAX_ENTRY_LENGTH - `${defaultMapiBaseUrl}|`.length)
+
+    await getAuthToken(request, defaultMapiBaseUrl, authKey, 'secret')
+    await getAuthToken(request, defaultMapiBaseUrl, authKey, 'secret')
+
+    expect(keys.length).toBe(1)
+    expect(authCacheSize()).toBe(1)
   })
 })

--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
@@ -1,0 +1,142 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import type { DecoratedResponse } from '@segment/actions-core'
+import Destination from '../index'
+
+import { defaultMapiBaseUrl, resetAuthCache } from '../cloudUtil'
+
+const testDestination = createTestIntegration(Destination)
+
+const merchantA = { authKey: 'aaaaaaaa-0000-4000-8000-000000000001', authSecret: 'secret-a' }
+const merchantB = { authKey: 'bbbbbbbb-0000-4000-8000-000000000002', authSecret: 'secret-b' }
+
+const tokenA = 'token-for-merchant-a'
+const tokenB = 'token-for-merchant-b'
+
+const expires = () => new Date(Date.now() + 300 * 1000).toISOString()
+
+// One token per credential, so a token served to the wrong merchant is obvious.
+function nockAuthFor(baseUrl: string, authKey: string, token: string) {
+  nock(baseUrl)
+    .post('/v1/authorization', (body: { key?: string }) => body.key === authKey)
+    .reply(200, { token, expires: expires() })
+}
+
+function nockPurchase(baseUrl: string, times = 1) {
+  nock(baseUrl).post('/v1/event/purchase').times(times).reply(200, {})
+}
+
+function purchaseEvent(orderId: string) {
+  return createTestEvent({
+    type: 'track',
+    event: 'Order Completed',
+    userId: 'customer-1',
+    properties: { order_id: orderId, total: 10, currency: 'USD' },
+    timestamp: '2021-10-05T15:30:35Z'
+  })
+}
+
+function requestsTo(responses: DecoratedResponse[], path: string) {
+  return responses.filter((response) => response.request.url.includes(path))
+}
+
+/** The bearer token the purchase call actually went out with. */
+function purchaseAuthToken(responses: DecoratedResponse[]) {
+  const [purchase] = requestsTo(responses, '/v1/event/purchase')
+  if (!purchase) {
+    throw new Error('no purchase request was made')
+  }
+  const headers = purchase.options.headers as Record<string, string> | Headers | undefined
+  if (headers && typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get('authorization')
+  }
+  return (headers as Record<string, string>)?.Authorization
+}
+
+function authCallCount(responses: DecoratedResponse[]) {
+  return requestsTo(responses, '/v1/authorization').length
+}
+
+function trackPurchase(orderId: string, settings: { authKey: string; authSecret: string }) {
+  return testDestination.testAction('trackPurchase', {
+    event: purchaseEvent(orderId),
+    settings,
+    useDefaultMappings: true
+  })
+}
+
+describe('Friendbuy cloud auth token cache', () => {
+  beforeEach(() => {
+    resetAuthCache()
+    nock.cleanAll()
+  })
+
+  test('does not reuse one merchant’s token for another merchant', async () => {
+    nockAuthFor(defaultMapiBaseUrl, merchantA.authKey, tokenA)
+    nockAuthFor(defaultMapiBaseUrl, merchantB.authKey, tokenB)
+    nockPurchase(defaultMapiBaseUrl, 2)
+
+    const resultA = await trackPurchase('order-a', merchantA)
+    const resultB = await trackPurchase('order-b', merchantB)
+
+    // Unkeyed, B's purchase went out under A's token and MAPI filed it to A.
+    expect(purchaseAuthToken(resultA)).toBe(tokenA)
+    expect(purchaseAuthToken(resultB)).toBe(tokenB)
+  })
+
+  test('reuses a cached token for the same credential', async () => {
+    // Only one authorization response is stubbed; a second call would not match.
+    nockAuthFor(defaultMapiBaseUrl, merchantA.authKey, tokenA)
+    nockPurchase(defaultMapiBaseUrl, 2)
+
+    const first = await trackPurchase('order-1', merchantA)
+    const second = await trackPurchase('order-2', merchantA)
+
+    expect(authCallCount(first)).toBe(1)
+    expect(authCallCount(second)).toBe(0)
+    expect(purchaseAuthToken(second)).toBe(tokenA)
+  })
+
+  test('keeps the cached token when only the secret is rotated', async () => {
+    nockAuthFor(defaultMapiBaseUrl, merchantA.authKey, tokenA)
+    nockPurchase(defaultMapiBaseUrl, 2)
+
+    await trackPurchase('order-1', merchantA)
+
+    // Deliberate: the issued token still resolves to the same merchant, which is
+    // all this cache has to protect.
+    const afterRotation = await trackPurchase('order-2', { ...merchantA, authSecret: 'secret-a-rotated' })
+
+    expect(authCallCount(afterRotation)).toBe(0)
+    expect(purchaseAuthToken(afterRotation)).toBe(tokenA)
+  })
+
+  test('keys the cache by environment as well as credential', async () => {
+    const stagingBaseUrl = 'https://mapi.fbot-staging.me'
+    const stagingToken = 'token-for-staging'
+
+    nockAuthFor(defaultMapiBaseUrl, merchantA.authKey, tokenA)
+    nockPurchase(defaultMapiBaseUrl)
+    nockAuthFor(stagingBaseUrl, merchantA.authKey, stagingToken)
+    nockPurchase(stagingBaseUrl)
+
+    await trackPurchase('order-prod', merchantA)
+
+    // An `environment:` prefix means a different host, which must not get the prod token.
+    const staging = await trackPurchase('order-staging', {
+      ...merchantA,
+      authSecret: `staging:${merchantA.authSecret}`
+    })
+
+    expect(purchaseAuthToken(staging)).toBe(stagingToken)
+  })
+
+  test('throws rather than falling back when authorization returns no token', async () => {
+    nock(defaultMapiBaseUrl).post('/v1/authorization').reply(200, {})
+    nockPurchase(defaultMapiBaseUrl)
+
+    await expect(trackPurchase('order-x', merchantB)).rejects.toThrowError(
+      'Friendbuy MAPI authorization did not return a token.'
+    )
+  })
+})

--- a/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/__tests__/cloudUtil.test.ts
@@ -57,12 +57,15 @@ function authCallCount(responses: DecoratedResponse[]) {
   return requestsTo(responses, '/v1/authorization').length
 }
 
-function trackPurchase(orderId: string, settings: { authKey: string; authSecret: string }) {
+function trackPurchase(
+  orderId: string,
+  settings: { authKey: string; authSecret: string }
+): Promise<DecoratedResponse[]> {
   return testDestination.testAction('trackPurchase', {
     event: purchaseEvent(orderId),
     settings,
     useDefaultMappings: true
-  })
+  }) as Promise<DecoratedResponse[]>
 }
 
 describe('Friendbuy cloud auth token cache', () => {

--- a/packages/destination-actions/src/destinations/friendbuy/cloudUtil.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/cloudUtil.ts
@@ -1,4 +1,4 @@
-import { JSONObject, RequestClient, RequestOptions } from '@segment/actions-core'
+import { JSONObject, RequestClient, RequestOptions, RetryableError } from '@segment/actions-core'
 
 import { Settings } from './generated-types'
 
@@ -39,32 +39,76 @@ export async function createMapiRequest(
 
 const AUTH_PADDING_MS = 10000 // 10 seconds
 
+// Workers are long-lived, so the cache needs a ceiling.
+const AUTH_CACHE_MAX_ENTRIES = 1000
+
 interface FriendbuyAuth {
   token: string
   expiresEpoch: number
 }
 
-let friendbuyAuth: FriendbuyAuth
+// Keyed per credential: a shared slot sends one merchant's token with another's events.
+const authCache = new Map<string, FriendbuyAuth>()
 
-export async function getAuthToken(request: RequestClient, mapiBaseUrl: string, authKey: string, authSecret: string) {
-  // Refresh the token if necessary.
-  if (!friendbuyAuth || Date.now() >= friendbuyAuth.expiresEpoch) {
-    const r = await request(`${mapiBaseUrl}/v1/authorization`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      json: { key: authKey, secret: authSecret }
-    })
+// Base URL is in the key because an `environment:` prefix repoints the same key at another host.
+function authCacheKey(mapiBaseUrl: string, authKey: string) {
+  return `${mapiBaseUrl}|${authKey}`
+}
 
-    if (r.data) {
-      const data = r.data as { token: string; expires: string }
-      friendbuyAuth = {
-        token: data.token,
-        expiresEpoch: Date.parse(data.expires) - AUTH_PADDING_MS
-      }
+function pruneAuthCache() {
+  const now = Date.now()
+  for (const [key, auth] of authCache) {
+    if (now >= auth.expiresEpoch) {
+      authCache.delete(key)
     }
   }
+  // Map iterates in insertion order, so the first key is the oldest.
+  while (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+    const oldest = authCache.keys().next()
+    if (oldest.done) {
+      break
+    }
+    authCache.delete(oldest.value)
+  }
+}
 
-  return friendbuyAuth.token
+/** Clears the cache; module state outlives a single test. */
+export function resetAuthCache() {
+  authCache.clear()
+}
+
+export async function getAuthToken(request: RequestClient, mapiBaseUrl: string, authKey: string, authSecret: string) {
+  const cacheKey = authCacheKey(mapiBaseUrl, authKey)
+
+  const cached = authCache.get(cacheKey)
+  if (cached && Date.now() < cached.expiresEpoch) {
+    return cached.token
+  }
+
+  const r = await request(`${mapiBaseUrl}/v1/authorization`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    json: { key: authKey, secret: authSecret }
+  })
+
+  const data = r.data as { token?: string; expires?: string } | undefined
+  if (!data?.token || !data.expires) {
+    // A rejected credential already threw an HTTPError above, so a 2xx without a
+    // token is service-side, not the merchant's to fix.
+    throw new RetryableError('Friendbuy MAPI authorization did not return a token.')
+  }
+
+  if (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+    pruneAuthCache()
+  }
+
+  // A malformed `expires` gives NaN, which compares false above and forces re-auth.
+  authCache.set(cacheKey, {
+    token: data.token,
+    expiresEpoch: Date.parse(data.expires) - AUTH_PADDING_MS
+  })
+
+  return data.token
 }

--- a/packages/destination-actions/src/destinations/friendbuy/cloudUtil.ts
+++ b/packages/destination-actions/src/destinations/friendbuy/cloudUtil.ts
@@ -40,7 +40,11 @@ export async function createMapiRequest(
 const AUTH_PADDING_MS = 10000 // 10 seconds
 
 // Workers are long-lived, so the cache needs a ceiling.
-const AUTH_CACHE_MAX_ENTRIES = 1000
+export const AUTH_CACHE_MAX_ENTRIES = 1000
+
+// The `environment:` prefix and the token are both external input, so bound the
+// per-entry size too; an oversized entry still authenticates, it just isn't kept.
+export const AUTH_CACHE_MAX_ENTRY_LENGTH = 256
 
 interface FriendbuyAuth {
   token: string
@@ -72,9 +76,18 @@ function pruneAuthCache() {
   }
 }
 
+function isCacheable(cacheKey: string, token: string) {
+  return cacheKey.length <= AUTH_CACHE_MAX_ENTRY_LENGTH && token.length <= AUTH_CACHE_MAX_ENTRY_LENGTH
+}
+
 /** Clears the cache; module state outlives a single test. */
 export function resetAuthCache() {
   authCache.clear()
+}
+
+/** Exposed so the cache ceiling can be asserted directly. */
+export function authCacheSize() {
+  return authCache.size
 }
 
 export async function getAuthToken(request: RequestClient, mapiBaseUrl: string, authKey: string, authSecret: string) {
@@ -100,15 +113,17 @@ export async function getAuthToken(request: RequestClient, mapiBaseUrl: string, 
     throw new RetryableError('Friendbuy MAPI authorization did not return a token.')
   }
 
-  if (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
-    pruneAuthCache()
-  }
+  if (isCacheable(cacheKey, data.token)) {
+    if (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+      pruneAuthCache()
+    }
 
-  // A malformed `expires` gives NaN, which compares false above and forces re-auth.
-  authCache.set(cacheKey, {
-    token: data.token,
-    expiresEpoch: Date.parse(data.expires) - AUTH_PADDING_MS
-  })
+    // A malformed `expires` gives NaN, which compares false above and forces re-auth.
+    authCache.set(cacheKey, {
+      token: data.token,
+      expiresEpoch: Date.parse(data.expires) - AUTH_PADDING_MS
+    })
+  }
 
   return data.token
 }


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

Previously a single merchant authentication was cached, causing the same token to be used for multiple merchants when running on the same instance. This update sets a cached token per merchant.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)

leaving this unchecked as this is not a new destination
