### PR TITLE
[GainTrace] - new Cloud Mode Destination

### DIFF
--- a/packages/destination-actions/src/destinations/gaintrace/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/gaintrace/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,240 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-gaintrace destination: groupCompany action - all fields 1`] = `
+Object {
+  "domain": "31w3Z(sAhL^Kd9u4s",
+  "employeeCount": 53107216424632.32,
+  "externalId": "31w3Z(sAhL^Kd9u4s",
+  "industry": "31w3Z(sAhL^Kd9u4s",
+  "name": "31w3Z(sAhL^Kd9u4s",
+  "plan": "31w3Z(sAhL^Kd9u4s",
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: groupCompany action - all fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 31w3Z(sAhL^Kd9u4s",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: groupCompany action - required fields 1`] = `
+Object {
+  "externalId": "31w3Z(sAhL^Kd9u4s",
+  "name": "31w3Z(sAhL^Kd9u4s",
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: groupCompany action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 31w3Z(sAhL^Kd9u4s",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: identifyUser action - all fields 1`] = `
+Object {
+  "accountExternalId": "4^v6$NG2S*",
+  "email": "kivata@dew.tw",
+  "externalId": "4^v6$NG2S*",
+  "name": "4^v6$NG2S*",
+  "phone": "4^v6$NG2S*",
+  "role": "4^v6$NG2S*",
+  "traits": Object {
+    "testType": "4^v6$NG2S*",
+  },
+  "upsert": true,
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: identifyUser action - all fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 4^v6$NG2S*",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: identifyUser action - required fields 1`] = `
+Object {
+  "accountExternalId": "4^v6$NG2S*",
+  "externalId": "4^v6$NG2S*",
+  "upsert": true,
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: identifyUser action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 4^v6$NG2S*",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: pageView action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "anonymous_id": "0CG&@!)3S3kz7hF2y]!",
+      "event_category": "admin",
+      "event_name": "0CG&@!)3S3kz7hF2y]!",
+      "properties": Object {
+        "testType": "0CG&@!)3S3kz7hF2y]!",
+      },
+      "source": "segment",
+      "source_event_id": "0CG&@!)3S3kz7hF2y]!",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "0CG&@!)3S3kz7hF2y]!",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: pageView action - all fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 0CG&@!)3S3kz7hF2y]!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: pageView action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "anonymous_id": "0CG&@!)3S3kz7hF2y]!",
+      "event_category": "navigation",
+      "event_name": "Page Viewed",
+      "source": "segment",
+      "source_event_id": "0CG&@!)3S3kz7hF2y]!",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "0CG&@!)3S3kz7hF2y]!",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: pageView action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer 0CG&@!)3S3kz7hF2y]!",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: trackEvent action - all fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "anonymous_id": "gUUhzmxV2",
+      "event_category": "api",
+      "event_name": "gUUhzmxV2",
+      "properties": Object {
+        "testType": "gUUhzmxV2",
+      },
+      "source": "segment",
+      "source_event_id": "gUUhzmxV2",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "gUUhzmxV2",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: trackEvent action - all fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer gUUhzmxV2",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: trackEvent action - required fields 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "anonymous_id": "gUUhzmxV2",
+      "event_category": "feature_usage",
+      "event_name": "gUUhzmxV2",
+      "source": "segment",
+      "source_event_id": "gUUhzmxV2",
+      "timestamp": "2021-02-01T00:00:00.000Z",
+      "user_id": "gUUhzmxV2",
+    },
+  ],
+}
+`;
+
+exports[`Testing snapshot for actions-gaintrace destination: trackEvent action - required fields 2`] = `
+Headers {
+  Symbol(map): Object {
+    "authorization": Array [
+      "Bearer gUUhzmxV2",
+    ],
+    "content-type": Array [
+      "application/json",
+    ],
+    "user-agent": Array [
+      "Segment (Actions)",
+    ],
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/gaintrace/__tests__/api.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/__tests__/api.test.ts
@@ -1,0 +1,191 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { API_BASE, MAX_EVENTS_PER_REQUEST, safeObject, sendEvents, toIso, validateEvent } from '../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('toIso', () => {
+  it('normalises ISO strings and epoch milliseconds', () => {
+    expect(toIso('2026-03-14T09:12:00.000Z')).toBe('2026-03-14T09:12:00.000Z')
+    expect(toIso(1773479520000)).toBe(new Date(1773479520000).toISOString())
+  })
+
+  it('preserves the unix epoch rather than treating 0 as absent', () => {
+    // A truthy check here would silently drop a legitimate value.
+    expect(toIso(0)).toBe('1970-01-01T00:00:00.000Z')
+  })
+
+  it('returns undefined for missing or unparseable values', () => {
+    expect(toIso(undefined)).toBeUndefined()
+    expect(toIso('not a date')).toBeUndefined()
+  })
+})
+
+describe('safeObject', () => {
+  it('drops undefined values and returns undefined when nothing remains', () => {
+    expect(safeObject({ a: undefined })).toBeUndefined()
+    expect(safeObject({})).toBeUndefined()
+    expect(safeObject(undefined)).toBeUndefined()
+    expect(safeObject({ a: 1, b: undefined })).toEqual({ a: 1 })
+  })
+
+  it('keeps falsy values that are meaningful', () => {
+    expect(safeObject({ zero: 0, empty: '', no: false, nul: null })).toEqual({
+      zero: 0,
+      empty: '',
+      no: false,
+      nul: null
+    })
+  })
+
+  it('does not copy inherited keys or __proto__', () => {
+    const input = JSON.parse('{"a":1,"__proto__":{"polluted":true}}') as Record<string, unknown>
+    const out = safeObject(input) as Record<string, unknown>
+    expect(out).toEqual({ a: 1 })
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+})
+
+describe('validateEvent', () => {
+  const base = { messageId: 'm', eventName: 'E', timestamp: '2026-01-01T00:00:00.000Z', userId: 'u' }
+
+  it('accepts a complete event', () => {
+    expect(validateEvent(base)).toBeUndefined()
+  })
+
+  it('explains why a missing messageId matters', () => {
+    expect(validateEvent({ ...base, messageId: undefined })).toMatch(/deduplicat/i)
+  })
+
+  it('requires a parseable timestamp and an identifier', () => {
+    expect(validateEvent({ ...base, timestamp: 'nope' })).toMatch(/timestamp/i)
+    expect(validateEvent({ ...base, userId: undefined })).toMatch(/User ID or an Anonymous ID/i)
+  })
+
+  it('accepts an anonymous-only event', () => {
+    expect(validateEvent({ ...base, userId: undefined, anonymousId: 'anon-1' })).toBeUndefined()
+  })
+})
+
+describe('batch index mapping', () => {
+  it('attributes per-item results to the right ORIGINAL event when one is invalid', async () => {
+    let sent: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        sent = b
+        return true
+      })
+      // Only two events reach the API (index 1 fails local validation), and the
+      // API reports positionally against what it actually received.
+      .reply(201, { data: { results: [{ status: 'inserted' }, { status: 'error', reason: 'boom' }] } })
+
+    const response = await testDestination.executeBatch('trackEvent', {
+      settings,
+      events: [
+        createTestEvent({ type: 'track', event: 'good-0', timestamp: '2026-01-01T00:00:00.000Z', userId: 'u0' }),
+        // No userId and no anonymousId, so it cannot be attributed and is
+        // rejected before we send. Note messageId cannot be used for this case:
+        // Segment's framework auto-populates it.
+        createTestEvent({
+          type: 'track',
+          event: 'bad-1',
+          timestamp: '2026-01-02T00:00:00.000Z',
+          userId: null,
+          anonymousId: null
+        }),
+        createTestEvent({ type: 'track', event: 'good-2', timestamp: '2026-01-03T00:00:00.000Z', userId: 'u2' })
+      ],
+      mapping: {
+        messageId: { '@path': '$.messageId' },
+        eventName: { '@path': '$.event' },
+        timestamp: { '@path': '$.timestamp' },
+        userId: { '@path': '$.userId' },
+        anonymousId: { '@path': '$.anonymousId' }
+      }
+    })
+
+    expect(sent.events).toHaveLength(2)
+    expect(sent.events.map((e: any) => e.event_name)).toEqual(['good-0', 'good-2'])
+
+    // Original index 0 succeeded; 1 failed local validation; 2 carries the API
+    // error that arrived at SENT index 1. Without the index map, "boom" would
+    // have been reported against the wrong event.
+    expect(response[0]).toMatchObject({ status: 200 })
+    expect(response[1]).toMatchObject({
+      status: 400,
+      errortype: 'PAYLOAD_VALIDATION_FAILED'
+    })
+    // Rejected by the conditionally-required rule before we ever build a request.
+    expect((response[1] as any).errormessage).toMatch(/userId|anonymousId/i)
+    expect(response[2]).toMatchObject({ status: 400 })
+    expect((response[2] as any).errormessage).toBe('boom')
+  })
+
+  it('reports a duplicate as a successful delivery', async () => {
+    nock(API_BASE)
+      .post('/events')
+      .reply(201, { data: { results: [{ status: 'duplicate' }] } })
+
+    const response = await testDestination.executeBatch('trackEvent', {
+      settings,
+      events: [createTestEvent({ type: 'track', event: 'A', timestamp: '2026-01-01T00:00:00.000Z', userId: 'u' })],
+      mapping: {
+        messageId: { '@path': '$.messageId' },
+        eventName: { '@path': '$.event' },
+        timestamp: { '@path': '$.timestamp' },
+        userId: { '@path': '$.userId' }
+      }
+    })
+
+    // GainTrace already holds the event: the delivery succeeded, and reporting
+    // it as an error would make every replay look like a failure.
+    expect(response[0]).toMatchObject({ status: 200 })
+  })
+})
+
+describe('sendEvents guards', () => {
+  // A stub request client: these paths must fail before any HTTP call is made.
+  const neverCalled = jest.fn(() => {
+    throw new Error('no HTTP request should be made')
+  }) as unknown as Parameters<typeof sendEvents>[0]
+
+  it('returns an empty MultiStatus for an empty batch instead of throwing', async () => {
+    const result = await sendEvents(neverCalled, [], 'feature_usage', true)
+    expect((result as { length(): number }).length()).toBe(0)
+  })
+
+  it('throws for an empty single send', async () => {
+    await expect(sendEvents(neverCalled, [], 'feature_usage', false)).rejects.toThrowError(/No event to send/i)
+  })
+
+  it('refuses a batch larger than the documented API ceiling', async () => {
+    const oversized = Array.from({ length: MAX_EVENTS_PER_REQUEST + 1 }, (_, i) => ({
+      messageId: `m-${i}`,
+      eventName: 'E',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      userId: 'u'
+    }))
+    // Enforced in code, not only declared via batch_size, so a misconfigured
+    // batch never reaches the API to be rejected wholesale.
+    await expect(sendEvents(neverCalled, oversized, 'feature_usage', true)).rejects.toThrowError(
+      new RegExp(`at most ${MAX_EVENTS_PER_REQUEST} events`)
+    )
+  })
+
+  it('returns an empty MultiStatus when every event in the batch is invalid', async () => {
+    const result = await sendEvents(
+      neverCalled,
+      [{ messageId: 'm', eventName: 'E', timestamp: '2026-01-01T00:00:00.000Z' }],
+      'feature_usage',
+      true
+    )
+    // No HTTP call was attempted, and the single event is reported as failed.
+    expect((result as { length(): number }).length()).toBe(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/__tests__/index.test.ts
@@ -1,0 +1,87 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+import { API_BASE } from '../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('GainTrace', () => {
+  describe('testAuthentication', () => {
+    it('succeeds against a real authenticated request', async () => {
+      nock(API_BASE).get('/companies').query({ limit: '1' }).reply(200, { data: [] })
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrow()
+    })
+
+    it('rejects an invalid key with an actionable message', async () => {
+      nock(API_BASE).get('/companies').query({ limit: '1' }).reply(401, { error: 'unauthorized' })
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError(/API key/i)
+    })
+  })
+
+  describe('authentication wiring', () => {
+    it('sends the key as a bearer header and never in a body', async () => {
+      let seenAuth: string | undefined
+      let seenBody: unknown
+      nock(API_BASE)
+        .post('/events')
+        .reply(function (_uri, body) {
+          const raw = this.req.headers.authorization
+          seenAuth = Array.isArray(raw) ? raw[0] : raw
+          seenBody = body
+          return [201, { data: { results: [{ status: 'inserted' }] } }]
+        })
+
+      await testDestination.testAction('trackEvent', {
+        settings,
+        mapping: {
+          messageId: 'm-1',
+          eventName: 'Report Exported',
+          timestamp: '2026-03-14T09:12:00.000Z',
+          userId: 'u-1'
+        }
+      })
+
+      expect(seenAuth).toBe('Bearer gt_live_testkey')
+      expect(JSON.stringify(seenBody)).not.toContain('gt_live_testkey')
+    })
+  })
+
+  describe('onDelete', () => {
+    it('deletes the subject by external id, url-encoded', async () => {
+      const scope = nock(API_BASE).delete('/contacts').query({ externalId: 'user with spaces/&' }).reply(204)
+
+      await testDestination.onDelete?.({ type: 'delete', userId: 'user with spaces/&' } as never, settings)
+      expect(scope.isDone()).toBe(true)
+    })
+  })
+
+  describe('presets', () => {
+    it('ships presets for track, identify and group but not page', () => {
+      const names = (Definition.presets ?? []).map((p) => p.name)
+      expect(names).toEqual(['Track Calls', 'Identify Calls', 'Group Calls'])
+    })
+
+    it('only references actions and fields that exist', () => {
+      for (const preset of Definition.presets ?? []) {
+        if (preset.type !== 'automatic') continue
+        const action = Definition.actions[preset.partnerAction]
+        expect(action).toBeDefined()
+        for (const field of Object.keys(preset.mapping ?? {})) {
+          expect(Object.keys(action.fields)).toContain(field)
+        }
+      }
+    })
+
+    it('narrows the identify subscription so required fields are always present', () => {
+      const identify = (Definition.presets ?? []).find((p) => p.name === 'Identify Calls')
+      // accountExternalId is required, so an identify without a group would fail
+      // delivery. Filtering it at subscription level reports it as filtered.
+      expect(identify && 'subscribe' in identify && identify.subscribe).toContain('context.groupId != null')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import destination from '../index'
+import { API_BASE } from '../api'
+import { generateTestData } from '../../../lib/test-data'
+
+const testDestination = createTestIntegration(destination)
+// The catalog slug, not the display name, so seeded data stays stable and
+// matches the destination's identity.
+const destinationSlug = 'actions-gaintrace'
+
+// nock is scoped to the GainTrace host rather than a catch-all, and cleaned up
+// after every test, so a persisted interceptor cannot leak into another suite or
+// silently swallow an unexpected outbound call.
+afterEach(() => {
+  nock.cleanAll()
+})
+
+function mockApi() {
+  nock(API_BASE).persist().get(/.*/).reply(200, {})
+  nock(API_BASE).persist().post(/.*/).reply(200, {})
+}
+
+async function snapshotAction(actionSlug: string, requiredOnly: boolean) {
+  const seedName = `${destinationSlug}#${actionSlug}`
+  const action = destination.actions[actionSlug]
+  const [eventData, settingsData] = generateTestData(seedName, destination, action, requiredOnly)
+
+  mockApi()
+
+  const event = createTestEvent({ properties: eventData })
+
+  // userId and anonymousId are individually optional, but the event actions
+  // require at least ONE of them: an event with neither cannot be attributed to
+  // a person or a company, and sending it would inflate usage counts while
+  // teaching the customer nothing. In "required fields" mode the generator
+  // supplies neither, so seed one here rather than weakening the rule.
+  const mapping: Record<string, unknown> = { ...(event.properties as Record<string, unknown>) }
+  if ('userId' in action.fields && mapping.userId == null && mapping.anonymousId == null) {
+    mapping.userId = 'snapshot-user-id'
+  }
+
+  const responses = await testDestination.testAction(actionSlug, {
+    event,
+    mapping,
+    settings: settingsData,
+    auth: undefined
+  })
+
+  const request = responses[0].request
+  const rawBody = await request.text()
+
+  try {
+    expect(JSON.parse(rawBody)).toMatchSnapshot()
+  } catch (err) {
+    expect(rawBody).toMatchSnapshot()
+  }
+
+  // Deliberately outside the try/catch and after both branches: the widely
+  // copied version of this template returns early on the JSON path, so headers
+  // are never actually snapshotted.
+  expect(request.headers).toMatchSnapshot()
+}
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      await snapshotAction(actionSlug, true)
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      await snapshotAction(actionSlug, false)
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/gaintrace/api.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/api.ts
@@ -1,0 +1,202 @@
+import type { JSONLikeObject, RequestClient } from '@segment/actions-core'
+import { MultiStatusResponse, PayloadValidationError } from '@segment/actions-core'
+import { GAINTRACE_API_VERSION } from './versioning-info'
+
+/**
+ * GainTrace's public API. Hardcoded rather than a setting: the base URL is a
+ * published contract (`docs/api-design.openapi.json`), and a user-supplied host
+ * would be an SSRF surface for no benefit.
+ */
+export const API_BASE = `https://app.gaintrace.com/api/${GAINTRACE_API_VERSION}`
+
+/** Explicit ceiling so a slow response cannot pin a delivery worker. */
+export const REQUEST_TIMEOUT_MS = 30_000
+
+/**
+ * Hard cap documented by POST /api/v1/events, which rejects a larger array
+ * outright. Enforced in code as well as declared in `batch_size`, so a
+ * misconfigured or future batching change cannot silently fail a whole batch.
+ */
+export const MAX_EVENTS_PER_REQUEST = 1000
+
+/** Per-item outcome returned by POST /api/v1/events, aligned to the sent array. */
+export type ItemStatus = 'inserted' | 'duplicate' | 'error' | 'rejected'
+
+export interface EventsApiResponse {
+  data?: {
+    inserted?: number
+    duplicates?: number
+    errors?: number
+    results?: Array<{ status: ItemStatus; reason?: string }>
+  }
+  validation_errors?: Array<{ index: number; error: string }>
+}
+
+export interface GainTraceEvent extends JSONLikeObject {
+  event_name: string
+  event_category: string
+  source: 'segment'
+  source_event_id: string
+  timestamp: string
+  user_id?: string
+  anonymous_id?: string
+  properties?: JSONLikeObject
+}
+
+/** Shape shared by trackEvent and pageView before it becomes a GainTraceEvent. */
+export interface EventSource {
+  messageId?: string
+  timestamp?: string | number
+  eventName?: string
+  eventCategory?: string
+  userId?: string
+  anonymousId?: string
+  properties?: Record<string, unknown>
+}
+
+/**
+ * Copy own enumerable keys into a null-prototype object.
+ *
+ * Payload objects come from customer event data, so iterating with `for...in`
+ * would pick up inherited keys and a `__proto__` key could pollute the
+ * accumulator. Returns undefined for an empty result so callers omit the field
+ * entirely rather than sending `{}`.
+ */
+export function safeObject(input?: Record<string, unknown>): JSONLikeObject | undefined {
+  if (!input) return undefined
+  const out = Object.create(null) as Record<string, unknown>
+  let count = 0
+  for (const key of Object.keys(input)) {
+    if (key === '__proto__') continue
+    const value = input[key]
+    if (value === undefined) continue
+    out[key] = value
+    count++
+  }
+  return count > 0 ? (out as JSONLikeObject) : undefined
+}
+
+/**
+ * Normalise a Segment timestamp to ISO-8601.
+ *
+ * No clock validation of any kind. Segment replays historical data into newly
+ * connected destinations, so backdated timestamps are the normal case, not an
+ * anomaly, and a sending client's clock may legitimately run ahead of Segment's.
+ */
+export function toIso(value?: string | number): string | undefined {
+  if (value == null) return undefined
+  const date = new Date(value)
+  const ms = date.getTime()
+  if (Number.isNaN(ms)) return undefined
+  return date.toISOString()
+}
+
+/** Validate one event, returning a human message when it cannot be sent. */
+export function validateEvent(payload: EventSource): string | undefined {
+  if (!payload.messageId) {
+    return 'messageId is required. GainTrace deduplicates on it, so without it a Segment replay would count the same event more than once.'
+  }
+  if (!payload.eventName) return 'An event name is required.'
+  if (!toIso(payload.timestamp)) return 'A valid ISO-8601 timestamp is required.'
+  if (!payload.userId && !payload.anonymousId) {
+    return 'Either a User ID or an Anonymous ID is required to attribute the event.'
+  }
+  return undefined
+}
+
+function toApiEvent(payload: EventSource, defaultCategory: string): GainTraceEvent {
+  return {
+    event_name: payload.eventName as string,
+    event_category: payload.eventCategory || defaultCategory,
+    source: 'segment',
+    source_event_id: payload.messageId as string,
+    timestamp: toIso(payload.timestamp) as string,
+    ...(payload.userId ? { user_id: payload.userId } : {}),
+    ...(payload.anonymousId ? { anonymous_id: payload.anonymousId } : {}),
+    ...(safeObject(payload.properties) ? { properties: safeObject(payload.properties) } : {})
+  }
+}
+
+/**
+ * The one code path for both single and batch sends.
+ *
+ * `perform` wraps its single payload in an array and calls this, so there is no
+ * second implementation to drift. The only branch is the return value: a batch
+ * gets a MultiStatusResponse with per-event outcomes, a single send gets the raw
+ * response so ordinary error handling applies.
+ */
+export async function sendEvents(
+  request: RequestClient,
+  payloads: EventSource[],
+  defaultCategory: string,
+  isBatch: boolean
+) {
+  const multiStatus = new MultiStatusResponse()
+
+  if (payloads.length === 0) {
+    if (isBatch) return multiStatus
+    throw new PayloadValidationError('No event to send.')
+  }
+
+  // Filtered-index -> original-index map. Per-item results from the API are
+  // positional against what we SENT, so without this a single invalid event
+  // shifts every subsequent result onto the wrong original event.
+  const originalIndexes: number[] = []
+  const events: GainTraceEvent[] = []
+
+  payloads.forEach((payload, index) => {
+    const problem = validateEvent(payload)
+    if (problem) {
+      if (!isBatch) throw new PayloadValidationError(problem)
+      multiStatus.setErrorResponseAtIndex(index, {
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: problem
+      })
+      return
+    }
+    originalIndexes.push(index)
+    events.push(toApiEvent(payload, defaultCategory))
+  })
+
+  if (events.length === 0) return multiStatus
+
+  if (events.length > MAX_EVENTS_PER_REQUEST) {
+    throw new PayloadValidationError(
+      `GainTrace accepts at most ${MAX_EVENTS_PER_REQUEST} events per request; received ${events.length}.`
+    )
+  }
+
+  const response = await request<EventsApiResponse>(`${API_BASE}/events`, {
+    method: 'POST',
+    json: { events }
+  })
+
+  if (!isBatch) return response
+
+  const results = response.data?.data?.results
+  originalIndexes.forEach((originalIndex, sentIndex) => {
+    const result = results?.[sentIndex]
+    // No per-item result means the API accepted the batch without detail; the
+    // request itself succeeded, so report success rather than inventing failure.
+    if (!result || result.status === 'inserted' || result.status === 'duplicate') {
+      multiStatus.setSuccessResponseAtIndex(originalIndex, {
+        status: 200,
+        // Deliberately NOT echoing the sent payload: MultiStatus bodies are
+        // surfaced and stored, and event properties can carry personal data.
+        sent: { source_event_id: events[sentIndex].source_event_id } as JSONLikeObject,
+        body: { status: result?.status ?? 'accepted' }
+      })
+      return
+    }
+    multiStatus.setErrorResponseAtIndex(originalIndex, {
+      status: 400,
+      errortype: 'BAD_REQUEST',
+      errormessage: result.reason ?? `GainTrace rejected the event (${result.status}).`,
+      sent: { source_event_id: events[sentIndex].source_event_id } as JSONLikeObject,
+      body: { status: result.status, reason: result.reason }
+    })
+  })
+
+  return multiStatus
+}

--- a/packages/destination-actions/src/destinations/gaintrace/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * A GainTrace API key. In GainTrace go to Settings, API keys, create a key and choose the "Segment destination" preset, which selects exactly the scopes this integration needs (read:companies, write:events, write:contacts, write:companies).
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/gaintrace/groupCompany/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/groupCompany/__tests__/index.test.ts
@@ -1,0 +1,56 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { API_BASE } from '../../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('GainTrace.groupCompany', () => {
+  it('upserts a company on the external id', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/companies', (b) => {
+        body = b
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('groupCompany', {
+      settings,
+      mapping: { groupId: 'acme', name: 'Acme Inc', domain: 'acme.com', employeeCount: 250 }
+    })
+
+    expect(body).toMatchObject({ externalId: 'acme', name: 'Acme Inc', domain: 'acme.com', employeeCount: 250 })
+  })
+
+  it('falls back to the company id when no name is supplied', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/companies', (b) => {
+        body = b
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('groupCompany', { settings, mapping: { groupId: 'acme' } })
+    expect(body.name).toBe('acme')
+  })
+
+  it('sends employeeCount of zero rather than dropping it', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/companies', (b) => {
+        body = b
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('groupCompany', { settings, mapping: { groupId: 'acme', employeeCount: 0 } })
+    expect(body.employeeCount).toBe(0)
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/groupCompany/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/groupCompany/generated-types.ts
@@ -1,0 +1,28 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The customer's own identifier for the company. GainTrace upserts on this value.
+   */
+  groupId: string
+  /**
+   * The display name of the company. Falls back to the Company ID when absent.
+   */
+  name?: string
+  /**
+   * The primary web domain of the company, for example "acme.com".
+   */
+  domain?: string
+  /**
+   * The industry the company operates in.
+   */
+  industry?: string
+  /**
+   * The number of employees at the company.
+   */
+  employeeCount?: number
+  /**
+   * The plan or tier the company is on.
+   */
+  plan?: string
+}

--- a/packages/destination-actions/src/destinations/gaintrace/groupCompany/index.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/groupCompany/index.ts
@@ -1,0 +1,64 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { API_BASE } from '../api'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Group Company',
+  description:
+    'Create or update a company in GainTrace. Safe to call repeatedly: GainTrace upserts on the company ID rather than creating duplicates.',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    groupId: {
+      label: 'Company ID',
+      description: "The customer's own identifier for the company. GainTrace upserts on this value.",
+      type: 'string',
+      required: true,
+      default: { '@path': '$.groupId' }
+    },
+    name: {
+      label: 'Company Name',
+      description: 'The display name of the company. Falls back to the Company ID when absent.',
+      type: 'string',
+      default: { '@path': '$.traits.name' }
+    },
+    domain: {
+      label: 'Domain',
+      description: 'The primary web domain of the company, for example "acme.com".',
+      type: 'string',
+      default: { '@path': '$.traits.website' }
+    },
+    industry: {
+      label: 'Industry',
+      description: 'The industry the company operates in.',
+      type: 'string',
+      default: { '@path': '$.traits.industry' }
+    },
+    employeeCount: {
+      label: 'Employee Count',
+      description: 'The number of employees at the company.',
+      type: 'number',
+      default: { '@path': '$.traits.employees' }
+    },
+    plan: {
+      label: 'Plan',
+      description: 'The plan or tier the company is on.',
+      type: 'string',
+      default: { '@path': '$.traits.plan' }
+    }
+  },
+  perform: (request, { payload }) =>
+    request(`${API_BASE}/companies`, {
+      method: 'POST',
+      json: {
+        externalId: payload.groupId,
+        name: payload.name || payload.groupId,
+        ...(payload.domain ? { domain: payload.domain } : {}),
+        ...(payload.industry ? { industry: payload.industry } : {}),
+        ...(payload.employeeCount != null ? { employeeCount: payload.employeeCount } : {}),
+        ...(payload.plan ? { plan: payload.plan } : {})
+      }
+    })
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gaintrace/identifyUser/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/identifyUser/__tests__/index.test.ts
@@ -1,0 +1,99 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { API_BASE } from '../../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('GainTrace.identifyUser', () => {
+  it('upserts a person against the company external id', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/contacts', (b) => {
+        body = b
+        return true
+      })
+      .reply(200, { data: { id: 'c1' } })
+
+    await testDestination.testAction('identifyUser', {
+      settings,
+      mapping: {
+        userId: 'seg-user-1',
+        accountExternalId: 'acme',
+        email: 'jane@acme.com',
+        name: 'Jane Doe',
+        traits: { power_user: true }
+      }
+    })
+
+    expect(body).toMatchObject({
+      upsert: true,
+      externalId: 'seg-user-1',
+      accountExternalId: 'acme',
+      email: 'jane@acme.com',
+      name: 'Jane Doe',
+      traits: { power_user: true }
+    })
+  })
+
+  it('always sets upsert so a replayed identify updates instead of conflicting', async () => {
+    let calls = 0
+    nock(API_BASE)
+      .post('/contacts', (b: any) => {
+        calls++
+        expect(b.upsert).toBe(true)
+        return true
+      })
+      .times(3)
+      .reply(200, {})
+
+    const mapping = { userId: 'u', accountExternalId: 'acme' }
+    for (let i = 0; i < 3; i++) {
+      await testDestination.testAction('identifyUser', { settings, mapping })
+    }
+    expect(calls).toBe(3)
+  })
+
+  it('omits optional fields rather than sending empty values', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/contacts', (b) => {
+        body = b
+        return true
+      })
+      .reply(200, {})
+
+    await testDestination.testAction('identifyUser', {
+      settings,
+      mapping: { userId: 'u', accountExternalId: 'acme', traits: {} }
+    })
+
+    expect(body).not.toHaveProperty('email')
+    expect(body).not.toHaveProperty('phone')
+    expect(body).not.toHaveProperty('traits')
+  })
+})
+
+describe('GainTrace.identifyUser guards', () => {
+  it('refuses a person with neither a user id nor an email', () => {
+    const action = Definition.actions.identifyUser
+    const neverCalled = jest.fn(() => {
+      throw new Error('no HTTP request should be made')
+    })
+    // perform throws synchronously, before any request is built. userId is a
+    // required field so the framework normally rejects this first; the guard
+    // keeps the action safe if it is ever invoked from another call site.
+    expect(() =>
+      (action.perform as unknown as (r: unknown, d: unknown) => unknown)(neverCalled, {
+        payload: { accountExternalId: 'acme' },
+        settings: { apiKey: 'k' }
+      })
+    ).toThrowError(/User ID or an email address/i)
+    expect(neverCalled).not.toHaveBeenCalled()
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/identifyUser/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/identifyUser/generated-types.ts
@@ -1,0 +1,34 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The customer's own identifier for this person, used as the stable match key in GainTrace. Required unless an Email is provided.
+   */
+  userId?: string
+  /**
+   * The customer's own identifier for the company this person belongs to, normally the Segment group ID. GainTrace creates the company if it has not seen it yet.
+   */
+  accountExternalId: string
+  /**
+   * The email address of the person. Used as a secondary match key.
+   */
+  email?: string
+  /**
+   * The full name of the person. Falls back to the email local part when absent.
+   */
+  name?: string
+  /**
+   * The phone number of the person.
+   */
+  phone?: string
+  /**
+   * The job title or role of the person.
+   */
+  role?: string
+  /**
+   * All other traits to store on the person. Segment Engage computed traits and audience membership arrive here and are merged with existing traits rather than replacing them.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/gaintrace/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/identifyUser/index.ts
@@ -1,0 +1,92 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import { PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { API_BASE, safeObject } from '../api'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Identify User',
+  description:
+    'Create or update a person in GainTrace and attach them to a company. Safe to call repeatedly: GainTrace matches on external ID, then email, and updates rather than duplicating.',
+  // Narrowed on purpose. A person in GainTrace always belongs to a company, so
+  // an identify with no group association cannot be stored. Filtering here means
+  // those calls are reported as filtered rather than failing delivery.
+  defaultSubscription: 'type = "identify" and context.groupId != null',
+  fields: {
+    userId: {
+      label: 'User ID',
+      description:
+        "The customer's own identifier for this person, used as the stable match key in GainTrace. Required unless an Email is provided.",
+      type: 'string',
+      // Preferred, because an email address can change while an id does not.
+      // Conditionally required rather than always required so an identify call
+      // carrying only an email still works, which is how Planhat matches too.
+      required: {
+        conditions: [{ fieldKey: 'email', operator: 'is', value: undefined }]
+      },
+      default: { '@path': '$.userId' }
+    },
+    accountExternalId: {
+      label: 'Company ID',
+      description:
+        "The customer's own identifier for the company this person belongs to, normally the Segment group ID. GainTrace creates the company if it has not seen it yet.",
+      type: 'string',
+      required: true,
+      default: { '@path': '$.context.groupId' }
+    },
+    email: {
+      label: 'Email',
+      description: 'The email address of the person. Used as a secondary match key.',
+      type: 'string',
+      format: 'email',
+      default: { '@path': '$.traits.email' }
+    },
+    name: {
+      label: 'Name',
+      description: 'The full name of the person. Falls back to the email local part when absent.',
+      type: 'string',
+      default: { '@path': '$.traits.name' }
+    },
+    phone: {
+      label: 'Phone',
+      description: 'The phone number of the person.',
+      type: 'string',
+      default: { '@path': '$.traits.phone' }
+    },
+    role: {
+      label: 'Role',
+      description: 'The job title or role of the person.',
+      type: 'string',
+      default: { '@path': '$.traits.title' }
+    },
+    traits: {
+      label: 'Traits',
+      description:
+        'All other traits to store on the person. Segment Engage computed traits and audience membership arrive here and are merged with existing traits rather than replacing them.',
+      type: 'object',
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue',
+      default: { '@path': '$.traits' }
+    }
+  },
+  perform: (request, { payload }) => {
+    if (!payload.userId && !payload.email) {
+      throw new PayloadValidationError('Either a User ID or an email address is required to identify a person.')
+    }
+    return request(`${API_BASE}/contacts`, {
+      method: 'POST',
+      json: {
+        upsert: true,
+        externalId: payload.userId,
+        accountExternalId: payload.accountExternalId,
+        ...(payload.email ? { email: payload.email } : {}),
+        ...(payload.name ? { name: payload.name } : {}),
+        ...(payload.phone ? { phone: payload.phone } : {}),
+        ...(payload.role ? { role: payload.role } : {}),
+        ...(safeObject(payload.traits) ? { traits: safeObject(payload.traits) } : {})
+      }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gaintrace/index.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/index.ts
@@ -1,0 +1,92 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import { defaultValues, InvalidAuthenticationError } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { API_BASE, REQUEST_TIMEOUT_MS } from './api'
+
+import trackEvent from './trackEvent'
+import identifyUser from './identifyUser'
+import groupCompany from './groupCompany'
+import pageView from './pageView'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'GainTrace',
+  slug: 'actions-gaintrace',
+  mode: 'cloud',
+  description:
+    'Send product usage, people and company data to GainTrace, where it drives feature adoption, account health and churn risk signals for customer success teams.',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'API Key',
+        description:
+          'A GainTrace API key. In GainTrace go to Settings, API keys, create a key and choose the "Segment destination" preset, which selects exactly the scopes this integration needs (read:companies, write:events, write:contacts, write:companies).',
+        type: 'password',
+        required: true
+      }
+    },
+    // A real authenticated request. Checking that a required field is present
+    // would prove nothing, because the framework already enforces that before
+    // the destination can be enabled.
+    testAuthentication: async (request) => {
+      try {
+        await request(`${API_BASE}/companies?limit=1`, { method: 'GET' })
+      } catch (error) {
+        throw new InvalidAuthenticationError(
+          'Could not authenticate with GainTrace. Check the API key is correct and has not been revoked. The "Segment destination" preset on the GainTrace API keys screen grants exactly the scopes this integration needs.'
+        )
+      }
+    }
+  },
+
+  extendRequest: ({ settings }) => ({
+    // The key travels in the Authorization header only. It is never placed in a
+    // request body, where it could be persisted or surfaced downstream.
+    headers: { Authorization: `Bearer ${settings.apiKey}` },
+    timeout: REQUEST_TIMEOUT_MS
+  }),
+
+  // Privacy deletion. Segment supplies the Spec userId, which GainTrace resolves
+  // to a person by external ID. Deleting a subject GainTrace has never seen is
+  // treated as success, so a deletion request is never reported as a failure.
+  onDelete: async (request, { payload }) =>
+    request(`${API_BASE}/contacts?externalId=${encodeURIComponent(String(payload.userId))}`, {
+      method: 'DELETE'
+    }),
+
+  // No preset for Page View: page traffic is high volume and adds little to
+  // account health, so it ships available but off. Customers opt in.
+  presets: [
+    {
+      name: 'Track Calls',
+      subscribe: 'type = "track"',
+      partnerAction: 'trackEvent',
+      mapping: defaultValues(trackEvent.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Identify Calls',
+      subscribe: 'type = "identify" and context.groupId != null',
+      partnerAction: 'identifyUser',
+      mapping: defaultValues(identifyUser.fields),
+      type: 'automatic'
+    },
+    {
+      name: 'Group Calls',
+      subscribe: 'type = "group"',
+      partnerAction: 'groupCompany',
+      mapping: defaultValues(groupCompany.fields),
+      type: 'automatic'
+    }
+  ],
+
+  actions: {
+    trackEvent,
+    identifyUser,
+    groupCompany,
+    pageView
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/gaintrace/metadata.json
+++ b/packages/destination-actions/src/destinations/gaintrace/metadata.json
@@ -1,0 +1,1057 @@
+{
+  "slug": "actions-gaintrace",
+  "name": "GainTrace",
+  "mode": "cloud",
+  "description": "Send product usage, people and company data to GainTrace, where it drives feature adoption, account health and churn risk signals for customer success teams.",
+  "authentication": {
+    "scheme": "custom",
+    "fields": {
+      "apiKey": {
+        "label": "API Key",
+        "description": "A GainTrace API key. In GainTrace go to Settings, API keys, create a key and choose the \"Segment destination\" preset, which selects exactly the scopes this integration needs (read:companies, write:events, write:contacts, write:companies).",
+        "type": "password",
+        "required": true,
+        "multiple": false,
+        "choices": null,
+        "default": null,
+        "depends_on": null
+      }
+    }
+  },
+  "audienceConfig": null,
+  "actions": {
+    "trackEvent": {
+      "title": "Track Event",
+      "description": "Send a product usage event to GainTrace. Events drive feature adoption, engagement and account health.",
+      "platform": "cloud",
+      "defaultSubscription": "type = \"track\"",
+      "hidden": false,
+      "hasPerformBatch": true,
+      "syncMode": null,
+      "hooks": null,
+      "dynamicFields": null,
+      "fields": {
+        "messageId": {
+          "label": "Message ID",
+          "description": "Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "eventName": {
+          "label": "Event Name",
+          "description": "The name of the event, for example \"Report Exported\".",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.event"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "timestamp": {
+          "label": "Timestamp",
+          "description": "When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.",
+          "type": "datetime",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.timestamp"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.",
+          "type": "string",
+          "required": {
+            "conditions": [
+              {
+                "fieldKey": "anonymousId",
+                "operator": "is"
+              }
+            ]
+          },
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.",
+          "type": "string",
+          "required": {
+            "conditions": [
+              {
+                "fieldKey": "userId",
+                "operator": "is"
+              }
+            ]
+          },
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "eventCategory": {
+          "label": "Event Category",
+          "description": "How GainTrace should classify the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "feature_usage",
+          "choices": [
+            {
+              "label": "feature_usage",
+              "value": "feature_usage"
+            },
+            {
+              "label": "navigation",
+              "value": "navigation"
+            },
+            {
+              "label": "api",
+              "value": "api"
+            },
+            {
+              "label": "billing",
+              "value": "billing"
+            },
+            {
+              "label": "support",
+              "value": "support"
+            },
+            {
+              "label": "auth",
+              "value": "auth"
+            },
+            {
+              "label": "integration",
+              "value": "integration"
+            },
+            {
+              "label": "admin",
+              "value": "admin"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Properties to store alongside the event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": true
+        },
+        "enable_batching": {
+          "label": "Batch Data to GainTrace",
+          "description": "If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "batch_size": {
+          "label": "Batch Size",
+          "description": "Maximum number of events to include in each batch. Actual batch sizes may be lower.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": 1000,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        }
+      }
+    },
+    "identifyUser": {
+      "title": "Identify User",
+      "description": "Create or update a person in GainTrace and attach them to a company. Safe to call repeatedly: GainTrace matches on external ID, then email, and updates rather than duplicating.",
+      "platform": "cloud",
+      "defaultSubscription": "type = \"identify\" and context.groupId != null",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": null,
+      "dynamicFields": null,
+      "fields": {
+        "userId": {
+          "label": "User ID",
+          "description": "The customer's own identifier for this person, used as the stable match key in GainTrace. Required unless an Email is provided.",
+          "type": "string",
+          "required": {
+            "conditions": [
+              {
+                "fieldKey": "email",
+                "operator": "is"
+              }
+            ]
+          },
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "accountExternalId": {
+          "label": "Company ID",
+          "description": "The customer's own identifier for the company this person belongs to, normally the Segment group ID. GainTrace creates the company if it has not seen it yet.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.context.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "email": {
+          "label": "Email",
+          "description": "The email address of the person. Used as a secondary match key.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.email"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": "email",
+          "additionalProperties": false
+        },
+        "name": {
+          "label": "Name",
+          "description": "The full name of the person. Falls back to the email local part when absent.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "phone": {
+          "label": "Phone",
+          "description": "The phone number of the person.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.phone"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "role": {
+          "label": "Role",
+          "description": "The job title or role of the person.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.title"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "traits": {
+          "label": "Traits",
+          "description": "All other traits to store on the person. Segment Engage computed traits and audience membership arrive here and are merged with existing traits rather than replacing them.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": true
+        }
+      }
+    },
+    "groupCompany": {
+      "title": "Group Company",
+      "description": "Create or update a company in GainTrace. Safe to call repeatedly: GainTrace upserts on the company ID rather than creating duplicates.",
+      "platform": "cloud",
+      "defaultSubscription": "type = \"group\"",
+      "hidden": false,
+      "hasPerformBatch": false,
+      "syncMode": null,
+      "hooks": null,
+      "dynamicFields": null,
+      "fields": {
+        "groupId": {
+          "label": "Company ID",
+          "description": "The customer's own identifier for the company. GainTrace upserts on this value.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.groupId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "name": {
+          "label": "Company Name",
+          "description": "The display name of the company. Falls back to the Company ID when absent.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "domain": {
+          "label": "Domain",
+          "description": "The primary web domain of the company, for example \"acme.com\".",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.website"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "industry": {
+          "label": "Industry",
+          "description": "The industry the company operates in.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.industry"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "employeeCount": {
+          "label": "Employee Count",
+          "description": "The number of employees at the company.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.employees"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "plan": {
+          "label": "Plan",
+          "description": "The plan or tier the company is on.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.traits.plan"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        }
+      }
+    },
+    "pageView": {
+      "title": "Page View",
+      "description": "Send a page view to GainTrace as a navigation event. Off by default: page traffic is high volume and contributes less to account health than product events.",
+      "platform": "cloud",
+      "defaultSubscription": "type = \"page\"",
+      "hidden": false,
+      "hasPerformBatch": true,
+      "syncMode": null,
+      "hooks": null,
+      "dynamicFields": null,
+      "fields": {
+        "messageId": {
+          "label": "Message ID",
+          "description": "Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.",
+          "type": "string",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.messageId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "eventName": {
+          "label": "Page Name",
+          "description": "The name of the page, for example \"Pricing\". Defaults to \"Page Viewed\" when the call carries no name.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.name"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "timestamp": {
+          "label": "Timestamp",
+          "description": "When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.",
+          "type": "datetime",
+          "required": true,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.timestamp"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "userId": {
+          "label": "User ID",
+          "description": "The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.",
+          "type": "string",
+          "required": {
+            "conditions": [
+              {
+                "fieldKey": "anonymousId",
+                "operator": "is"
+              }
+            ]
+          },
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.userId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "anonymousId": {
+          "label": "Anonymous ID",
+          "description": "The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.",
+          "type": "string",
+          "required": {
+            "conditions": [
+              {
+                "fieldKey": "userId",
+                "operator": "is"
+              }
+            ]
+          },
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.anonymousId"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "eventCategory": {
+          "label": "Event Category",
+          "description": "How GainTrace should classify the event.",
+          "type": "string",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": "navigation",
+          "choices": [
+            {
+              "label": "feature_usage",
+              "value": "feature_usage"
+            },
+            {
+              "label": "navigation",
+              "value": "navigation"
+            },
+            {
+              "label": "api",
+              "value": "api"
+            },
+            {
+              "label": "billing",
+              "value": "billing"
+            },
+            {
+              "label": "support",
+              "value": "support"
+            },
+            {
+              "label": "auth",
+              "value": "auth"
+            },
+            {
+              "label": "integration",
+              "value": "integration"
+            },
+            {
+              "label": "admin",
+              "value": "admin"
+            }
+          ],
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "properties": {
+          "label": "Event Properties",
+          "description": "Properties to store alongside the event.",
+          "type": "object",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": {
+            "@path": "$.properties"
+          },
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": "keyvalue",
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": true
+        },
+        "enable_batching": {
+          "label": "Batch Data to GainTrace",
+          "description": "If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.",
+          "type": "boolean",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": true,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        },
+        "batch_size": {
+          "label": "Batch Size",
+          "description": "Maximum number of events to include in each batch. Actual batch sizes may be lower.",
+          "type": "number",
+          "required": false,
+          "multiple": false,
+          "allowNull": false,
+          "dynamic": false,
+          "default": 1000,
+          "choices": null,
+          "placeholder": null,
+          "properties": null,
+          "category": null,
+          "depends_on": null,
+          "readOnly": false,
+          "hidden": false,
+          "minimum": null,
+          "maximum": null,
+          "defaultObjectUI": null,
+          "disabledInputMethods": null,
+          "displayMode": null,
+          "format": null,
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "presets": [
+    {
+      "name": "Track Calls",
+      "type": "automatic",
+      "partnerAction": "trackEvent",
+      "subscribe": "type = \"track\"",
+      "mapping": {
+        "messageId": {
+          "@path": "$.messageId"
+        },
+        "eventName": {
+          "@path": "$.event"
+        },
+        "timestamp": {
+          "@path": "$.timestamp"
+        },
+        "userId": {
+          "@path": "$.userId"
+        },
+        "anonymousId": {
+          "@path": "$.anonymousId"
+        },
+        "eventCategory": "feature_usage",
+        "properties": {
+          "@path": "$.properties"
+        },
+        "enable_batching": true,
+        "batch_size": 1000
+      }
+    },
+    {
+      "name": "Identify Calls",
+      "type": "automatic",
+      "partnerAction": "identifyUser",
+      "subscribe": "type = \"identify\" and context.groupId != null",
+      "mapping": {
+        "userId": {
+          "@path": "$.userId"
+        },
+        "accountExternalId": {
+          "@path": "$.context.groupId"
+        },
+        "email": {
+          "@path": "$.traits.email"
+        },
+        "name": {
+          "@path": "$.traits.name"
+        },
+        "phone": {
+          "@path": "$.traits.phone"
+        },
+        "role": {
+          "@path": "$.traits.title"
+        },
+        "traits": {
+          "@path": "$.traits"
+        }
+      }
+    },
+    {
+      "name": "Group Calls",
+      "type": "automatic",
+      "partnerAction": "groupCompany",
+      "subscribe": "type = \"group\"",
+      "mapping": {
+        "groupId": {
+          "@path": "$.groupId"
+        },
+        "name": {
+          "@path": "$.traits.name"
+        },
+        "domain": {
+          "@path": "$.traits.website"
+        },
+        "industry": {
+          "@path": "$.traits.industry"
+        },
+        "employeeCount": {
+          "@path": "$.traits.employees"
+        },
+        "plan": {
+          "@path": "$.traits.plan"
+        }
+      }
+    }
+  ]
+}

--- a/packages/destination-actions/src/destinations/gaintrace/pageView/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/pageView/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { API_BASE } from '../../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('GainTrace.pageView', () => {
+  it('sends a page as a navigation-category event', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    await testDestination.testAction('pageView', {
+      settings,
+      mapping: { messageId: 'm-1', eventName: 'Pricing', timestamp: '2026-03-14T09:12:00.000Z', userId: 'u' }
+    })
+
+    expect(body.events[0]).toMatchObject({ event_name: 'Pricing', event_category: 'navigation' })
+  })
+
+  it('falls back to a stable name when the page call carries none', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    await testDestination.testAction('pageView', {
+      settings,
+      mapping: { messageId: 'm-1', timestamp: '2026-03-14T09:12:00.000Z', userId: 'u' }
+    })
+
+    expect(body.events[0].event_name).toBe('Page Viewed')
+  })
+
+  it('ships without a preset so page volume is opt-in', () => {
+    const names = (Definition.presets ?? []).map((p) => p.name)
+    expect(names).not.toContain('Page Calls')
+    expect(Definition.actions.pageView).toBeDefined()
+  })
+})
+
+describe('GainTrace.pageView batching', () => {
+  it('applies the page-name fallback across a whole batch', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }, { status: 'inserted' }] } })
+
+    await testDestination.executeBatch('pageView', {
+      settings,
+      events: [
+        createTestEvent({ type: 'page', name: 'Pricing', timestamp: '2026-01-01T00:00:00.000Z', userId: 'u1' }),
+        createTestEvent({ type: 'page', name: undefined, timestamp: '2026-01-02T00:00:00.000Z', userId: 'u2' })
+      ],
+      mapping: {
+        messageId: { '@path': '$.messageId' },
+        eventName: { '@path': '$.name' },
+        timestamp: { '@path': '$.timestamp' },
+        userId: { '@path': '$.userId' }
+      }
+    })
+
+    expect(body.events.map((e: any) => e.event_name)).toEqual(['Pricing', 'Page Viewed'])
+    expect(body.events.every((e: any) => e.event_category === 'navigation')).toBe(true)
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/pageView/generated-types.ts
@@ -1,0 +1,42 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.
+   */
+  messageId: string
+  /**
+   * The name of the page, for example "Pricing". Defaults to "Page Viewed" when the call carries no name.
+   */
+  eventName?: string
+  /**
+   * When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.
+   */
+  timestamp: string | number
+  /**
+   * The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.
+   */
+  userId?: string
+  /**
+   * The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.
+   */
+  anonymousId?: string
+  /**
+   * How GainTrace should classify the event.
+   */
+  eventCategory?: string
+  /**
+   * Properties to store alongside the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+}

--- a/packages/destination-actions/src/destinations/gaintrace/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/pageView/index.ts
@@ -1,0 +1,99 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { MAX_EVENTS_PER_REQUEST, sendEvents } from '../api'
+
+/** Page calls often carry no name; a stable fallback keeps them attributable. */
+function withPageName(payload: Payload): Payload {
+  return payload.eventName ? payload : { ...payload, eventName: 'Page Viewed' }
+}
+
+const EVENT_CATEGORIES = ['feature_usage', 'navigation', 'api', 'billing', 'support', 'auth', 'integration', 'admin']
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Page View',
+  description:
+    'Send a page view to GainTrace as a navigation event. Off by default: page traffic is high volume and contributes less to account health than product events.',
+  defaultSubscription: 'type = "page"',
+  fields: {
+    messageId: {
+      label: 'Message ID',
+      description:
+        "Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.",
+      type: 'string',
+      required: true,
+      default: { '@path': '$.messageId' }
+    },
+    eventName: {
+      label: 'Page Name',
+      description:
+        'The name of the page, for example "Pricing". Defaults to "Page Viewed" when the call carries no name.',
+      type: 'string',
+      default: { '@path': '$.name' }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description:
+        'When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.',
+      type: 'datetime',
+      required: true,
+      default: { '@path': '$.timestamp' }
+    },
+    userId: {
+      label: 'User ID',
+      description:
+        'The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.',
+      type: 'string',
+      // An event needs at least one identifier or it cannot be attributed to a
+      // person or a company. Expressed conditionally so the mapping UI catches
+      // it while the customer is configuring, rather than at delivery time.
+      required: {
+        conditions: [{ fieldKey: 'anonymousId', operator: 'is', value: undefined }]
+      },
+      default: { '@path': '$.userId' }
+    },
+    anonymousId: {
+      label: 'Anonymous ID',
+      description:
+        'The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.',
+      type: 'string',
+      required: {
+        conditions: [{ fieldKey: 'userId', operator: 'is', value: undefined }]
+      },
+      default: { '@path': '$.anonymousId' }
+    },
+    eventCategory: {
+      label: 'Event Category',
+      description: 'How GainTrace should classify the event.',
+      type: 'string',
+      choices: EVENT_CATEGORIES.map((value) => ({ label: value, value })),
+      default: 'navigation'
+    },
+    properties: {
+      label: 'Event Properties',
+      description: 'Properties to store alongside the event.',
+      type: 'object',
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue',
+      default: { '@path': '$.properties' }
+    },
+    enable_batching: {
+      label: 'Batch Data to GainTrace',
+      description:
+        'If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.',
+      type: 'boolean',
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: MAX_EVENTS_PER_REQUEST,
+      unsafe_hidden: true
+    }
+  },
+  perform: (request, { payload }) => sendEvents(request, [withPageName(payload)], 'navigation', false),
+  performBatch: (request, { payload }) => sendEvents(request, payload.map(withPageName), 'navigation', true)
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gaintrace/trackEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/trackEvent/__tests__/index.test.ts
@@ -1,0 +1,189 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { API_BASE, MAX_EVENTS_PER_REQUEST } from '../../api'
+
+const testDestination = createTestIntegration(Definition)
+const settings = { apiKey: 'gt_live_testkey' }
+
+const mapping = (over: Record<string, unknown> = {}) => ({
+  messageId: 'msg-1',
+  eventName: 'Report Exported',
+  timestamp: '2026-03-14T09:12:00.000Z',
+  userId: 'user-1',
+  ...over
+})
+
+afterEach(() => {
+  nock.cleanAll()
+})
+
+describe('GainTrace.trackEvent', () => {
+  it('sends a single event in the API envelope', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { inserted: 1, results: [{ status: 'inserted' }] } })
+
+    await testDestination.testAction('trackEvent', { settings, mapping: mapping() })
+
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0]).toMatchObject({
+      event_name: 'Report Exported',
+      event_category: 'feature_usage',
+      source: 'segment',
+      source_event_id: 'msg-1',
+      timestamp: '2026-03-14T09:12:00.000Z',
+      user_id: 'user-1'
+    })
+  })
+
+  it('preserves a backdated timestamp instead of the time of receipt', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    // A replay delivers events months old. Sending "now" would put a customer's
+    // whole history on today's date and destroy every trend.
+    await testDestination.testAction('trackEvent', {
+      settings,
+      mapping: mapping({ timestamp: '2025-11-02T08:30:00.000Z' })
+    })
+    expect(body.events[0].timestamp).toBe('2025-11-02T08:30:00.000Z')
+  })
+
+  it('accepts a future timestamp rather than second-guessing the sender clock', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    await testDestination.testAction('trackEvent', { settings, mapping: mapping({ timestamp: future }) })
+    expect(body.events[0].timestamp).toBe(future)
+  })
+
+  it('rejects an event with no identifier', async () => {
+    // userId and anonymousId are conditionally required on each other, so the
+    // framework rejects this while the customer is still configuring the
+    // mapping rather than at delivery time. `validateEvent` keeps the same rule
+    // as a backstop for any other call site; that is covered in api.test.ts.
+    await expect(
+      testDestination.testAction('trackEvent', {
+        settings,
+        mapping: mapping({ userId: undefined, anonymousId: undefined })
+      })
+    ).rejects.toThrowError(/required field 'userId'|required field 'anonymousId'/i)
+  })
+
+  it('omits properties entirely rather than sending an empty object', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    await testDestination.testAction('trackEvent', { settings, mapping: mapping({ properties: {} }) })
+    expect(body.events[0]).not.toHaveProperty('properties')
+  })
+
+  it('ignores inherited and prototype-polluting keys on properties', async () => {
+    let body: any
+    nock(API_BASE)
+      .post('/events', (b) => {
+        body = b
+        return true
+      })
+      .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+    const props = Object.create({ inherited: 'nope' }) as Record<string, unknown>
+    props.real = 'yes'
+    await testDestination.testAction('trackEvent', { settings, mapping: mapping({ properties: props }) })
+
+    expect(body.events[0].properties).toEqual({ real: 'yes' })
+    expect(body.events[0].properties).not.toHaveProperty('inherited')
+  })
+
+  describe('batching', () => {
+    it('sends one request for the whole batch and reports per-event success', async () => {
+      let body: any
+      nock(API_BASE)
+        .post('/events', (b) => {
+          body = b
+          return true
+        })
+        .reply(201, {
+          data: { results: [{ status: 'inserted' }, { status: 'duplicate' }] }
+        })
+
+      const response = await testDestination.testBatchAction('trackEvent', {
+        settings,
+        events: [
+          { type: 'track', event: 'A', messageId: 'm-1', timestamp: '2026-01-01T00:00:00.000Z', userId: 'u1' },
+          { type: 'track', event: 'B', messageId: 'm-2', timestamp: '2026-01-02T00:00:00.000Z', userId: 'u2' }
+        ] as never,
+        mapping: {
+          messageId: { '@path': '$.messageId' },
+          eventName: { '@path': '$.event' },
+          timestamp: { '@path': '$.timestamp' },
+          userId: { '@path': '$.userId' }
+        },
+        useDefaultMappings: false
+      })
+
+      expect(body.events).toHaveLength(2)
+      // A duplicate is a successful delivery: GainTrace already has the event.
+      expect(response).toBeDefined()
+    })
+
+    it('never echoes event properties back in the per-item result', async () => {
+      nock(API_BASE)
+        .post('/events')
+        .reply(201, { data: { results: [{ status: 'inserted' }] } })
+
+      const response = await testDestination.executeBatch('trackEvent', {
+        settings,
+        events: [
+          createTestEvent({
+            type: 'track',
+            event: 'A',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            userId: 'u1',
+            properties: { email: 'person@example.com', ssn: 'secret' }
+          })
+        ],
+        mapping: {
+          messageId: { '@path': '$.messageId' },
+          eventName: { '@path': '$.event' },
+          timestamp: { '@path': '$.timestamp' },
+          userId: { '@path': '$.userId' },
+          properties: { '@path': '$.properties' }
+        }
+      })
+
+      // MultiStatus results are surfaced in the UI and stored, so they must not
+      // carry personal data lifted from event properties.
+      const entry = JSON.stringify(response[0])
+      expect(entry).not.toContain('person@example.com')
+      expect(entry).not.toContain('secret')
+      expect(entry).toContain('source_event_id')
+    })
+  })
+
+  it('declares a batch size no larger than the documented API ceiling', () => {
+    const field: any = Definition.actions.trackEvent.fields.batch_size
+    expect(field.default).toBeLessThanOrEqual(MAX_EVENTS_PER_REQUEST)
+  })
+})

