### PR TITLE
LinkedIn Conversions: clarify the conversion rule hook label and unlinked-rule error

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-conversions/metadata.json
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/metadata.json
@@ -18,8 +18,8 @@
       "syncMode": null,
       "hooks": {
         "onMappingSave": {
-          "label": "Create a Conversion Rule",
-          "description": "When saving this mapping, we will create a conversion rule in LinkedIn using the fields you provided.\n To configure: either provide an existing conversion rule ID or fill in the fields below to create a new conversion rule.",
+          "label": "Link or Create a Conversion Rule",
+          "description": "Links this mapping to a LinkedIn conversion rule. Events cannot be delivered until this step completes. If you already have a conversion rule, enter its ID in \"Existing Conversion Rule ID\" and we will use that rule — this will not create a duplicate in LinkedIn. Otherwise, leave that field blank and fill in the details below, and we will create a new rule for you.",
           "inputFields": {
             "adAccountId": {
               "label": "Ad Account",

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-import { DynamicFieldResponse } from '@segment/actions-core'
 import { BASE_URL, FLAGON_NAME, LINKEDIN_API_VERSION, LINKEDIN_CANARY_API_VERSION } from '../../constants'
 import Destination from '../../index'
 
@@ -512,6 +511,51 @@ describe('LinkedinConversions.streamConversion', () => {
     ).rejects.toThrowError('One of email or LinkedIn UUID or Acxiom ID or Oracle ID is required.')
   })
 
+  it('should throw an actionable error when no conversion rule is linked to the mapping', async () => {
+    await expect(
+      testDestination.testAction('streamConversion', {
+        event,
+        settings,
+        mapping: {
+          email: { '@path': '$.context.traits.email' },
+          conversionHappenedAt: {
+            '@path': '$.timestamp'
+          },
+          enable_batching: true,
+          batch_size: 5000
+        }
+      })
+    ).rejects.toThrowError(
+      'No conversion rule is linked to this mapping. Open the mapping and click "Create a Conversion Rule" to link one. If you have already entered an existing Conversion Rule ID, this will link that rule and will not create a duplicate in LinkedIn.'
+    )
+  })
+
+  // Asserts a prefix of the error message intentionally: the test above owns its exact wording.
+  it('should throw an actionable error when hook inputs were saved but the hook never produced outputs', async () => {
+    await expect(
+      testDestination.testAction('streamConversion', {
+        event,
+        settings,
+        mapping: {
+          email: { '@path': '$.context.traits.email' },
+          conversionHappenedAt: {
+            '@path': '$.timestamp'
+          },
+          // The mapping is saved with the user's hook inputs but no outputs, which is the state
+          // produced when the mapping is saved without running the 'Create a Conversion Rule' hook.
+          onMappingSave: {
+            inputs: {
+              adAccountId: 'urn:li:sponsoredAccount:12345',
+              conversionRuleId: '20812604'
+            }
+          },
+          enable_batching: true,
+          batch_size: 5000
+        }
+      })
+    ).rejects.toThrowError('No conversion rule is linked to this mapping.')
+  })
+
   it('should normalize the user ID email field such that uppercase letters are converted to lowercase', async () => {
     nock(`${BASE_URL}/conversionEvents`)
       .post('', {
@@ -661,7 +705,7 @@ describe('LinkedinConversions.dynamicField', () => {
 
     const dynamicFn =
       testDestination.actions.streamConversion.definition.hooks?.onMappingSave?.inputFields?.conversionRuleId.dynamic
-    const responses = (await testDestination.testDynamicField(
+    const responses = await testDestination.testDynamicField(
       'streamConversion',
       'conversionId',
       {
@@ -669,7 +713,7 @@ describe('LinkedinConversions.dynamicField', () => {
         payload
       },
       dynamicFn
-    )) as DynamicFieldResponse
+    )
 
     expect(responses).toMatchObject({
       choices: [],
@@ -689,7 +733,7 @@ describe('LinkedinConversions.dynamicField', () => {
 
     const dynamicFn =
       testDestination.actions.streamConversion.definition.hooks?.onMappingSave?.inputFields?.campaignId.dynamic
-    const responses = (await testDestination.testDynamicField(
+    const responses = await testDestination.testDynamicField(
       'streamConversion',
       'campaignId',
       {
@@ -697,7 +741,7 @@ describe('LinkedinConversions.dynamicField', () => {
         payload
       },
       dynamicFn
-    )) as DynamicFieldResponse
+    )
 
     expect(responses).toMatchObject({
       choices: [],

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/__tests__/index.test.ts
@@ -526,7 +526,7 @@ describe('LinkedinConversions.streamConversion', () => {
         }
       })
     ).rejects.toThrowError(
-      'No conversion rule is linked to this mapping. Open the mapping and click "Create a Conversion Rule" to link one. If you have already entered an existing Conversion Rule ID, this will link that rule and will not create a duplicate in LinkedIn.'
+      'No conversion rule is linked to this mapping. Open the mapping and click "Link or Create a Conversion Rule" to link one. If you have already entered an existing Conversion Rule ID, this will link that rule and will not create a duplicate in LinkedIn.'
     )
   })
 

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -7,12 +7,18 @@ import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from './gener
 import { LinkedInError } from '../types'
 
 /**
+ * Rendered as the button text for this hook in the mapping editor, and quoted in the error below so the two cannot
+ * drift apart. Update this constant rather than either usage.
+ */
+const CONVERSION_RULE_HOOK_LABEL = 'Link or Create a Conversion Rule'
+
+/**
  * Entering an ID in the 'Existing Conversion Rule ID' field is not enough on its own: the conversion rule is only
- * linked to the mapping once the 'Create a Conversion Rule' hook runs and stores its output. Saving the mapping does
- * not run the hook, so the field can look correctly filled in while no rule is actually linked.
+ * linked to the mapping once the hook runs and stores its output. Saving the mapping does not run the hook, so the
+ * field can look correctly filled in while no rule is actually linked.
  */
 const NO_CONVERSION_RULE_LINKED_ERROR =
-  'No conversion rule is linked to this mapping. Open the mapping and click "Create a Conversion Rule" to link one. ' +
+  `No conversion rule is linked to this mapping. Open the mapping and click "${CONVERSION_RULE_HOOK_LABEL}" to link one. ` +
   'If you have already entered an existing Conversion Rule ID, this will link that rule and will not create a duplicate in LinkedIn.'
 
 const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs, OnMappingSaveOutputs> = {
@@ -21,7 +27,7 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
   defaultSubscription: 'type = "track"',
   hooks: {
     onMappingSave: {
-      label: 'Link or Create a Conversion Rule',
+      label: CONVERSION_RULE_HOOK_LABEL,
       description:
         'Links this mapping to a LinkedIn conversion rule. Events cannot be delivered until this step completes. ' +
         'If you already have a conversion rule, enter its ID in "Existing Conversion Rule ID" and we will use that ' +

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -21,9 +21,12 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
   defaultSubscription: 'type = "track"',
   hooks: {
     onMappingSave: {
-      label: 'Create a Conversion Rule',
+      label: 'Link or Create a Conversion Rule',
       description:
-        'When saving this mapping, we will create a conversion rule in LinkedIn using the fields you provided.\n To configure: either provide an existing conversion rule ID or fill in the fields below to create a new conversion rule.',
+        'Links this mapping to a LinkedIn conversion rule. Events cannot be delivered until this step completes. ' +
+        'If you already have a conversion rule, enter its ID in "Existing Conversion Rule ID" and we will use that ' +
+        'rule — this will not create a duplicate in LinkedIn. Otherwise, leave that field blank and fill in the ' +
+        'details below, and we will create a new rule for you.',
       inputFields: {
         adAccountId: {
           label: 'Ad Account',

--- a/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-conversions/streamConversion/index.ts
@@ -6,6 +6,15 @@ import { CONVERSION_TYPE_OPTIONS, SUPPORTED_LOOKBACK_WINDOW_CHOICES, DEPENDS_ON_
 import type { Payload, OnMappingSaveInputs, OnMappingSaveOutputs } from './generated-types'
 import { LinkedInError } from '../types'
 
+/**
+ * Entering an ID in the 'Existing Conversion Rule ID' field is not enough on its own: the conversion rule is only
+ * linked to the mapping once the 'Create a Conversion Rule' hook runs and stores its output. Saving the mapping does
+ * not run the hook, so the field can look correctly filled in while no rule is actually linked.
+ */
+const NO_CONVERSION_RULE_LINKED_ERROR =
+  'No conversion rule is linked to this mapping. Open the mapping and click "Create a Conversion Rule" to link one. ' +
+  'If you have already entered an existing Conversion Rule ID, this will link that rule and will not create a duplicate in LinkedIn.'
+
 const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs, OnMappingSaveOutputs> = {
   title: 'Stream Conversion Event',
   description: 'Directly streams conversion events to a specific conversion rule.',
@@ -334,7 +343,7 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
     }
 
     if (!conversionRuleId) {
-      throw new PayloadValidationError('Conversion Rule ID is required.')
+      throw new PayloadValidationError(NO_CONVERSION_RULE_LINKED_ERROR)
     }
 
     const linkedinApiClient: LinkedInConversions = new LinkedInConversions(request)
@@ -351,7 +360,7 @@ const action: ActionDefinition<Settings, Payload, undefined, OnMappingSaveInputs
     const conversionRuleId = hookOutputs?.onMappingSave?.outputs?.id
 
     if (!conversionRuleId) {
-      throw new PayloadValidationError('Conversion Rule ID is required.')
+      throw new PayloadValidationError(NO_CONVERSION_RULE_LINKED_ERROR)
     }
 
     linkedinApiClient.setConversionRuleId(conversionRuleId)


### PR DESCRIPTION
Improves two user-facing strings in the LinkedIn Conversions API destination. No behaviour changes.

### Background

The Stream Conversion Event action reads the conversion rule ID only from the persisted `onMappingSave` hook output. Entering a value in the "Existing Conversion Rule ID" hook input is not sufficient on its own — the hook has to run for that value to be stored where delivery reads it. A mapping can therefore be saved with the field visibly populated while no rule is actually linked, and every event then fails with `400: Conversion Rule ID is required`. That message contradicts what the user is looking at and offers no way forward.

Reproducible on `main`: enter an existing Conversion Rule ID, press Save without pressing the hook button, send a test event.

### Changes

**1. The error message.** Replaced `Conversion Rule ID is required.` with one that states no rule is linked, names the button that fixes it, and notes that supplying an existing ID links that rule rather than duplicating it. Extracted to a shared constant so the `perform` and `performBatch` sites cannot drift.

**2. The hook label and description.** The hook's `label` is rendered as the button text in the mapping editor, so `Create a Conversion Rule` was the only thing users saw. It names one of the operations the hook performs, and not the common one: supplying an existing Conversion Rule ID short-circuits to a `GET`, so the rule is looked up and linked, never created. Users understandably decline to press "Create" for a rule they already have. Renamed to `Link or Create a Conversion Rule`, consistent with the existing `Create or Select Data Extension` precedent for Salesforce Marketing Cloud.

The description opened with "When saving this mapping, we will create a conversion rule", which is not what happens and contradicted its own second sentence. Replaced with an accurate summary.

Deliberately **not** claimed: that the existing rule is left untouched. `bulkAssociateCampaignToConversion` runs on every successful path including the lookup path, so campaigns selected in the card are associated to the rule.

### Also included

Two redundant `DynamicFieldResponse` casts and the now-unused import were removed from the test file. These are auto-removed by the `eslint --fix` pass in `lint-staged`, which otherwise fails the pre-commit hook for anyone editing this file.

### Not addressed here

The underlying cause is app-side: the mapping editor saves a hook-using mapping with no hook outputs and reports success, and its hardcoded copy tells users to click Save to run the hook. Being raised separately, as it affects every destination using `onMappingSave`.

## Testing

- [x] Added unit tests for new functionality
- [ ] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

#### Stage Testing

Clearer Title and description
<img width="708" height="488" alt="Screenshot 2026-08-25 at 1 10 45 PM" src="https://github.com/user-attachments/assets/5af24d2b-5fef-4a41-b56d-01316193e4ae" />

Clearer Error Message
<img width="673" height="344" alt="Screenshot 2026-08-25 at 1 06 17 PM" src="https://github.com/user-attachments/assets/6e50d953-dca6-4431-9e51-8a7efde85f0f" />

Successfully Sent Event after linking ID
<img width="1135" height="742" alt="Screenshot 2026-08-25 at 1 11 05 PM" src="https://github.com/user-attachments/assets/1d978978-a292-43c4-a1a6-e993283712fc" />



Two tests added covering the missing-hook-output case and the inputs-saved-without-outputs case. All 59 tests across the four `linkedin-conversions` suites pass.

Note: the local server (`./bin/run serve`) cannot exercise this path — the CLI dev server returns hook results over HTTP and discards them, so hook output persistence is not reproducible locally.

Backward compatibility: only string literals and one display label change. No field definitions, no request shapes, no new required fields. The hook key remains `onMappingSave`, so existing mappings are unaffected.

## Security Review

- [x] **Reviewed all field definitions** for sensitive data and confirmed they use `type: 'password'` — no field definitions were changed by this PR.
