### PR TITLE
STRATCONN-2460: Webhook: sign full batch body for X-Signature header

### DIFF
--- a/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
+++ b/packages/destination-actions/src/destinations/webhook/__test__/webhook.test.ts
@@ -125,9 +125,11 @@ export const baseWebhookTests = (def: DestinationDefinition<any>) => {
             // body) so we re-serialize the body here so that we can demonstrate
             // signture validation
 
-            // Validate the signature
+            // Validate the signature against the full batch body (all events),
+            // not just the first event. The X-Signature HMAC must be computed
+            // over the exact body that is sent when batching is enabled.
             const expectSignature = this.req.headers['x-signature'][0]
-            const actualSignature = createHmac('sha1', sharedSecret).update(JSON.stringify(body[0])).digest('hex')
+            const actualSignature = createHmac('sha1', sharedSecret).update(JSON.stringify(body)).digest('hex')
 
             // Use constant-time comparison to avoid timing attacks
             if (

--- a/packages/destination-actions/src/destinations/webhook/index.ts
+++ b/packages/destination-actions/src/destinations/webhook/index.ts
@@ -20,9 +20,14 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   extendRequest: ({ settings, payload }) => {
-    const payloadData = payload.length ? payload[0]['data'] : payload['data']
-    if (settings.sharedSecret && payloadData) {
-      const digest = createHmac('sha1', settings.sharedSecret).update(JSON.stringify(payloadData), 'utf8').digest('hex')
+    // In batch mode `payload` is an array and the request body is the array of
+    // each event's `data`; in single mode it's a single event and the body is
+    // its `data`. Sign the exact body that will be sent so the X-Signature HMAC
+    // matches whether or not batching is enabled.
+    const signedBody = Array.isArray(payload) ? payload.map((p) => p['data']) : payload['data']
+    const hasBody = Array.isArray(payload) ? payload.length > 0 : Boolean(signedBody)
+    if (settings.sharedSecret && hasBody) {
+      const digest = createHmac('sha1', settings.sharedSecret).update(JSON.stringify(signedBody), 'utf8').digest('hex')
       return { headers: { 'X-Signature': digest } }
     }
     return {}


### PR DESCRIPTION
## Summary

Autonomous fix generated by the **ticket-to-fix** pipeline. Every step below ran against the destination's real `serve` runtime — reproduced before the fix, validated after.

**Root cause:** extendRequest computed the X-Signature HMAC over only payload[0]['data'] in batch mode instead of the full array of event data actually sent as the request body.

## Reproduction (before fix)

- Verdict: **CONFIRMED** — reproduced: X-Signature computed over wrong body (header 7d7cc884de40… ≠ 7ec0b73c7bf0… for actual body)
- Status: `200`


## Fix

```
.../src/destinations/webhook/__test__/webhook.test.ts         |  6 ++++--
 .../destination-actions/src/destinations/webhook/index.ts     | 11 ++++++++---
 2 files changed, 12 insertions(+), 5 deletions(-)
```

## Verification (local)

- ✅ lint — clean
- ✅ unit — Test Suites: 1 passed, 1 total | Tests:       7 passed, 7 total

## Validation (after fix, real destination)

- Verdict: **CONFIRMED** — destination accepted the event (200)
- Status: `200`


## Regression tests

- nock unit test added/updated in the destination `__test__` suite (CI guard)
- real-API reproduce spec retained for replay

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) · draft PR, not auto-merged