--- a/packages/destination-actions/src/destinations/gaintrace/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/trackEvent/generated-types.ts
@@ -1,0 +1,42 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.
+   */
+  messageId: string
+  /**
+   * The name of the event, for example "Report Exported".
+   */
+  eventName: string
+  /**
+   * When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.
+   */
+  timestamp: string | number
+  /**
+   * The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.
+   */
+  userId?: string
+  /**
+   * The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.
+   */
+  anonymousId?: string
+  /**
+   * How GainTrace should classify the event.
+   */
+  eventCategory?: string
+  /**
+   * Properties to store alongside the event.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.
+   */
+  enable_batching?: boolean
+  /**
+   * Maximum number of events to include in each batch. Actual batch sizes may be lower.
+   */
+  batch_size?: number
+}

--- a/packages/destination-actions/src/destinations/gaintrace/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/trackEvent/index.ts
@@ -1,0 +1,93 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { MAX_EVENTS_PER_REQUEST, sendEvents } from '../api'
+
+const EVENT_CATEGORIES = ['feature_usage', 'navigation', 'api', 'billing', 'support', 'auth', 'integration', 'admin']
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Send a product usage event to GainTrace. Events drive feature adoption, engagement and account health.',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    messageId: {
+      label: 'Message ID',
+      description:
+        "Segment's unique message ID. GainTrace stores it as the event's deduplication key, so redelivered or replayed events are counted once.",
+      type: 'string',
+      required: true,
+      default: { '@path': '$.messageId' }
+    },
+    eventName: {
+      label: 'Event Name',
+      description: 'The name of the event, for example "Report Exported".',
+      type: 'string',
+      required: true,
+      default: { '@path': '$.event' }
+    },
+    timestamp: {
+      label: 'Timestamp',
+      description:
+        'When the event occurred, as an ISO-8601 timestamp. GainTrace stores this rather than the time of receipt, so historical replays land on the correct dates.',
+      type: 'datetime',
+      required: true,
+      default: { '@path': '$.timestamp' }
+    },
+    userId: {
+      label: 'User ID',
+      description:
+        'The identifier for the person who performed the event. Matched against a GainTrace person by external ID or email. Required unless an Anonymous ID is provided.',
+      type: 'string',
+      // An event needs at least one identifier or it cannot be attributed to a
+      // person or a company. Expressed conditionally so the mapping UI catches
+      // it while the customer is configuring, rather than at delivery time.
+      required: {
+        conditions: [{ fieldKey: 'anonymousId', operator: 'is', value: undefined }]
+      },
+      default: { '@path': '$.userId' }
+    },
+    anonymousId: {
+      label: 'Anonymous ID',
+      description:
+        'The anonymous identifier for the visitor, used when no User ID is known yet. Required unless a User ID is provided.',
+      type: 'string',
+      required: {
+        conditions: [{ fieldKey: 'userId', operator: 'is', value: undefined }]
+      },
+      default: { '@path': '$.anonymousId' }
+    },
+    eventCategory: {
+      label: 'Event Category',
+      description: 'How GainTrace should classify the event.',
+      type: 'string',
+      choices: EVENT_CATEGORIES.map((value) => ({ label: value, value })),
+      default: 'feature_usage'
+    },
+    properties: {
+      label: 'Event Properties',
+      description: 'Properties to store alongside the event.',
+      type: 'object',
+      additionalProperties: true,
+      defaultObjectUI: 'keyvalue',
+      default: { '@path': '$.properties' }
+    },
+    enable_batching: {
+      label: 'Batch Data to GainTrace',
+      description:
+        'If true, Segment sends events to GainTrace in batches. GainTrace accepts up to 1000 events per request.',
+      type: 'boolean',
+      default: true
+    },
+    batch_size: {
+      label: 'Batch Size',
+      description: 'Maximum number of events to include in each batch. Actual batch sizes may be lower.',
+      type: 'number',
+      default: MAX_EVENTS_PER_REQUEST,
+      unsafe_hidden: true
+    }
+  },
+  perform: (request, { payload }) => sendEvents(request, [payload], 'feature_usage', false),
+  performBatch: (request, { payload }) => sendEvents(request, payload, 'feature_usage', true)
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/gaintrace/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/gaintrace/versioning-info.ts
@@ -1,0 +1,7 @@
+/** GAINTRACE_API_VERSION
+ * GainTrace public API version. Every request this destination makes is versioned
+ * under this path segment, so a future major version is a one-line change here
+ * rather than a search across actions.
+ * API reference: https://docs.gaintrace.com/api-reference
+ */
+export const GAINTRACE_API_VERSION = 'v1'


