### PR TITLE
[Amplitude-Plugins] Merge into integrations['Actions Amplitude'] instead of replacing it

### DIFF
--- a/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/__tests__/sessionId.test.ts
+++ b/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/__tests__/sessionId.test.ts
@@ -112,6 +112,100 @@ describe('ajs-integration', () => {
     expect(typeof updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBe('number')
   })
 
+  test('preserves caller supplied options on the Actions Amplitude entry', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        All: false,
+        // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+        'Actions Amplitude': { subscriptionId: 'sub-123' },
+        Split: true
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(typeof updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBe('number')
+    // @ts-expect-error
+    expect(updatedCtx?.event.integrations['Actions Amplitude']?.subscriptionId).toBe('sub-123')
+    expect(updatedCtx?.event.integrations?.Split).toBe(true)
+    expect(updatedCtx?.event.integrations?.All).toBe(false)
+  })
+
+  test('keeps the rest of the allowlist intact when All: false but Actions Amplitude: true', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        All: false,
+        'Actions Amplitude': true,
+        Split: true
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(typeof updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBe('number')
+    expect(updatedCtx?.event.integrations['Actions Amplitude']).toBeTruthy()
+    expect(updatedCtx?.event.integrations?.Split).toBe(true)
+    expect(updatedCtx?.event.integrations?.All).toBe(false)
+  })
+
+  test('sets a session id when the Actions Amplitude entry is null', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+        'Actions Amplitude': null
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+
+    // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+    expect(typeof updatedCtx?.event.integrations['Actions Amplitude']?.session_id).toBe('number')
+  })
+
+  test('sets a session id that survives serialization when the Actions Amplitude entry is an array', async () => {
+    await sessionIdPlugin.load(Context.system(), ajs)
+
+    const ctx = new Context({
+      type: 'track',
+      event: 'greet',
+      properties: {
+        greeting: 'Oi!'
+      },
+      integrations: {
+        // @ts-expect-error Need to fix ajs-next types to allow for complex objects in `integrations`
+        'Actions Amplitude': []
+      }
+    })
+
+    const updatedCtx = await sessionIdPlugin.track?.(ctx)
+    const serialized = JSON.parse(JSON.stringify(updatedCtx?.event))
+
+    expect(typeof serialized.integrations['Actions Amplitude']?.session_id).toBe('number')
+  })
+
   test('doesnt update the original event with a session id when All: false', async () => {
     await sessionIdPlugin.load(Context.system(), ajs)
 

--- a/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts
+++ b/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts
@@ -145,8 +145,13 @@ const action: BrowserActionDefinition<Settings, {}, Payload> = {
     storage.set('analytics_session_id.last_access', newSession)
 
     if (context.event.integrations?.All !== false || context.event.integrations['Actions Amplitude']) {
-      context.updateEvent('integrations.Actions Amplitude', {})
-      context.updateEvent('integrations.Actions Amplitude.session_id', id)
+      const configured: unknown = context.event.integrations?.['Actions Amplitude']
+      const existing =
+        configured !== null && typeof configured === 'object' && !Array.isArray(configured)
+          ? (configured as Record<string, unknown>)
+          : {}
+
+      context.updateEvent('integrations.Actions Amplitude', { ...existing, session_id: id })
     }
 
     return


### PR DESCRIPTION
The `sessionId` plugin replaces the caller's `integrations['Actions Amplitude']` value before writing `session_id`, so anything the caller put there is discarded.

`packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts`:

```ts
if (context.event.integrations?.All !== false || context.event.integrations['Actions Amplitude']) {
  context.updateEvent('integrations.Actions Amplitude', {})   // <- replaces the caller's value
  context.updateEvent('integrations.Actions Amplitude.session_id', id)
}
```

Caller payload (allowlist style — "block everything except these"):

```json
{ "All": false, "Actions Amplitude": true, "Split": true }
```

After enrichment:

```json
{ "All": false, "Actions Amplitude": { "session_id": 1712345678901 }, "Split": true }
```

The clearest case is a caller who allowlists *and* passes options — every property they set is dropped:

```json
// caller
{ "All": false, "Actions Amplitude": { "subscriptionId": "sub-123" } }
// today
{ "All": false, "Actions Amplitude": { "session_id": 1712345678901 } }
```

## Change

Read the existing value and write one merged object, instead of blanking the node and then writing into it:

```ts
const configured: unknown = context.event.integrations?.['Actions Amplitude']
const existing =
  configured !== null && typeof configured === 'object' && !Array.isArray(configured)
    ? (configured as Record<string, unknown>)
    : {}

context.updateEvent('integrations.Actions Amplitude', { ...existing, session_id: id })
```

`session_id` stays at the same path, and the merge is done explicitly rather than leaning on `dset`'s behaviour for intermediate values. Per-case, before → after:

| value at `integrations['Actions Amplitude']` | before | after |
| --- | --- | --- |
| `integrations` absent | `{session_id:N}` | unchanged |
| key absent | `{session_id:N}` | unchanged |
| `true` | `{session_id:N}` | unchanged |
| `false` | no write (`updateEvent` returns early) | unchanged |
| string / number | `{session_id:N}` | unchanged |
| `null` | `{session_id:N}` | unchanged |
| array / `Date` / other exotic object | `{session_id:N}` | unchanged |
| **plain object** | **caller's properties destroyed** | **`{...caller, session_id:N}`** |

Only the last row changes. The spread also means the caller's own object is no longer mutated in place — `EventFactory.normalize` shallow-spreads per-call integrations, so the nested value is the caller's reference, and a customer reusing one options object across `track` calls would otherwise accumulate `session_id` in it.

Two of those rows are worth calling out, because the obvious smaller fix — just deleting the `updateEvent(..., {})` line and letting `dset` create the intermediate — silently breaks them:

- `null`: `dset` reuses an intermediate when `typeof(existing) === typeof(keys)`, and `typeof null === 'object'`, so it descends into `null` and throws `TypeError: Cannot set properties of null`. The throw is swallowed by the delivery pipeline (`attempt()` logs `plugin Error`, the enrichment loop keeps the un-enriched context), so the event ships with no session id and no visible error — and the remaining action subscriptions in that iteration are skipped.
- array / `Date`: `typeof [] === 'object'`, so `dset` keeps the exotic value and sets `session_id` as a non-index property, which `JSON.stringify` drops.

Both are covered by new tests.

## Observed downstream effect

On one workspace with a cloud-mode Amplitude (Actions) destination, events from users whose `integrations` object was `{ All: false, 'Actions Amplitude': true, ... }` did not arrive in Amplitude, while the same events without the plugin's rewrite were delivered. That is an observation from a single workspace, not a claim about how Segment's server-side filtering works — I could not determine that from this repo.

A report of the same shape: https://github.com/segmentio/consent-manager/issues/296

## What this PR does not fix

It does not fix delivery for the allowlist payload above, and I want to be explicit about that rather than imply otherwise.

A reporter tested both shapes against a live workspace with a cloud-mode Amplitude (Actions) destination, under `All: false`:

| `integrations['Actions Amplitude']` | events reach Amplitude |
| --- | --- |
| `true` | yes |
| `{ ... }` (object, set by the caller directly) | no |

So an object-valued entry does not satisfy the allowlist the way `true` does — which means the plugin overwriting `true` with an object is what stops delivery, and merging rather than replacing does not change that. This PR narrows the damage to callers who pass options (their properties stop being destroyed); it does not restore delivery for callers who allowlist with `true`.

That is an observation from one workspace, not a claim about Segment's filtering internals, and it is the piece I cannot verify from this repo. If maintainers can confirm the rule, the follow-up is straightforward: the plugin should leave an explicit non-object entry alone when `All: false`, which means trading `session_id` for delivery on those events unless the value can also travel by another path (there is precedent for a dual-write in #185).

Client side, `Context.updateEvent` refuses to write only when the entry is exactly `false`, so nothing in this repo treats the object as disabled — the behaviour is server-side.

For history: #368 added the `updateEvent(..., {})` line, the `All !== false` guard, and the test `updates the original eveent when All: false but Actions Amplitude: true` in one commit, so attaching `session_id` for the boolean allowlist case is deliberate. That test still passes here. If the table above holds, that decision is the origin of the delivery problem and needs revisiting separately.

## Why `session_id` stays at the same path

The cloud-mode destination's default mapping reads it from exactly `$.integrations.Actions Amplitude.session_id` (`packages/destination-actions/src/destinations/amplitude/event-schema.ts`), added in #190 ("[Amplitude-Cloud] Support `session_id` fetched from `$.integrations.Actions Amplitude.session_id`"). That mapping has no fallback, so moving the value would break session stitching.

## Related, not changed here

`packages/browser-destinations/destinations/devrev/src/revUserEnrichment/index.ts` has the same `updateEvent('integrations.DevRev', {})`-then-write pattern, and nine other browser plugins replace their integrations node wholesale. Left alone per the one-integration-per-PR guidance, but the underlying hazard is that `updateEvent` has no merge semantics — possibly worth addressing there instead.

## Testing

Four tests added to `src/sessionId/__tests__/sessionId.test.ts`:

- `preserves caller supplied options on the Actions Amplitude entry` — fails before the change (`subscriptionId` is `undefined`), passes after. This is the test for the bug.
- `sets a session id when the Actions Amplitude entry is null` and `sets a session id that survives serialization when the Actions Amplitude entry is an array` — cover the two `dset` edge cases above, which had no coverage before.
- `keeps the rest of the allowlist intact when All: false but Actions Amplitude: true` — a guard on the reported payload. It passes both before and after; the old code only ever wrote a two-segment path, so the sibling keys were never at risk. Included so the reported shape is pinned.

```
PASS destinations/amplitude-plugins/src/sessionId/__tests__/sessionId.test.ts
Tests:       19 passed, 19 total
```

- [x] Added unit tests for new functionality
- [ ] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination

## Security Review

- [x] **Reviewed all field definitions** for sensitive data — no field definitions changed. The merged keys are values the caller already set on the event, and `integrations` is transmitted regardless of this plugin; the old code's blanking of that node was incidental, not a control.
