### PR TITLE
fix(braze-web): gate deferUntilIdentified on a fresh identify, not localStorage

### DIFF
--- a/packages/browser-destinations/destinations/braze/src/__tests__/initialization.test.ts
+++ b/packages/browser-destinations/destinations/braze/src/__tests__/initialization.test.ts
@@ -137,6 +137,66 @@ describe('initialization', () => {
     expect(logCustomEventSpy).toHaveBeenCalledWith('FIFA', { goat: 'deno' })
   })
 
+  test('does not initialize when a userId is only present in persisted storage (no identify this page load)', async () => {
+    const [updateUserProfile, trackEvent] = await brazeDestination({
+      api_key: 'b_123',
+      deferUntilIdentified: true,
+      subscriptions: destination.presets?.map((sub) => ({ ...sub, enabled: true })) as Subscription[],
+      ...settings
+    })
+
+    const initializeSpy = jest.spyOn(destination, 'initialize')
+    const analytics = new Analytics({ writeKey: '123' })
+
+    await analytics.register(updateUserProfile, trackEvent)
+
+    // Simulate a userId persisted from a prior session (ajs_user_id in localStorage).
+    // This must NOT be enough to open a Braze session on its own.
+    jest.spyOn(analytics.user(), 'id').mockReturnValue('stale-user-123')
+
+    const { instance: braze } = await initializeSpy.mock.results[0].value
+    const openSessionSpy = jest.spyOn(braze, 'openSession')
+    const changeUserSpy = jest.spyOn(braze, 'changeUser')
+
+    await analytics.track?.({
+      type: 'track',
+      event: 'UFC',
+      properties: {
+        goat: 'hasbulla'
+      }
+    })
+
+    expect(analytics.user().id()).toBe('stale-user-123')
+    expect(openSessionSpy).not.toHaveBeenCalled()
+    expect(changeUserSpy).not.toHaveBeenCalled()
+  })
+
+  test('changes to the identified user before opening the session', async () => {
+    const [updateUserProfile, trackEvent] = await brazeDestination({
+      api_key: 'b_123',
+      deferUntilIdentified: true,
+      subscriptions: destination.presets?.map((sub) => ({ ...sub, enabled: true })) as Subscription[],
+      ...settings
+    })
+
+    const initializeSpy = jest.spyOn(destination, 'initialize')
+    const analytics = new Analytics({ writeKey: '123' })
+
+    await analytics.register(updateUserProfile, trackEvent)
+
+    const { instance: braze } = await initializeSpy.mock.results[0].value
+    const openSessionSpy = jest.spyOn(braze, 'openSession')
+    const changeUserSpy = jest.spyOn(braze, 'changeUser')
+
+    await analytics.identify('user-42')
+
+    expect(changeUserSpy).toHaveBeenCalledWith('user-42')
+    expect(openSessionSpy).toHaveBeenCalled()
+    // changeUser must run before openSession so the session is attributed to the
+    // known user and Braze does not create a separate anonymous profile.
+    expect(changeUserSpy.mock.invocationCallOrder[0]).toBeLessThan(openSessionSpy.mock.invocationCallOrder[0])
+  })
+
   test('passes devicePropertyAllowlist to Braze SDK initialization', async () => {
     const devicePropertyAllowlist = ['os', 'browser']
     const [event] = await brazeDestination({

--- a/packages/browser-destinations/destinations/braze/src/braze-types.ts
+++ b/packages/browser-destinations/destinations/braze/src/braze-types.ts
@@ -9,5 +9,5 @@ export type BrazeDestinationClient = {
   // Records the userId from an identify observed in the current page load so that,
   // when `deferUntilIdentified` is enabled, `ready()` can gate initialization on a
   // fresh identify instead of a value persisted in localStorage.
-  setDeferredUser?: (userId: string) => void
+  setDeferredUser: (userId: string) => void
 }

--- a/packages/browser-destinations/destinations/braze/src/braze-types.ts
+++ b/packages/browser-destinations/destinations/braze/src/braze-types.ts
@@ -6,4 +6,8 @@ export type BrazeType = typeof braze | typeof appboy
 export type BrazeDestinationClient = {
   instance: BrazeType
   ready: () => boolean
+  // Records the userId from an identify observed in the current page load so that,
+  // when `deferUntilIdentified` is enabled, `ready()` can gate initialization on a
+  // fresh identify instead of a value persisted in localStorage.
+  setDeferredUser?: (userId: string) => void
 }

--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -398,7 +398,10 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
 
           // Attribute the session to the identified user before opening it so Braze
           // does not create a separate, un-mergeable anonymous profile for this device.
-          if (deferredUserId !== undefined) {
+          // Gated on `deferUntilIdentified` so behavior is provably unchanged when the
+          // setting is off: in that path attribution is handled by updateUserProfile's
+          // own changeUser() on identify, and the session opens as before.
+          if (deferUntilIdentified && deferredUserId !== undefined) {
             client.instance.changeUser(deferredUserId)
           }
 

--- a/packages/browser-destinations/destinations/braze/src/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/index.ts
@@ -319,7 +319,7 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
         'By default, sessions time out after 30 minutes of inactivity. Provide a value for this configuration option to override that default with a value of your own.'
     }
   },
-  initialize: async ({ settings, analytics }, dependencies) => {
+  initialize: async ({ settings }, dependencies) => {
     try {
       const {
         endpoint,
@@ -354,6 +354,10 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
       }
 
       let initialized = false
+      // userId captured from an identify seen during the current page load (set via
+      // `setDeferredUser` from the updateUserProfile action). Undefined until an
+      // identify actually fires this load.
+      let deferredUserId: string | undefined
 
       const client: BrazeDestinationClient = {
         instance: version.indexOf('3.') === 0 ? window.appboy : window.braze,
@@ -362,7 +366,12 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
             return true
           }
 
-          if (deferUntilIdentified && typeof analytics.user().id() !== 'string') {
+          // When deferring, only initialize once an identify with a userId has been
+          // observed in the current page load. We intentionally do NOT read
+          // analytics.user().id() here: that resolves from the persisted ajs_user_id
+          // in localStorage, which stays set across sessions and would let the SDK
+          // open an anonymous session on page loads where no identify actually fired.
+          if (deferUntilIdentified && deferredUserId === undefined) {
             return false
           }
 
@@ -387,9 +396,18 @@ export const destination: BrowserDestinationDefinition<Settings, BrazeDestinatio
             }
           }
 
+          // Attribute the session to the identified user before opening it so Braze
+          // does not create a separate, un-mergeable anonymous profile for this device.
+          if (deferredUserId !== undefined) {
+            client.instance.changeUser(deferredUserId)
+          }
+
           client.instance.openSession()
 
           return (initialized = true)
+        },
+        setDeferredUser: (userId: string) => {
+          deferredUserId = userId
         }
       }
 

--- a/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
@@ -179,7 +179,7 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
     // When deferUntilIdentified is enabled this is what allows ready() to initialize
     // the SDK, using this fresh userId rather than a stale value from localStorage.
     if (payload.external_id) {
-      client.setDeferredUser?.(payload.external_id)
+      client.setDeferredUser(payload.external_id)
     }
 
     if (!client.ready()) {

--- a/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
+++ b/packages/browser-destinations/destinations/braze/src/updateUserProfile/index.ts
@@ -175,6 +175,13 @@ const action: BrowserActionDefinition<Settings, BrazeDestinationClient, Payload>
   },
 
   perform: (client, { payload }) => {
+    // Record the identified user for the current page load before checking ready().
+    // When deferUntilIdentified is enabled this is what allows ready() to initialize
+    // the SDK, using this fresh userId rather than a stale value from localStorage.
+    if (payload.external_id) {
+      client.setDeferredUser?.(payload.external_id)
+    }
+
     if (!client.ready()) {
       return
     }


### PR DESCRIPTION
## Summary

Fixes a bug in **Braze Web Mode (Actions)** where the **"Only Track Known Users"** setting (`deferUntilIdentified`) still created permanent anonymous Braze profiles.

The guard in the `ready()` closure checked `analytics.user().id()`, which resolves from the **persisted** `ajs_user_id` value in localStorage. That value survives across sessions, so the guard passed on page loads where a userId was cached but **no `identify()` fired in the current page load**. Braze then ran `initialize()` + `openSession()` without `changeUser()`, producing anonymous profiles (device ID, no external ID) that Braze can never merge and that still count against Braze MAU billing.

### Fix

Gate initialization on an identify **actually observed in the current page load**, not on a cached localStorage value:

- `updateUserProfile` (subscribed to `identify`) records the fresh `userId` via a new `client.setDeferredUser()` before calling `ready()`.
- `ready()` gates on that in-session value and calls `changeUser()` **before** `openSession()`, so the session is attributed to the known user.

This matches the original intent of **DEST-1710**, the analogous fix in the classic (non-Actions) Braze destination.

### Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Stale `ajs_user_id` in localStorage, no identify this load (Path A) | Opens session → orphan anonymous profile | No init, no session ✅ |
| Login race — identify fires, init runs before `updateUserProfile` (Path B) | Anonymous profile + identified profile (unmerged) | `changeUser()` before `openSession()` → single attributed profile ✅ |
| `deferUntilIdentified` **off** | Unchanged | Unchanged |

Jira: STRATCONN-6967

### Rollout note

Behavior only changes when the setting is ON, but since Braze is high-volume, reviewers may want to gate the rollout behind a feature flag per repo guidance for critical destinations.

## Testing

Path 1: Braze sdk is no longer initiialized if identify is not called.
<img width="2992" height="1934" alt="image" src="https://github.com/user-attachments/assets/d6cdc0d8-4c3d-4c6b-a8df-cd99b6f10171" />


Path 2: login race (identify fires) Steps: clear site data → spy-wrap openSession/changeUser → analytics.identify('user-123'). Console call order on the fixed bundle:
<img width="2992" height="1934" alt="image" src="https://github.com/user-attachments/assets/b86d9132-4dd4-4383-a75a-5d58bcdba7e4" />
<img width="2992" height="1934" alt="image" src="https://github.com/user-attachments/assets/18239add-2ba1-48b7-b33a-bd4f89a57025" />


- [x] Added unit tests for new functionality
- [x] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

Added two tests in `initialization.test.ts`:
- Path A: a stale `analytics.user().id()` does **not** open a session when no identify fires.
- Path B: `changeUser()` is invoked **before** `openSession()` (asserted via `invocationCallOrder`).

Full braze suite: **6 suites / 24 tests pass**. No new required fields; no signature or default changes — backward compatible.

### Manual verification (canary bundle)

Verified in a browser against the deployed canary bundle (Chrome incognito, a page loading analytics.js + Braze Web with **"Only Track Known Users" ON**, `deferUntilIdentified` confirmed on, correct write key).

**Bundle confirmation** — verified the running code is the fixed bundle by searching loaded sources for `setDeferredUser` (present). An earlier run against a not-yet-propagated bundle still reproduced the bug, confirming the check matters.

**Path A — stale `ajs_user_id` in localStorage, no `identify()` this load**

Steps: clear site data → `localStorage.setItem('ajs_user_id', '"user-123"')` → reload, no identify.

| | Pre-fix | Fixed bundle |
| --- | --- | --- |
| `ab.storage.deviceId` / `ab.storage.sessionId` written | yes | **none** |
| `POST /api/v3/data` (session-start `"ss"` event) | 201 Created | **no request** |
| Orphan anonymous profile created | yes | **no** |

Pre-fix (bug reproduced) — session opened, `ab.storage.*` written, `/api/v3/data` 201 with an `"ss"` event:

_➡️ attach screenshot: pre-fix Local Storage (ab.storage.* keys present)_

_➡️ attach screenshot: pre-fix Network `/api/v3/data` 201 + payload with `events:[{name:"ss"}]`_

Fixed bundle — after reload, Local Storage has only `ajs_user_id` / `ajs_anonymous_id`, no `ab.storage.*`, no Braze network call:

_➡️ attach screenshot: fixed-bundle Local Storage (no ab.storage.* after reload)_

**Path B — login race (`identify` fires; init would otherwise open an anonymous session first)**

Steps: clear site data → spy-wrap `openSession`/`changeUser` → `analytics.identify('user-123')`.

Console call order on the fixed bundle:

```
▶ changeUser user-123     ← attribution first (from ready())
▶ openSession             ← session opened after changeUser
▶ changeUser user-123     ← redundant call from updateUserProfile action (idempotent, no orphan)
```

Local Storage after identify now contains `ab.storage.userId.* = g:user-123|…` alongside `ab.storage.sessionId` — a single session attributed to the known user.

_➡️ attach screenshot: Path B console (changeUser before openSession)_

_➡️ attach screenshot: Path B Local Storage (`ab.storage.userId` present)_

**Scale signal (in progress):** watching the Braze anonymous-web-profile creation rate for the canary cohort (external ID blank / 1 session / 0 events) trend toward zero from the pre-fix baseline (~8,000/day) while identified profiles stay flat.

## Security Review

- [x] **Reviewed all field definitions** for sensitive data — no field changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