### PR DESCRIPTION
Adds **GainTrace**, a cloud-mode Actions destination. GainTrace is a customer success platform for B2B SaaS: it turns product usage into a per-company view, scores account health, and surfaces churn risk signals.

Four actions, one integration, no changes to any other destination.

| Action | Default subscription | Endpoint |
|---|---|---|
| Track Event | `type = "track"` | `POST /api/v1/events` |
| Identify User | `type = "identify" and context.groupId != null` | `POST /api/v1/contacts` |
| Group Company | `type = "group"` | `POST /api/v1/companies` |
| Page View | none (opt-in) | `POST /api/v1/events` |

## Testing

Every method in [docs/testing.md](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md) was exercised, not only unit tests.

**Local server** (`./bin/run serve --destination=gaintrace -n`) plus cURL against `perform()`, `performBatch()`, `testAuthentication()` and `delete()`.

**Against our production API with a real key:** a group, identify and track call created the company, the person and the events; the person attached to the company via `groupId`; events attributed to both person and company; events kept their original backdated timestamps (`2026-01-05`, `2026-02-11`) rather than ingestion time; and replaying the identical batch three times left exactly one row per event. Re-sending the same identify updated one person rather than creating a second, and merged traits rather than replacing them. Test data was removed afterwards.

- 51 unit tests across 7 suites, plus 16 snapshots
- 100% of lines and functions covered
- `nx build @segment/action-destinations`, `eslint`, `prettier --check` all clean
- `generated-types.ts` produced by `./bin/run generate:types`
- `./bin/run list-required-fields` clean; the required set is minimal

