### PR TITLE
feat(facebook-custom-audiences): Upgrade Graph API canary to v26.0

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/versioning-info.ts
@@ -7,5 +7,6 @@ export const FACEBOOK_CUSTOM_AUDIENCES_API_VERSION = 'v24.0'
 /** FACEBOOK_CUSTOM_AUDIENCES_CANARY_API_VERSION
  * Facebook Custom Audiences API canary version.
  * API reference: https://developers.facebook.com/docs/marketing-api/audiences/guides/custom-audiences
+ * Testing v26.0 behind the 'facebook-custom-audience-actions-canary-version' feature flag. v24.0 is sunset by Meta on 2026-10-06.
  */
-export const FACEBOOK_CUSTOM_AUDIENCES_CANARY_API_VERSION = 'v24.0'
+export const FACEBOOK_CUSTOM_AUDIENCES_CANARY_API_VERSION = 'v26.0'


### PR DESCRIPTION
## Summary

Meta is sunsetting Graph API **v24.0** on **2026-10-06**. Upgrades the `facebook-custom-audiences` destination's canary version from **v24.0** to **v26.0**, deployed behind the existing feature flag `facebook-custom-audience-actions-canary-version`.

Jira: [STRATCONN-6972](https://twilio-engineering.atlassian.net/browse/STRATCONN-6972) (parent: [STRATCONN-6959](https://twilio-engineering.atlassian.net/browse/STRATCONN-6959))

Sibling PR for the same parent ticket: #3977 (`facebook-conversions-api` → v26.0)

## Changes

### Version Management
- ✅ Updated `versioning-info.ts` canary constant: `v24.0` → `v26.0` (stable remains `v24.0`)
- ✅ Reused existing `getApiVersion(features, statsContext)` helper and `FLAGON_NAME = 'facebook-custom-audience-actions-canary-version'` — this destination already has the canary-flag pattern in place from a prior version upgrade, so no code changes were needed beyond the version constant.

### Testing
- ✅ All existing tests pass (they reference `API_VERSION`/`CANARY_API_VERSION` dynamically, not hardcoded strings)
- ✅ Existing `__tests__/canary.test.ts` already covers both stable and canary paths for `sync`, `createAudience`, and `getAudience`
- ✅ Test results: **9 suites passed, 97 tests passed**
- ✅ Lint: clean

[Stage Testing Document](https://docs.google.com/document/d/1cIgM_q4AkrUHmyl0UQULs0TVxhbP6HTJw2SpXlJHQYA/edit?tab=t.hb5fruckckq1)

## Breaking Changes Analysis: v24.0 → v26.0

**No breaking changes identified** for v25.0 or v26.0 affecting this destination's usage of `POST {ad_account_id}/customaudiences` (create), `GET {audience_id}` / `GET {ad_account_id}/customaudiences` (get/list), or `POST|DELETE {audience_id}/users` (add/remove members) — including the request schema (`name`, `subtype`, `customer_file_source`, `description`, `payload.schema`/`payload.data`) and response shape (`id`, `audience_id`, `num_received`, `num_invalid_entries`, `invalid_entry_samples`).

### Critical Breaking Changes
None identified.

### Non-Breaking Changes (informational, not applicable to this destination)
- **v25.0**: Insights API metric deprecations (Page/Post/Video/Stories) — not used here.
- **v25.0**: `metadata=1` query parameter deprecated on node queries — not used here.
- **v25.0**: Async ad-report job error fields expanded (`error_code` type `uint`→`int`, +4 fields) — this destination doesn't use the ad-insights/reports API.
- **v25.0**: Webhooks mTLS CA transition (by 2026-03-31) — this destination doesn't consume webhooks.
- **v26.0**: Commerce Order Management API fully deprecated (47 endpoints) — unrelated API surface.
- **v26.0**: Graph API protocol cleanup — `pretty`/`debug` params ignored, `date_format` now errors, legacy `GET /?ids=...` removed, `ETag`/`304 Not Modified` removed. None of these are used by this destination's request pattern.
- **v26.0**: Marketing/creative surface deprecations (Messenger Stories, Poll ads, Instagram Explore Feed placement, HEC-F targeting flag), Rights Manager and New Pages Experience field deprecations — all unrelated to Custom Audiences.
- Docs note (Sep 2025) that `operation_status` can return `471` for a Custom Audience flagged as suggesting health/financial status — an existing possible response value; the destination doesn't special-case `operation_status` codes today and doesn't need to for this upgrade. Flagged for awareness only.

### Deprecation Warnings
None applicable to this destination.

### Testing Requirements
- Confirm feature-flag toggle correctly switches the version segment in the request URL between stable (`v24.0`) and canary (`v26.0`) — covered by `canary.test.ts`.
- Manually smoke test against a real Meta test ad account with the flag on/off before promoting canary to stable — no automated `__validation__/validate.ts` script exists for this destination and no test credentials were available in this environment, so this step is deferred to manual verification (see Testing Plan).

## Testing Plan

### Manual Testing Required
- [ ] Test with feature flag disabled (stable v24.0)
- [ ] Test with feature flag enabled (canary v26.0) against a real Facebook test ad account
- [ ] Verify no regression in `sync` action (upsert/mirror/delete modes) and the `retlOnMappingSave` hook (create/connect audience)

### Automated Testing
- [x] Unit tests passing (97/97)
- [ ] Real-endpoint structural diff validation (Step 5.5) — skipped, no validation script or test credentials available in this environment.

## Rollout Plan

1. Merge PR, feature flag off by default (stable stays on v24.0)
2. Enable flag for internal testing against v26.0
3. Gradual rollout to a subset of customers
4. Promote canary (v26.0) to stable once validated — must land before 2026-10-06 sunset
5. Remove feature flag and clean up v24.0 references

## Risk Assessment

**Risk Level**: LOW — no request/response schema changes identified for the endpoints this destination calls. Feature flag allows instant rollback. Stable version is untouched until the canary is validated.

## Additional Notes

The canary-flag infrastructure (`versioning-info.ts`, `getApiVersion()`, `FACEBOOK_CUSTOM_AUDIENCE_FLAGON`, and the `canary.test.ts` suite) already existed in this destination from a prior version upgrade, so this PR is purely a version-constant bump plus the breaking-changes review above — no new code paths were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STRATCONN-6972]: https://twilio-engineering.atlassian.net/browse/STRATCONN-6972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRATCONN-6959]: https://twilio-engineering.atlassian.net/browse/STRATCONN-6959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