### PR TITLE
Send Snap-native action_source values (WEB/MOBILE_APP/OFFLINE) to Snapchat CAPI, and wire up native input aliases

### DIFF
--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
@@ -199,6 +199,20 @@ describe('Snap Conversions API ', () => {
       expect(app_data).toBeUndefined()
     })
 
+    it('should send the Snap-native action_source value as-is when explicitly selected', async () => {
+      const { data } = await reportConversionEvent({
+        mapping: {
+          event_type: 'PURCHASE',
+          event_conversion_type: 'WEB',
+          action_source: { '@literal': 'WEB' }
+        }
+      })
+
+      const { action_source } = data
+
+      expect(action_source).toBe('WEB')
+    })
+
     it('should handle a mobile app event conversion type', async () => {
       const { data } = await reportConversionEvent({
         mapping: {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/_tests_/index.test.ts
@@ -213,6 +213,40 @@ describe('Snap Conversions API ', () => {
       expect(action_source).toBe('WEB')
     })
 
+    it('should route to the pixel_id endpoint when action_source is the native WEB alias', async () => {
+      const { url, data } = await reportConversionEvent({
+        event: {
+          ...testEvent,
+          properties: {}
+        },
+        mapping: {
+          event_type: 'PURCHASE',
+          event_conversion_type: 'WEB',
+          action_source: { '@literal': 'WEB' }
+        }
+      })
+
+      expect(url).toBe('https://tr.snapchat.com/v3/pixel123/events?access_token=access123')
+      expect(data.action_source).toBe('WEB')
+    })
+
+    it('should route to the snap_app_id endpoint when action_source is the native MOBILE_APP alias', async () => {
+      const { url, data } = await reportConversionEvent({
+        event: {
+          ...testEvent,
+          properties: {}
+        },
+        mapping: {
+          event_type: 'PURCHASE',
+          event_conversion_type: 'MOBILE_APP',
+          action_source: { '@literal': 'MOBILE_APP' }
+        }
+      })
+
+      expect(url).toBe('https://tr.snapchat.com/v3/test123/events?access_token=access123')
+      expect(data.action_source).toBe('MOBILE_APP')
+    })
+
     it('should handle a mobile app event conversion type', async () => {
       const { data } = await reportConversionEvent({
         mapping: {

--- a/packages/destination-actions/src/destinations/snap-conversions-api/metadata.json
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/metadata.json
@@ -137,6 +137,18 @@
           "default": null,
           "choices": [
             {
+              "label": "WEB (Snap Native)",
+              "value": "WEB"
+            },
+            {
+              "label": "MOBILE_APP (Snap Native)",
+              "value": "MOBILE_APP"
+            },
+            {
+              "label": "OFFLINE (Snap Native)",
+              "value": "OFFLINE"
+            },
+            {
               "label": "EMAIL",
               "value": "email"
             },

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-input-fields-v3.ts
@@ -5,6 +5,11 @@ const action_source: InputField = {
   description: 'This field allows you to specify where your conversions occurred.',
   type: 'string',
   choices: [
+    // Native action sources
+    { label: 'WEB (Snap Native)', value: 'WEB' },
+    { label: 'MOBILE_APP (Snap Native)', value: 'MOBILE_APP' },
+    { label: 'OFFLINE (Snap Native)', value: 'OFFLINE' },
+    // Meta compatible action sources
     { label: 'EMAIL', value: 'email' },
     { label: 'WEBSITE', value: 'website' },
     { label: 'APP', value: 'app' },

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -596,15 +596,30 @@ const eventConversionTypeToActionSource: { [k in string]?: string } = {
   OFFLINE: 'OFFLINE'
 }
 
+// Snap-native action_source values a customer can pick directly. When chosen explicitly,
+// we send them to Snap as-is instead of the legacy internal value.
+const NATIVE_ACTION_SOURCE_VALUES = ['WEB', 'MOBILE_APP', 'OFFLINE']
+
+// Snap-native action_source values are accepted as aliases for their internal equivalents,
+// so routing/validation logic below can keep working off 'website' | 'app' | 'OFFLINE'.
+const nativeActionSourceToInternal: { [k in string]?: string } = {
+  WEB: 'website',
+  MOBILE_APP: 'app',
+  OFFLINE: 'OFFLINE'
+}
+
 const getSupportedActionSource = (action_source: string | undefined): string | undefined => {
   const normalizedActionSource = emptyStringToUndefined(action_source)
+  if (normalizedActionSource == null) {
+    return undefined
+  }
+
+  if (normalizedActionSource in nativeActionSourceToInternal) {
+    return nativeActionSourceToInternal[normalizedActionSource]
+  }
 
   // Snap doesn't support all the defined action sources, so fall back to OFFLINE if specified.
-  return ['website', 'app'].indexOf(normalizedActionSource ?? '') > -1
-    ? normalizedActionSource
-    : normalizedActionSource != null
-    ? 'OFFLINE'
-    : undefined
+  return ['website', 'app'].indexOf(normalizedActionSource) > -1 ? normalizedActionSource : 'OFFLINE'
 }
 
 const buildPayloadData = (payload: Payload, settings: Settings) => {
@@ -613,6 +628,14 @@ const buildPayloadData = (payload: Payload, settings: Settings) => {
   const action_source =
     getSupportedActionSource(payload.action_source) ??
     eventConversionTypeToActionSource[payload.event_conversion_type ?? '']
+
+  // If the customer explicitly picked a Snap-native action_source value, send it to Snap
+  // as-is. Otherwise, preserve the existing (legacy) behavior of sending the internal value.
+  const rawActionSource = emptyStringToUndefined(payload.action_source)
+  const outbound_action_source =
+    rawActionSource != null && NATIVE_ACTION_SOURCE_VALUES.indexOf(rawActionSource) > -1
+      ? rawActionSource
+      : action_source
 
   // Snaps CAPI v3 supports the legacy v2 events so don't bother
   // translating them
@@ -640,7 +663,10 @@ const buildPayloadData = (payload: Payload, settings: Settings) => {
     event_time,
     user_data,
     custom_data,
+    // action_source is used internally for settings validation and request routing.
     action_source,
+    // outbound_action_source is the literal value sent to Snap's API.
+    outbound_action_source,
     app_data,
     data_processing_options,
     data_processing_options_country: payload.data_processing_options_country,
@@ -745,10 +771,12 @@ export const performSnapCAPIv3 = async (
 
   const url = buildRequestURL(settings, payloadData.action_source, authToken)
 
+  const { outbound_action_source, ...rest } = payloadData
+
   return request(url, {
     method: 'post',
     json: {
-      data: [payloadData]
+      data: [{ ...rest, action_source: outbound_action_source }]
     }
   })
 }

--- a/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
+++ b/packages/destination-actions/src/destinations/snap-conversions-api/reportConversionEvent/snap-capi-v3.ts
@@ -598,11 +598,16 @@ const eventConversionTypeToActionSource: { [k in string]?: string } = {
 
 // Snap-native action_source values a customer can pick directly. When chosen explicitly,
 // we send them to Snap as-is instead of the legacy internal value.
-const NATIVE_ACTION_SOURCE_VALUES = ['WEB', 'MOBILE_APP', 'OFFLINE']
+const NATIVE_ACTION_SOURCE_VALUES = ['WEB', 'MOBILE_APP', 'OFFLINE'] as const
+type NativeActionSourceValue = typeof NATIVE_ACTION_SOURCE_VALUES[number]
+const nativeActionSourceValueSet = new Set<string>(NATIVE_ACTION_SOURCE_VALUES)
+const isNativeActionSourceValue = (value: string): value is NativeActionSourceValue => {
+  return nativeActionSourceValueSet.has(value)
+}
 
 // Snap-native action_source values are accepted as aliases for their internal equivalents,
 // so routing/validation logic below can keep working off 'website' | 'app' | 'OFFLINE'.
-const nativeActionSourceToInternal: { [k in string]?: string } = {
+const nativeActionSourceToInternal: Record<NativeActionSourceValue, string> = {
   WEB: 'website',
   MOBILE_APP: 'app',
   OFFLINE: 'OFFLINE'
@@ -614,7 +619,7 @@ const getSupportedActionSource = (action_source: string | undefined): string | u
     return undefined
   }
 
-  if (normalizedActionSource in nativeActionSourceToInternal) {
+  if (isNativeActionSourceValue(normalizedActionSource)) {
     return nativeActionSourceToInternal[normalizedActionSource]
   }
 
@@ -633,9 +638,7 @@ const buildPayloadData = (payload: Payload, settings: Settings) => {
   // as-is. Otherwise, preserve the existing (legacy) behavior of sending the internal value.
   const rawActionSource = emptyStringToUndefined(payload.action_source)
   const outbound_action_source =
-    rawActionSource != null && NATIVE_ACTION_SOURCE_VALUES.indexOf(rawActionSource) > -1
-      ? rawActionSource
-      : action_source
+    rawActionSource != null && isNativeActionSourceValue(rawActionSource) ? rawActionSource : action_source
 
   // Snaps CAPI v3 supports the legacy v2 events so don't bother
   // translating them


### PR DESCRIPTION
### Summary

The Snap Conversions API destination currently sends the literal strings website, app, or OFFLINE as action_source in the request body to Snapchat's Conversions API — but Snapchat's API requires WEB, MOBILE_APP, or OFFLINE. Customers who need to satisfy Snapchat's strict validation had no way to work around this, since Segment's own action_source field enum (email, website, app, phone_call, etc.) rejected the native values outright.

Slack Thread - https://twilio.slack.com/archives/CJUBHU9M4/p1786730228101879

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [ ] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [ ] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