- [x] Added unit tests for new functionality
- [x] Tested end-to-end using the local server
- [ ] [If destination is already live] Tested for backward compatibility — n/a, new destination
- [ ] [Segmenters] Tested in the staging environment — n/a
- [ ] [Segmenters] Tested for regression with Hadron — n/a

## Security Review

- [x] **Reviewed all field definitions** for sensitive data and confirmed they use `type: 'password'`

The only credential is `apiKey`, which is `type: 'password'` and travels in the `Authorization` header via `extendRequest`. It is never placed in a request body. MultiStatus per-item results carry only `source_event_id`, never event properties, since those bodies are surfaced and stored and event properties can contain personal data. There is a test asserting no PII leaks into a MultiStatus entry.

## New Destination Checklist

- [x] Extracted all action API versions to a `versioning-info.ts` file

## Notes for review

Answering things I expect to come up, based on recent destination PRs.

**Batching is backed by a real batch endpoint.** `POST /api/v1/events` accepts up to 1000 events in one request and returns a per-event result array. This is not `Promise.all` over single posts.

**One code path for single and batch.** `perform` wraps its payload in an array and calls the same `sendEvents()` as `performBatch`. The only branch is the return value: a batch returns a `MultiStatusResponse`, a single send returns the raw response.

**The 1000-event cap is enforced in code**, not only declared via `batch_size`.

