### PR TITLE
STRATCONN-6989: fix CSV header desync (clean all delimiters + encode headers)

### DIFF
--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/index.test.ts
@@ -40,6 +40,13 @@ describe('clean', () => {
     expect(clean(',', 'abcd,Efg')).toEqual('abcdEfg')
   })
 
+  it('removes EVERY delimiter, not just the first (regression: STRATCONN-6989)', () => {
+    // The old code used str.replace(delimiter, '') which removed only the first match,
+    // leaving residual delimiters that split the (unencoded) header row.
+    expect(clean(',', 'tag,list,csv')).toBe('taglistcsv')
+    expect(clean(';', 'a;b;c;d')).toBe('abcd')
+  })
+
   it('should handle undefined input', () => {
     expect(clean(',', '')).toBe('')
   })
@@ -172,7 +179,7 @@ describe('generateFile', () => {
     { cleanName: 'batch_size', originalName: 'batch_size' }
   ]
 
-  const output = `event_name,event_type,user_id,anonymous_id,email,properties,traits,context,timestamp,message_id,integrations,audience_name,audience_id,audience_space_id,Custom Field 1,Custom Field 2,audience_action,batch_size\n"Custom Event 1","track","user_id_1","anonymous_id_1","test@test.com","{""prop_str"":""Hello String!"",""prop_num"":123.45,""prop_bool"":true,""prop_datetime"":""2024-01-08T13:52:50.212Z"",""prop_date"":""2024-01-08"",""prop_obj"":{""key1"":""value1"",""key2"":""value2""},""prop_arr"":[""value1"",""value2""],""custom_field_1"":""Custom Field Value 1"",""custom_field_2"":""Custom Field Value 2""}","{""first_name"":""John"",""last_name"":""Doe"",""email"":""test@test.com""}","{""traits"":{""first_name"":""John"",""last_name"":""Doe"",""email"":""test@test.com""},""personas"":{""computation_key"":""audience_name_1"",""computation_id"":""audience_id_1"",""space_id"":""space_id_1""}}","2024-01-08T13:52:50.212Z","aaa-bbb-ccc","{}","audience_name_1","audience_id_1","space_id_1","Custom Field Value 1","Custom Field Value 2","true","1"`
+  const output = `"event_name","event_type","user_id","anonymous_id","email","properties","traits","context","timestamp","message_id","integrations","audience_name","audience_id","audience_space_id","Custom Field 1","Custom Field 2","audience_action","batch_size"\n"Custom Event 1","track","user_id_1","anonymous_id_1","test@test.com","{""prop_str"":""Hello String!"",""prop_num"":123.45,""prop_bool"":true,""prop_datetime"":""2024-01-08T13:52:50.212Z"",""prop_date"":""2024-01-08"",""prop_obj"":{""key1"":""value1"",""key2"":""value2""},""prop_arr"":[""value1"",""value2""],""custom_field_1"":""Custom Field Value 1"",""custom_field_2"":""Custom Field Value 2""}","{""first_name"":""John"",""last_name"":""Doe"",""email"":""test@test.com""}","{""traits"":{""first_name"":""John"",""last_name"":""Doe"",""email"":""test@test.com""},""personas"":{""computation_key"":""audience_name_1"",""computation_id"":""audience_id_1"",""space_id"":""space_id_1""}}","2024-01-08T13:52:50.212Z","aaa-bbb-ccc","{}","audience_name_1","audience_id_1","space_id_1","Custom Field Value 1","Custom Field Value 2","true","1"`
 
   it('should generate a CSV file with correct content', () => {
     const result = generateFile(payloads, headers, ',', 'audience_action', 'batch_size')
@@ -186,7 +193,7 @@ describe('generateFile', () => {
     const headerRow = rows[0].split(',')
     const dataRow = rows[1].split(',')
 
-    const emailIndex = headerRow.indexOf('email')
+    const emailIndex = headerRow.indexOf('"email"')
     const expectedHash = processHashing('test@test.com', 'sha256', 'hex')
     expect(dataRow[emailIndex]).toBe(`"${expectedHash}"`)
   })
@@ -228,8 +235,8 @@ describe('generateFile', () => {
     const headerRow = rows[0].split(',')
     const dataRow = rows[1].split(',')
 
-    const emailIndex = headerRow.indexOf('email')
-    const userIdIndex = headerRow.indexOf('user_id')
+    const emailIndex = headerRow.indexOf('"email"')
+    const userIdIndex = headerRow.indexOf('"user_id"')
 
     const expectedEmailHash = processHashing('test@test.com', 'sha256', 'hex')
     const expectedUserIdHash = processHashing('user_id_1', 'sha256', 'hex')
@@ -245,7 +252,7 @@ describe('generateFile', () => {
     const headerRow = rows[0].split(',')
     const dataRow = rows[1].split(',')
 
-    const userIdIndex = headerRow.indexOf('user_id')
+    const userIdIndex = headerRow.indexOf('"user_id"')
     expect(dataRow[userIdIndex]).toBe('"user_id_1"')
   })
 
@@ -264,7 +271,8 @@ describe('generateFile', () => {
 
   const readColumn = (buffer: Buffer, column: string): string => {
     const rows = buffer.toString().split('\n')
-    const index = rows[0].split(',').indexOf(column)
+    // Header cells are encoded (quoted) just like data cells.
+    const index = rows[0].split(',').indexOf(`"${column}"`)
     return rows[1].split(',')[index]
   }
 
@@ -491,5 +499,34 @@ describe('send with hashing feature flag', () => {
     await expect(
       send([payloadNormalizeOnly], settings, rawMapping, { [S3_HASHING_FEATURE_FLAG]: true })
     ).resolves.not.toThrow()
+  })
+})
+
+describe('generateFile header/data alignment (STRATCONN-6989)', () => {
+  it('keeps header column count equal to data column count when a column name contains the delimiter', () => {
+    const cols = ['event_name', 'tag,list,csv', 'amount']
+    const headers: ColumnHeader[] = cols.map((c) => ({ cleanName: clean(',', c), originalName: c }))
+    const payloads = [
+      { columns: { event_name: 'Purchase', 'tag,list,csv': 'u-1', amount: '100' } },
+      { columns: { event_name: 'Refund', 'tag,list,csv': 'u-2', amount: '50' } }
+    ] as unknown as Payload[]
+
+    const rows = generateFile(payloads, headers, ',').toString().split('\n')
+    const headerCols = rows[0].split(',')
+    const dataCols = rows[1].split(',')
+
+    // No desync: header and data rows have the same number of columns.
+    expect(headerCols.length).toBe(dataCols.length)
+    // Header cells are encoded (quoted) like data cells, and clean() stripped BOTH commas.
+    expect(rows[0]).toBe('"event_name","taglistcsv","amount"')
+    expect(rows[1]).toBe('"Purchase","u-1","100"')
+  })
+
+  it('encodes header cells so an embedded quote in a column name does not corrupt the row', () => {
+    const headers: ColumnHeader[] = [{ cleanName: clean(',', 'na"me'), originalName: 'na"me' }]
+    const payloads = [{ columns: { 'na"me': 'v' } }] as unknown as Payload[]
+    const rows = generateFile(payloads, headers, ',').toString().split('\n')
+    expect(rows[0]).toBe('"na""me"')
+    expect(rows[1]).toBe('"v"')
   })
 })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/functions.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/functions.ts
@@ -64,7 +64,12 @@ export function clean(delimiter: string, str?: string) {
   if (!str) {
     return ''
   }
-  return delimiter === 'tab' ? str : str.replace(delimiter, '')
+  // Remove EVERY occurrence of the delimiter, not just the first. `String.replace`
+  // with a string argument replaces only the first match, so a column name with
+  // multiple delimiters (e.g. "tag,list,csv") kept residual delimiters that split
+  // the header row and desynced it from the data rows (STRATCONN-6989). split/join
+  // is used instead of a RegExp so delimiter characters are treated literally.
+  return delimiter === 'tab' ? str : str.split(delimiter).join('')
 }
 
 export function getNormalizer(normalize?: Normalization): ((value: string) => string) | undefined {
@@ -125,7 +130,13 @@ export function generateFile(
   })
 
   return Buffer.concat([
-    Buffer.from(`${headers.map((header) => header.cleanName).join(delimiter === 'tab' ? '\t' : delimiter)}\n`),
+    // Encode header cells the same way data cells are encoded (processField ->
+    // encodeString). Previously headers were written raw while data was quoted,
+    // so a header containing the delimiter or a quote desynced from the data
+    // columns beneath it (STRATCONN-6989).
+    Buffer.from(
+      `${headers.map((header) => encodeString(header.cleanName)).join(delimiter === 'tab' ? '\t' : delimiter)}\n`
+    ),
     ...rows
   ])
 }


### PR DESCRIPTION
## STRATCONN-6989 — Fix CSV header desync in `syncToS3`

### Problem
Two issues in `syncToS3/functions.ts` combined to desync the CSV header row from the data rows:

1. **`clean()` removed only the first delimiter.** `str.replace(delimiter, '')` (string arg) replaces a single occurrence, so a column name with multiple delimiters (e.g. `tag,list,csv`) kept residual delimiters.
2. **Header cells skipped `encodeString`.** Data cells go through `processField → encodeString` (quoted), but the header row was written raw. So a residual delimiter in a header name split the header into extra columns, while quoted data rows kept their column count.

Net effect: header column count ≠ data column count → every column mapped wrong by downstream loaders.

```
event_name,taglist,csv,amount,audience_action,batch_size   ← 6 columns (raw, split)
"Purchase","u-1","100","","2"                              ← 5 columns (quoted)
```

### Fix
- `clean()` now removes **every** delimiter (`split(delimiter).join('')`; literal, so it's safe for `|`, `;`, `:` too).
- Header cells are now passed through `encodeString`, exactly like data cells.

### Tests
- `clean` regression: removes all delimiters, not just the first.
- `generateFile` regression: header column count == data column count when a column name contains the delimiter; header cells quoted like data; embedded quote in a column name is escaped.
- Updated existing golden/index-based assertions to the corrected (quoted-header) output. Full `s3` suite passes (50 tests).

<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/2edb10dc-b195-4836-ac7f-f92953c09a75" />
<img width="1496" height="818" alt="image" src="https://github.com/user-attachments/assets/c1a20152-6b40-42bf-adf8-1e30e9bb9b4b" />
<img width="1254" height="873" alt="image" src="https://github.com/user-attachments/assets/e4dcfd50-a116-4cc8-b74f-20184bf9c448" />


### Validation
Human-validated against a real S3 upload (stage): a `tag,list,csv` column produced a 6-vs-5 desynced object before the fix; aligned after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
