### PR TITLE
[steward] version upgrade for destination google-enhanced-conversions

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
@@ -3,7 +3,7 @@
  * API reference: https://developers.google.com/google-ads/api/docs/upgrade
  */
 export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v22'
-export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v22'
+export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v23'
 
 /** GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION
  * Google Ads event API version.


### PR DESCRIPTION
Opened automatically by the Connector Steward pipeline (prototype) for the destination "google-enhanced-conversions" in Segment Action Destinations (cloud-mode).

Trigger: manual (Check whether the Google Ads API version this destination pins is current, and whether it is deprecated or scheduled for sunset. Report only what you can verify from the code and Google's public Google Ads API documentation. Do not create files outside the working directory and do not save fetched documentation to disk.)

Agent's plan:

## Findings

**Current code state** (`versioning-info.ts` at repo root of the sandbox, i.e. `packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts`):
```ts
export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v22'
export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v22'
```
Both the live and canary constants are already equal, at `v22` — no canary is currently in flight. `functions.ts` confirms the single-source-of-truth pattern: `getApiVersion()` picks between `API_VERSION`/`CANARY_API_VERSION` based on flagon flag `google-enhanced-canary-version` (`FLAGON_NAME`), and every action (`uploadClickConversion`, `uploadClickConversion2`, `uploadCallConversion`, `uploadCallConversion2`, `uploadConversionAdjustment`, `uploadConversionAdjustment2`) builds its request URL via `getApiVersion(...)`, so the literal version string genuinely lives only in `versioning-info.ts`. (`postConversion` uses a separate, unrelated `GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION = 'v1'` for a different Google endpoint, not the Ads API — out of scope here.)

**Verified against Google's public docs** (developers.google.com/google-ads/api/docs/sunset-dates and .../docs/upgrade, fetched live, not cached to disk):
- Sandbox clock is 2026-08-26.
- v21 is explicitly noted as already sunset.
- v22 (the version this destination pins) released 2025-10-15, with a **tentative sunset of October 2026** — about five weeks from today.
- Google has already released v23 (2026-01-28), v23.1, v23.2, v24, v24.1, v24.2, and v25 (2026-07-22, the current latest). So v22 is now the *oldest* still-supported version and is several majors behind.
- The v22→v23 proto diff (Added 34 / Removed 0 / Changed 56) shows no removal of anything under `services/conversion_upload_service`, `services/offline_user_data_job_service`, or `services/google_ads_service` methods this destination depends on for click/call conversions, conversion adjustments, or user lists — the changed list is dominated by unrelated resources (campaign, ad_group, asset, etc.) and one enum (`conversion_action_category.proto`). This is a reasonable first data point but should be re-verified in detail (including the v23 release notes text, not just the proto diff table) before shipping.

## Conclusion

The trigger's premise is correct: the pinned Google Ads API version (v22) is not current, is several versions behind the latest released version (v25), and is approaching its own tentative sunset (~Oct 2026, about 5 weeks out). No canary is currently in progress (both constants are still equal at v22), so the two-step process needs to start from scratch.

ACTION_NEEDED: true

**Plan for whoever implements this (fresh checkout, path: `packages/destination-actions/src/destinations/google-enhanced-conversions/`):**

1. **Canary step only — do not touch the live constant in this change.**
   - File: `versioning-info.ts`
   - Change:
     ```ts
     export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v22'                 // unchanged
     export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v23'          // v22 -> v23
     ```
   - Leave `GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION = 'v1'` untouched (unrelated endpoint).

2. **Check for field-level breakage before shipping the canary**, even though the proto diff table for v22→v23 shows no removals:
   - Read the actual v23 release notes (`https://developers.google.com/google-ads/api/docs/release-notes#v23-2026-01-28`) for any behavioral/field changes to `ConversionUploadService`, `ConversionAdjustmentUploadService`, `OfflineUserDataJobService`, or `GoogleAdsService` (used by `uploadClickConversion`, `uploadClickConversion2`, `uploadCallConversion`, `uploadCallConversion2`, `uploadConversionAdjustment`, `uploadConversionAdjustment2`, `userList`).
   - If any request/response field used in these actions' payload schemas or `generated-types.ts` was renamed/removed, update the corresponding action's field mappings and regenerate `generated-types.ts` (`yarn generate:types` or repo's standard type-gen command) and adjust the `__tests__` snapshots/fixtures under each action's `__tests__` folder (e.g. `uploadClickConversion.test.ts`, `uploadCallConversion2.test.ts`, etc.) to match any changed request/response shape.

3. **Run and update tests** with the corrected flag: `yarn cloud jest --testPathPatterns=google-enhanced-conversions` (note: `--testPathPattern` is deprecated in favor of `--testPathPatterns`). Confirm the canary-flag tests in `__tests__/functions.test.ts` (which set `'google-enhanced-canary-version': true`) exercise the new `v23` value and pass.

4. **Ship** this canary-only change, then enable the flagon flag `google-enhanced-canary-version` for a slice of traffic to route to v23, and monitor for errors from Google Ads API (schema/validation errors, deprecation warnings).

5. **Only after the canary is verified clean**, promote by bumping `GOOGLE_ENHANCED_CONVERSIONS_API_VERSION` to `'v23'` in a separate follow-up commit (leaving `CANARY_API_VERSION` at `'v23'` too, matching), and repeat the same canary→live cycle for the subsequent releases (v23 → v23.1/v23.2 → v24 → v25, etc.) to close the multi-version gap before the tentative October 2026 sunset of v22 — treat each major bump as its own canary/live pair rather than jumping straight to v25.

Review carefully before merging — these are agent-generated changes to real code, with no human review yet applied.