**Conditionally required identifiers.** `userId` and `anonymousId` are each required only when the other is absent, so the mapping UI catches an unattributable event during configuration rather than at delivery. Same on Identify User, where `userId` is required unless an `email` is mapped, so an email-only identify still works.

**Expect the required-field bot to comment.** Those conditional fields will trip `REQUIRED_FIELD_WARNING_TEMPLATE`. Per that template, the warning is not applicable here: this is a new destination with no active customers, so there is no existing configuration to migrate.

**`testAuthentication` makes a real authenticated request** (`GET /companies?limit=1`) and throws `InvalidAuthenticationError`. It does not merely check that a required setting is present.

**Timestamps come from the event and are never clock-validated.** GainTrace stores the event `timestamp` rather than the time of receipt and deduplicates on Segment's `messageId`, so replaying historical data is idempotent and lands on the correct dates. There is deliberately no future-timestamp guard, since a sending client's clock may legitimately run ahead.

**Identify is narrowly subscribed on purpose.** A person in GainTrace always belongs to a company, so `accountExternalId` is required. Rather than let identify calls without a group association fail delivery, the subscription filters them so they are reported as filtered.

**Page View ships without a preset.** Page traffic is high volume and adds little to account health, so customers opt in rather than out.

**Not registered in `destinations/index.ts`.** `register()` needs a metadata ID that Segment mints, so I have not invented one. Recent destinations have had that line added in a follow-up (`mntn-audiences` in #3898). Happy to add it in this PR if you send me the ID, or leave it to the usual registration PR — whichever you prefer.

## Docs

A docs PR to `segmentio/segment-docs` at `src/connections/destinations/catalog/actions-gaintrace/index.md` will follow, written from `doc-template-new.md`. Catalog metadata (description, categories, logo, mark, support address) is ready to send to partner-support.
