### PR TITLE
[Memora] Add identifier overlap metrics for batched profile upserts

### DIFF
--- a/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
@@ -1532,14 +1532,15 @@ describe('Memora.upsertProfile', () => {
       profile_traits: { 'Contact.$.firstName': 'X' }
     })
 
-    const runBatch = async (payloads: Payload[]) => {
+    const runBatch = async (payloads: Payload[], statsContext: unknown = mockStatsContext) => {
       const mockRequestFn = jest.fn().mockResolvedValue({ status: 202, data: {}, headers: { get: () => null } })
       await Destination.actions.upsertProfile.performBatch!(mockRequestFn as unknown as RequestClient, {
         payload: payloads,
         settings: defaultSettings,
-        statsContext: mockStatsContext,
+        statsContext: statsContext as never,
         logger: mockLogger as any
       })
+      return mockRequestFn
     }
 
     beforeEach(() => {
@@ -1663,6 +1664,50 @@ describe('Memora.upsertProfile', () => {
       expect(warning).toContain('2 profile(s) resolve to 1 distinct profile(s)')
       expect(warning).toContain('largest group is 2')
       expect(warning).not.toContain('secret@example.com')
+    })
+
+    // Regression: an identifier value of `{ toString: null }` is expressible in plain
+    // JSON and makes String() throw. The metric ran outside the request try/catch, so
+    // one such event rejected the whole batch before the upsert was attempted, with no
+    // status code to mark it non-retryable. Delivery must survive; the batch forfeits
+    // its overlap metrics, which is the accepted tradeoff.
+    it('should still deliver the batch when an identifier value cannot be coerced to a string', async () => {
+      const hostile = JSON.parse('{"toString":null}')
+
+      const mockRequestFn = await runBatch([
+        profile({ 'Contact.$.email': 'ok1@example.com' }),
+        profile({ 'Contact.$.email': hostile }),
+        profile({ 'Contact.$.email': 'ok2@example.com' })
+      ])
+
+      // The bulk upsert must still have been sent, with all three profiles
+      expect(mockRequestFn).toHaveBeenCalledTimes(1)
+      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(3)
+
+      // Metrics for this batch are forfeited rather than emitted, and the failure is logged
+      expect(mockStatsClient.histogram).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to compute identifier overlap'))
+    })
+
+    it('should deliver the batch even if the stats client itself throws', async () => {
+      const throwingStatsContext = {
+        statsClient: {
+          ...mockStatsClient,
+          histogram: jest.fn(() => {
+            throw new Error('statsd exploded')
+          })
+        },
+        tags: ['env:test']
+      }
+
+      const mockRequestFn = await runBatch(
+        [profile({ 'Contact.$.email': 'a@example.com' }), profile({ 'Contact.$.email': 'a@example.com' })],
+        throwingStatsContext
+      )
+
+      expect(mockRequestFn).toHaveBeenCalledTimes(1)
+      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(2)
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to compute identifier overlap'))
     })
   })
 

--- a/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-import type { RequestClient, Logger, DynamicFieldResponse } from '@segment/actions-core'
+import type { RequestClient, Logger } from '@segment/actions-core'
 import Destination from '../../index'
 import { API_VERSION } from '../../versioning-info'
 import { BASE_URL } from '../../constants'
@@ -1503,6 +1503,169 @@ describe('Memora.upsertProfile', () => {
     })
   })
 
