### PR TITLE
[STRATCONN-6957] [Google enhanced conversion] :  upgraded the canary version of google enhanaced conversion to v25 (latest version) 

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/canary-v25.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/canary-v25.test.ts
@@ -1,0 +1,314 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, SegmentEvent } from '@segment/actions-core'
+import GoogleEnhancedConversions from '../index'
+import { API_VERSION, CANARY_API_VERSION, FLAGON_NAME } from '../functions'
+
+/**
+ * Canary v25 Tests
+ * Verifies that when the `google-enhanced-canary-version` feature flag is enabled,
+ * all actions route requests to the canary API version (v25) instead of the stable version (v22).
+ */
+
+const testDestination = createTestIntegration(GoogleEnhancedConversions)
+const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight Time)').toISOString()
+const customerId = '1234'
+
+describe('Google Enhanced Conversions — Canary v25', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  // ─── uploadClickConversion ────────────────────────────────────────────────
+
+  describe('uploadClickConversion', () => {
+    it('single event: uses canary v25 URL when flagon is enabled', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test@gmail.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD'
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+
+    it('single event: uses stable v22 URL when flagon is disabled', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test@gmail.com',
+          orderId: '1234',
+          total: '200',
+          currency: 'USD'
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: false }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(API_VERSION)
+      expect(responses[0].url).not.toContain(CANARY_API_VERSION)
+    })
+
+    it('batch event: uses canary v25 URL when flagon is enabled', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '300', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}, {}] })
+
+      const responses = await testDestination.testBatchAction('uploadClickConversion', {
+        events,
+        mapping: { conversion_action: '12345' },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+
+    it('single event: canary v25 with custom variables uses v25 for searchStream', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: { gclid: '54321', orderId: '1234', total: '200', currency: 'USD' }
+      })
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(200, [
+          {
+            results: [
+              {
+                conversionCustomVariable: {
+                  resourceName: `customers/${customerId}/conversionCustomVariables/123445`,
+                  id: '123445',
+                  name: 'username'
+                }
+              }
+            ]
+          }
+        ])
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadClickConversion', {
+        event,
+        mapping: { conversion_action: '12345', custom_variables: { username: 'spongebob' } },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(2)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+      expect(responses[1].url).toContain(CANARY_API_VERSION)
+      expect(responses[1].status).toBe(201)
+    })
+  })
+
+  // ─── uploadCallConversion ─────────────────────────────────────────────────
+
+  describe('uploadCallConversion', () => {
+    it('single event: uses canary v25 URL when flagon is enabled', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: { total: '200', currency: 'USD' }
+      })
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadCallConversion', {
+        event,
+        mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+
+    it('batch event: uses canary v25 URL when flagon is enabled', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { total: '300', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadCallConversions`)
+        .post('')
+        .reply(201, { results: [{}, {}] })
+
+      const responses = await testDestination.testBatchAction('uploadCallConversion', {
+        events,
+        mapping: { conversion_action: '12345', caller_id: '+1234567890', call_timestamp: timestamp },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+  })
+
+  // ─── uploadConversionAdjustment ───────────────────────────────────────────
+
+  describe('uploadConversionAdjustment', () => {
+    it('single event: uses canary v25 URL when flagon is enabled', async () => {
+      const event = createTestEvent({
+        timestamp,
+        event: 'Test Event',
+        properties: {
+          gclid: '54321',
+          email: 'test@gmail.com',
+          orderId: '1234',
+          currency: 'USD',
+          value: '123'
+        }
+      })
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}] })
+
+      const responses = await testDestination.testAction('uploadConversionAdjustment', {
+        event,
+        mapping: {
+          gclid: { '@path': '$.properties.gclid' },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          restatement_value: { '@path': '$.properties.value' },
+          restatement_currency_code: { '@path': '$.properties.currency' }
+        },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+
+    it('batch event: uses canary v25 URL when flagon is enabled', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', orderId: '1234', currency: 'USD', value: '123' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', orderId: '1235', currency: 'USD', value: '456' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${CANARY_API_VERSION}/customers/${customerId}:uploadConversionAdjustments`)
+        .post('')
+        .reply(201, { results: [{}, {}] })
+
+      const responses = await testDestination.testBatchAction('uploadConversionAdjustment', {
+        events,
+        mapping: {
+          gclid: { '@path': '$.properties.gclid' },
+          conversion_action: '12345',
+          adjustment_type: 'ENHANCEMENT',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          restatement_value: { '@path': '$.properties.value' },
+          restatement_currency_code: { '@path': '$.properties.currency' }
+        },
+        useDefaultMappings: true,
+        settings: { customerId },
+        features: { [FLAGON_NAME]: true }
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+      expect(responses[0].url).toContain(CANARY_API_VERSION)
+    })
+  })
+
+  // ─── getApiVersion helper ─────────────────────────────────────────────────
+
+  describe('getApiVersion', () => {
+    it('returns CANARY_API_VERSION (v25) when flagon is enabled', async () => {
+      expect(CANARY_API_VERSION).toBe('v25')
+    })
+
+    it('CANARY_API_VERSION differs from stable API_VERSION', async () => {
+      const { API_VERSION } = await import('../functions')
+      expect(CANARY_API_VERSION).not.toBe(API_VERSION)
+      expect(CANARY_API_VERSION).toBe('v25')
+      expect(API_VERSION).toBe('v22')
+    })
+
+    it('FLAGON_NAME is the correct feature flag key', () => {
+      expect(FLAGON_NAME).toBe('google-enhanced-canary-version')
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/functions.test.ts
@@ -131,7 +131,7 @@ describe('.getConversionActionId', () => {
       }
     }
     nock(`https://googleads.googleapis.com`)
-      .post(`/v22/customers/${settings.customerId}/googleAds:searchStream`)
+      .post(`/${CANARY_API_VERSION}/customers/${settings.customerId}/googleAds:searchStream`)
       .reply(401, errorResponse)
 
     const payload = {}

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/versioning-info.ts
@@ -3,7 +3,7 @@
  * API reference: https://developers.google.com/google-ads/api/docs/upgrade
  */
 export const GOOGLE_ENHANCED_CONVERSIONS_API_VERSION = 'v22'
-export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v22'
+export const GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION = 'v25'
 
 /** GOOGLE_ENHANCED_CONVERSIONS_EVENTS_API_VERSION
  * Google Ads event API version.


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

 https://twilio-engineering.atlassian.net/browse/STRATCONN-6957
 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. This PR introduces the changes for upgradation of google enhanced conversion canary version to v25 .
2. It has the v22 for api version and this version is going to sunset on October 2026 https://developers.google.com/google-ads/api/docs/sunset-dates
3. Added the testcases for new version v25.


## Testing

Tested done in staging 
please find the testing document .
https://docs.google.com/document/d/1lTnPz0MDpcAotX59Zd0SXUkk71cwNHflJMpN0cA3_mg/edit?tab=t.0

Rollout using the flagon deployment for version .
https://flagon.segment.com/families/centrifuge-destinations/gates/google-enhanced-canary-version


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
