### PR TITLE
STRATCONN-6988: fix filename extension corruption in syncToS3 uploadS3

### DIFF
--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { isAWSError } from '../syncToS3/client'
+import { isAWSError, buildTimestampedFilename } from '../syncToS3/client'
 import { _Error as AWSError } from '@aws-sdk/client-s3'
 
 // Mock AWS SDK before any imports to avoid initialization issues
@@ -58,5 +58,32 @@ describe('isAWSError', () => {
   it('should return false for an object without Message property', () => {
     const error = { Code: 'SomeError' }
     expect(isAWSError(error)).toBe(false)
+  })
+})
+
+describe('buildTimestampedFilename', () => {
+  const DATE = '2026-09-02T11-23-42-574Z'
+
+  it('inserts the date suffix before the extension for a plain name', () => {
+    expect(buildTimestampedFilename('export.csv', DATE, 'csv')).toBe(`export_${DATE}.csv`)
+  })
+
+  it('does NOT corrupt a name whose base contains the extension string (regression: STRATCONN-6988)', () => {
+    // The old code did filename_prefix.replace('csv', ...), which replaced the
+    // leading "csv" in "csv_export" and produced "_<date>.csv_export.csv".
+    expect(buildTimestampedFilename('csv_export.csv', DATE, 'csv')).toBe(`csv_export_${DATE}.csv`)
+    expect(buildTimestampedFilename('my_txt_report.txt', DATE, 'txt')).toBe(`my_txt_report_${DATE}.txt`)
+  })
+
+  it('appends suffix and extension when the prefix has no extension', () => {
+    expect(buildTimestampedFilename('export', DATE, 'csv')).toBe(`export_${DATE}.csv`)
+  })
+
+  it('uses only the date suffix when the prefix is empty', () => {
+    expect(buildTimestampedFilename('', DATE, 'csv')).toBe(`${DATE}.csv`)
+  })
+
+  it('appends the configured extension when the prefix ends with a different extension', () => {
+    expect(buildTimestampedFilename('report.txt', DATE, 'csv')).toBe(`report.txt_${DATE}.csv`)
   })
 })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -6,6 +6,24 @@ import * as process from 'process'
 import { ErrorCodes, IntegrationError, RetryableError, APIError, RequestTimeoutError } from '@segment/actions-core'
 import { Credentials } from './types'
 
+/**
+ * Insert a timestamp suffix into the filename, immediately before the extension.
+ *
+ * If the prefix already ends with `.<fileExtension>`, the suffix is inserted just
+ * before that extension; otherwise the suffix and extension are appended. We strip
+ * the trailing extension by length rather than `String.prototype.replace`, because
+ * `replace` with a string replaces the FIRST occurrence of `fileExtension` anywhere
+ * in the name (e.g. the leading "csv" in "csv_export.csv"), corrupting the filename.
+ */
+export function buildTimestampedFilename(filenamePrefix: string, dateSuffix: string, fileExtension: string): string {
+  const ext = `.${fileExtension}`
+  if (filenamePrefix.endsWith(ext)) {
+    const base = filenamePrefix.slice(0, filenamePrefix.length - ext.length)
+    return `${base}_${dateSuffix}${ext}`
+  }
+  return filenamePrefix ? `${filenamePrefix}_${dateSuffix}${ext}` : `${dateSuffix}${ext}`
+}
+
 export class Client {
   roleArn: string
   roleSessionName: string
@@ -61,15 +79,7 @@ export class Client {
   ) {
     const dateSuffix = new Date().toISOString().replace(/[:.]/g, '-')
 
-    if (filename_prefix.endsWith('.csv') || filename_prefix.endsWith('.txt')) {
-      // Insert the date suffix before the extension
-      filename_prefix = filename_prefix.replace(fileExtension, `_${dateSuffix}.${fileExtension}`)
-    } else {
-      // Append the date suffix followed by the extension
-      filename_prefix = filename_prefix
-        ? `${filename_prefix}_${dateSuffix}.${fileExtension}`
-        : `${dateSuffix}.${fileExtension}`
-    }
+    filename_prefix = buildTimestampedFilename(filename_prefix, dateSuffix, fileExtension)
 
     const bucketName = settings.s3_aws_bucket_name
     const folderName = ['', null, undefined].includes(s3_aws_folder_name)


### PR DESCRIPTION
## STRATCONN-6988 — Fix filename extension corruption in `syncToS3`

### Problem
In `syncToS3/client.ts`, when a `filename_prefix` already ended with the file extension, the code inserted the date suffix via:

```js
filename_prefix.replace(fileExtension, `_${dateSuffix}.${fileExtension}`)
```

`String.prototype.replace` with a **string** argument replaces the **first** occurrence of `fileExtension` **anywhere** in the name — not the trailing extension. So a prefix like `csv_export.csv` (extension `csv`) had its **leading** `csv` replaced, producing a corrupted key:

```
_<date>.csv_export.csv        ← actual (wrong)
csv_export_<date>.csv         ← expected
```

The old code also hard-coded `.csv`/`.txt` in the guard instead of using the configured `fileExtension`.

### Fix
Extracted the logic into a pure, exported `buildTimestampedFilename()` helper that strips the trailing `.<ext>` **by length** and re-appends `_<date>.<ext>`. Behavior for prefixes without the extension is unchanged.

### Tests
Added a `buildTimestampedFilename` unit suite, including a regression case for a base name that contains the extension string (`csv_export.csv`). Full `s3` suite passes (52 tests).

<img width="2992" height="3507" alt="image" src="https://github.com/user-attachments/assets/0b25ece0-6654-4aa7-94d3-1c839a60c0d0" />
<img width="1493" height="806" alt="image" src="https://github.com/user-attachments/assets/00e425a6-3f47-4997-a156-2c8bb28a3fc3" />



### Validation
Human-validated against a real S3 upload (stage credentials): the object key was corrupted before the fix and correct after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