+  describe('identifier overlap stats', () => {
+    const mockStatsClient = {
+      observe: jest.fn(),
+      _name: jest.fn(),
+      _tags: jest.fn(),
+      incr: jest.fn(),
+      set: jest.fn(),
+      histogram: jest.fn()
+    }
+    const mockStatsContext = { statsClient: mockStatsClient, tags: ['env:test'] }
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      crit: jest.fn(),
+      log: jest.fn(),
+      level: ''
+    }
+
+    const histogramCall = (name: string) =>
+      mockStatsClient.histogram.mock.calls.find((c: any[]) => c[0] === `memora.upsert_profile.${name}`)
+    const histogramValue = (name: string) => histogramCall(name)?.[1]
+
+    const profile = (identifiers: Record<string, unknown>): Payload => ({
+      memora_store: 'test-store-id',
+      profile_identifiers: identifiers,
+      profile_traits: { 'Contact.$.firstName': 'X' }
+    })
+
+    const runBatch = async (payloads: Payload[]) => {
+      const mockRequestFn = jest.fn().mockResolvedValue({ status: 202, data: {}, headers: { get: () => null } })
+      await Destination.actions.upsertProfile.performBatch!(mockRequestFn as unknown as RequestClient, {
+        payload: payloads,
+        settings: defaultSettings,
+        statsContext: mockStatsContext,
+        logger: mockLogger as any
+      })
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      nock.cleanAll()
+    })
+
+    it('should report no overlap when every profile has unique identifiers', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'a@example.com' }),
+        profile({ 'Contact.$.email': 'b@example.com' }),
+        profile({ 'Contact.$.email': 'c@example.com' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(0)
+      expect(histogramValue('batch_largest_group')).toBe(1)
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Overlapping identifiers'))
+
+      // These are the only two overlap metrics emitted
+      expect(mockStatsClient.histogram.mock.calls.map((c: any[]) => c[0])).toEqual([
+        'memora.upsert_profile.batch_overlapping_events',
+        'memora.upsert_profile.batch_largest_group'
+      ])
+    })
+
+    it('should collapse repeated identifier pairs into one distinct profile', async () => {
+      // 3 events all carrying email1 + phone1 -> a single distinct pair
+      const identifiers = { 'Contact.$.email': 'email1@example.com', 'Contact.$.phone': '+15550001' }
+      await runBatch([profile(identifiers), profile(identifiers), profile(identifiers)])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(3)
+      expect(histogramValue('batch_largest_group')).toBe(3)
+      expect(histogramCall('batch_overlapping_events')?.[2]).toEqual(expect.arrayContaining(['env:test']))
+    })
+
+    it('should link profiles transitively through a shared identifier value', async () => {
+      // {email1, phone1} x3 plus {email1} and {phone1} -> still one profile upstream
+      const pair = { 'Contact.$.email': 'email1@example.com', 'Contact.$.phone': '+15550001' }
+      await runBatch([
+        profile(pair),
+        profile(pair),
+        profile(pair),
+        profile({ 'Contact.$.email': 'email1@example.com' }),
+        profile({ 'Contact.$.phone': '+15550001' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(5)
+      expect(histogramValue('batch_largest_group')).toBe(5)
+    })
+
+    it('should count overlapping and unique profiles separately in a mixed batch', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'dupe@example.com' }),
+        profile({ 'Contact.$.email': 'dupe@example.com' }),
+        profile({ 'Contact.$.email': 'unique1@example.com' }),
+        profile({ 'Contact.$.email': 'unique2@example.com' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(2)
+      expect(histogramValue('batch_largest_group')).toBe(2)
+    })
+
+    it('should not treat the same value under different identifier keys as an overlap', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'shared-value' }),
+        profile({ 'Contact.$.externalId': 'shared-value' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(0)
+      expect(histogramValue('batch_largest_group')).toBe(1)
+    })
+
+    it('should match identifier values that differ only by surrounding whitespace', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'dupe@example.com' }),
+        profile({ 'Contact.$.email': '  dupe@example.com  ' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(2)
+      expect(histogramValue('batch_largest_group')).toBe(2)
+    })
+
+    it('should ignore blank identifier values when grouping', async () => {
+      await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com', 'Contact.$.phone': '   ' },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com', 'Contact.$.phone': '' },
+          profile_traits: { 'Contact.$.firstName': 'B' }
+        }
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(0)
+      expect(histogramValue('batch_largest_group')).toBe(1)
+    })
+
+    it('should exclude profiles that failed validation from the overlap counts', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'valid@example.com' }),
+        { memora_store: 'test-store-id', profile_identifiers: {}, profile_traits: { 'Contact.$.firstName': 'Bad' } }
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(0)
+      expect(histogramValue('batch_largest_group')).toBe(1)
+    })
+
+    it('should log a warning with counts but never the identifier values', async () => {
+      await runBatch([
+        profile({ 'Contact.$.email': 'secret@example.com' }),
+        profile({ 'Contact.$.email': 'secret@example.com' })
+      ])
+
+      const warning = mockLogger.warn.mock.calls
+        .map((c: any[]) => String(c[0]))
+        .find((m: string) => m.includes('Overlapping identifiers'))
+      expect(warning).toBeDefined()
+      expect(warning).toContain('2 profile(s) resolve to 1 distinct profile(s)')
+      expect(warning).toContain('largest group is 2')
+      expect(warning).not.toContain('secret@example.com')
+    })
+  })
+
   describe('error handling', () => {
     it('should throw error when API returns error response', async () => {
       const event = createTestEvent({
@@ -1558,10 +1721,10 @@ describe('Memora.upsertProfile', () => {
           .matchHeader('X-Pre-Auth-Context', 'AC1234567890')
           .reply(200, { id: 'store-3', displayName: 'Store Three' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([
@@ -1580,10 +1743,10 @@ describe('Memora.upsertProfile', () => {
           .get(`/${API_VERSION}/ControlPlane/Stores/store-no-name`)
           .reply(200, { id: 'store-no-name', displayName: '' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([{ label: 'store-no-name', value: 'store-no-name' }])
@@ -1606,10 +1769,10 @@ describe('Memora.upsertProfile', () => {
           .matchHeader('X-Pre-Auth-Context', 'AC9876543210')
           .reply(200, { id: 'store-1', displayName: 'Store One' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: settingsWithTwilio,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([{ label: 'Store One', value: 'store-1' }])
@@ -1623,10 +1786,10 @@ describe('Memora.upsertProfile', () => {
             meta: { pageSize: 100 }
           })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1641,10 +1804,10 @@ describe('Memora.upsertProfile', () => {
           .get(`/${API_VERSION}/ControlPlane/Stores/store-1`)
           .reply(500, { message: 'Internal server error' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1658,10 +1821,10 @@ describe('Memora.upsertProfile', () => {
           .get(`/${API_VERSION}/ControlPlane/Stores?pageSize=100&orderBy=ASC`)
           .reply(500, { message: 'Internal server error' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'memora_store', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'memora_store', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1752,10 +1915,10 @@ describe('Memora.upsertProfile', () => {
             ]
           })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
           settings: defaultSettings,
           payload: { memora_store: 'test-store-id' }
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         // Should return all traits with idTypePromotion set, regardless of dataType
@@ -1768,10 +1931,10 @@ describe('Memora.upsertProfile', () => {
       })
 
       it('should return error when memora_store is not selected', async () => {
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1785,10 +1948,10 @@ describe('Memora.upsertProfile', () => {
           .get(`/${API_VERSION}/ControlPlane/Stores/test-store-id/TraitGroups?pageSize=100&includeTraits=true`)
           .reply(500, { message: 'Internal server error' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_identifiers.__keys__', {
           settings: defaultSettings,
           payload: { memora_store: 'test-store-id' }
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1886,10 +2049,10 @@ describe('Memora.upsertProfile', () => {
             ]
           })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
           settings: defaultSettings,
           payload: { memora_store: 'test-store-id' }
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         // Should exclude identifiers (traits with idTypePromotion) but include all non-identifier traits regardless of dataType
@@ -1918,10 +2081,10 @@ describe('Memora.upsertProfile', () => {
       })
 
       it('should return error when memora_store is not selected', async () => {
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
           settings: defaultSettings,
           payload: {}
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])
@@ -1935,10 +2098,10 @@ describe('Memora.upsertProfile', () => {
           .get(`/${API_VERSION}/ControlPlane/Stores/test-store-id/TraitGroups?pageSize=100&includeTraits=true`)
           .reply(500, { message: 'Internal server error' })
 
-        const result = (await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
+        const result = await testDestination.testDynamicField('upsertProfile', 'profile_traits.__keys__', {
           settings: defaultSettings,
           payload: { memora_store: 'test-store-id' }
-        })) as DynamicFieldResponse
+        })
 
         expect(result).toBeDefined()
         expect(result.choices).toEqual([])

--- a/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
@@ -127,6 +127,7 @@ async function upsertProfiles(
 
   // Track valid profiles and their original indices
   const validProfiles: { traits: Record<string, Record<string, unknown>> }[] = []
+  const validIdentifiers: Record<string, unknown>[] = []
   const validIndices: number[] = []
   const invalidIndices: number[] = []
   const validationErrors: Map<number, string> = new Map()
@@ -162,6 +163,7 @@ async function upsertProfiles(
     try {
       const traitGroups = buildTraitGroups(payload)
       validProfiles.push({ traits: traitGroups })
+      validIdentifiers.push(identifiers as Record<string, unknown>)
       validIndices.push(index)
     } catch (error) {
       // Catch validation errors for invalid trait key formats
@@ -194,6 +196,8 @@ async function upsertProfiles(
     })
     return { rawResponse: undefined, multiStatus: multiStatusResponse }
   }
+
+  reportIdentifierOverlap(computeIdentifierOverlap(validIdentifiers), statsTags, tagStr, logger, statsContext)
 
   try {
     const response = await request(`${BASE_URL}/${API_VERSION}/Stores/${storeId}/Profiles/Bulk`, {
@@ -248,6 +252,116 @@ async function upsertProfiles(
     )
     statsContext?.statsClient?.incr('memora.upsert_profile.failure', payloads.length, statsTags)
     throw error
+  }
+}
+
+interface IdentifierOverlapStats {
+  /** Number of profiles in the request. */
+  events: number
+  /** Events that share no identifier value with any other event, plus one per overlapping group. */
+  distinctProfiles: number
+  /** Events that share at least one identifier value with another event in the request. */
+  overlappingEvents: number
+  /** Size of the largest group of events collapsing into a single profile. */
+  largestGroupSize: number
+}
+
+/**
+ * Measure how much a batch collapses upstream.
+ *
+ * Two events belong to the same profile if they share any identifier value, and that
+ * relation is transitive: events carrying {email1, phone1}, {email1} and {phone1} all
+ * resolve to one profile even though the last two share nothing directly. That makes
+ * this a connected-components count over identifier values rather than a count of
+ * distinct identifier tuples.
+ */
+function computeIdentifierOverlap(identifierSets: Record<string, unknown>[]): IdentifierOverlapStats {
+  const total = identifierSets.length
+  const parent = Array.from({ length: total }, (_, i) => i)
+
+  const find = (index: number): number => {
+    let root = index
+    while (parent[root] !== root) {
+      parent[root] = parent[parent[root]] // path halving
+      root = parent[root]
+    }
+    return root
+  }
+
+  const union = (a: number, b: number): void => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA !== rootB) {
+      parent[rootB] = rootA
+    }
+  }
+
+  // `identifierKey=value` -> index of the first event that carried it
+  const firstSeenAt = new Map<string, number>()
+
+  identifierSets.forEach((identifiers, index) => {
+    Object.entries(identifiers).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return
+      }
+      const normalized = String(value).trim()
+      if (normalized === '') {
+        // Blank identifiers carry no identity; joining every event that has one would
+        // report a single huge group that upstream never actually sees.
+        return
+      }
+      const identity = `${key}=${normalized}`
+      const previousIndex = firstSeenAt.get(identity)
+      if (previousIndex === undefined) {
+        firstSeenAt.set(identity, index)
+      } else {
+        union(previousIndex, index)
+      }
+    })
+  })
+
+  const groupSizes = new Map<number, number>()
+  for (let index = 0; index < total; index++) {
+    const root = find(index)
+    groupSizes.set(root, (groupSizes.get(root) ?? 0) + 1)
+  }
+
+  let overlappingEvents = 0
+  let largestGroupSize = 0
+  groupSizes.forEach((size) => {
+    if (size > 1) {
+      overlappingEvents += size
+    }
+    if (size > largestGroupSize) {
+      largestGroupSize = size
+    }
+  })
+
+  return {
+    events: total,
+    distinctProfiles: groupSizes.size,
+    overlappingEvents,
+    largestGroupSize
+  }
+}
+
+// Identifier values are PII, so only counts are ever emitted — never the values themselves.
+function reportIdentifierOverlap(
+  stats: IdentifierOverlapStats,
+  statsTags: string[],
+  tagStr: string,
+  logger?: Logger,
+  statsContext?: StatsContext
+): void {
+  const statsClient = statsContext?.statsClient
+  statsClient?.histogram('memora.upsert_profile.batch_overlapping_events', stats.overlappingEvents, statsTags)
+  statsClient?.histogram('memora.upsert_profile.batch_largest_group', stats.largestGroupSize, statsTags)
+
+  if (stats.overlappingEvents > 0) {
+    logger?.warn?.(
+      `Overlapping identifiers in batch: ${stats.events} profile(s) resolve to ${stats.distinctProfiles} distinct profile(s). ` +
+        `${stats.overlappingEvents} profile(s) share an identifier value with another profile; largest group is ${stats.largestGroupSize}. ${tagStr}`
+    )
   }
 }
 

--- a/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
@@ -197,7 +197,16 @@ async function upsertProfiles(
     return { rawResponse: undefined, multiStatus: multiStatusResponse }
   }
 
-  reportIdentifierOverlap(computeIdentifierOverlap(validIdentifiers), statsTags, tagStr, logger, statsContext)
+  // Observability must never affect delivery: a throw here would reject the whole
+  // batch before the upsert is even attempted, with no status code to mark it
+  // non-retryable. Nothing in this block is worth losing events over.
+  try {
+    reportIdentifierOverlap(computeIdentifierOverlap(validIdentifiers), statsTags, tagStr, logger, statsContext)
+  } catch (error) {
+    logger?.warn?.(
+      `Failed to compute identifier overlap: ${error instanceof Error ? error.message : String(error)}. ${tagStr}`
+    )
+  }
 
   try {
     const response = await request(`${BASE_URL}/${API_VERSION}/Stores/${storeId}/Profiles/Bulk`, {


### PR DESCRIPTION
Adds observability for a problem the upstream Memora team is hitting: when several events in the same bulk request carry the same identifier value (e.g. the same email or phone), they collapse into one profile upstream. Today we have no way to see how often that happens or how severe it gets. This change measures it before the request goes out.

**Measurement only — no delivery behavior changes.** No request payload, response handling, field definition, or validation logic was touched.

### How overlap is counted

Two events belong to the same profile if they share *any* identifier value, and the relation is transitive. Events carrying `{email1, phone1}`, `{email1}` and `{phone1}` all resolve to **one** profile, even though the last two share nothing directly with each other. That makes this a connected-components count (union-find over identifier values) rather than a count of distinct identifier tuples — the tuple count would report 3 here and understate the collapse.

Two histograms are emitted, on the existing stats tags (`twilioAccountId`, `memory_store_id`, `audience_key`, `space_id`):

| Metric | Meaning |
| --- | --- |
| `memora.upsert_profile.batch_overlapping_events` | events sharing an identifier value with at least one other event in the request |
| `memora.upsert_profile.batch_largest_group` | size of the largest group collapsing into a single profile — the number most likely to break upstream |

A `warn` log with the same counts is written only when overlap is present. **Only counts are ever emitted or logged, never identifier values**, since those are PII.

### Implementation notes

- Measured over the *valid* payloads only, since those are what upstream actually receives.
- Emitted *before* the bulk request, so a failed call still records the batch shape.
- Identifier keys are part of the grouping key, so the same string under `Contact.$.email` vs `Contact.$.externalId` does not falsely join.
- Blank/whitespace-only identifier values are skipped — otherwise every event with an empty phone would collapse into one bogus mega-group that upstream never sees.
- Values are trimmed before comparison. Casing is **not** folded, so case-variant emails read as distinct; if Memora's identity resolution is case-insensitive, this will undercount and is an easy follow-up.
- `memora-internal` spreads this action, so it inherits the metrics with no duplication.

This deliberately only *measures* the problem. If upstream genuinely cannot accept duplicates in one request, the fix is merging payloads that resolve to one profile, or a batch key that keeps them apart — both change delivery semantics, so they belong in a separate PR once these metrics show how big the problem actually is.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

### Staging Testing
- Triggered 3 events with same email
<img width="1080" height="616" alt="Screenshot 2026-09-01 at 8 06 59 PM" src="https://github.com/user-attachments/assets/ba3731bb-ba3e-4f78-9fa0-954bc5704597" />
<img width="1097" height="585" alt="Screenshot 2026-09-01 at 8 07 37 PM" src="https://github.com/user-attachments/assets/bb4d3466-9201-4ca4-b60c-93be93825bae" />


Verification run locally:

- **70/70** tests pass across all memora suites (`memora`, `memora-internal`), snapshots unchanged — expected, since no request/response strings changed.
- `tsc --noEmit` on `destination-actions`: exit 0, zero errors.
- ESLint: 0 errors.

Backward compatibility: no fields added or changed, so nothing for existing subscriptions to break on. The only runtime additions are two `statsClient.histogram` calls and one conditional `logger.warn`, all null-safe via optional chaining.

Not tested with the local server — this change is only observable through stats/logs, which the local server does not surface, so the unit tests are the meaningful check here.

## Security Review

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

No field definitions were added or modified. Identifier values are treated as PII throughout: the union-find keys are held in a local `Map` for the duration of the call and never emitted — every metric and log line carries counts only.

## Note on the diff

The diff shows 25 deletions alongside the additions. Those are not part of the feature: the repo's `lint-staged` pre-commit hook runs `eslint --fix`, which strips 12 pre-existing redundant `as DynamicFieldResponse` assertions in the test file, and that in turn leaves the import unused and trips `no-unused-vars` as a hard error. This is latent on `main` — any commit staging that test file hits the same wall — so the import was dropped to let the hook pass.
