### PR TITLE
feat(s3): reject S3 object keys over 1024 bytes up front

### DIFF
--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -1,0 +1,85 @@
+import { PayloadValidationError } from '@segment/actions-core'
+import { Settings } from '../../generated-types'
+
+// Shared spies so each test can assert whether AWS was actually contacted.
+const stsSend = jest.fn()
+const s3Send = jest.fn()
+
+jest.mock('@aws-sdk/client-sts', () => ({
+  STSClient: jest.fn().mockImplementation(() => ({ send: stsSend })),
+  AssumeRoleCommand: jest.fn()
+}))
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: s3Send })),
+  PutObjectCommand: jest.fn(),
+  _Error: jest.fn()
+}))
+
+// Import after the mocks are registered.
+import { Client } from '../client'
+
+const settings: Settings = {
+  iam_role_arn: 'arn:aws:iam::123456789012:role/test',
+  s3_aws_bucket_name: 'test-bucket',
+  s3_aws_region: 'us-east-1',
+  iam_external_id: 'external-id'
+}
+
+// assumeRole() calls STS twice (intermediary role, then the customer role); both must
+// return a full set of credentials for the happy path to reach the PUT.
+const validStsResponse = {
+  Credentials: {
+    AccessKeyId: 'AKIA_TEST',
+    SecretAccessKey: 'secret',
+    SessionToken: 'token'
+  }
+}
+
+function newClient() {
+  return new Client('us-east-1', settings.iam_role_arn, settings.iam_external_id)
+}
+
+describe('uploadS3 object key length guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stsSend.mockResolvedValue(validStsResponse)
+    s3Send.mockResolvedValue({})
+  })
+
+  it('rejects an object key over 1024 bytes with a non-retryable PayloadValidationError and does not PUT', async () => {
+    const client = newClient()
+    // A multi-byte folder name: 400 "€" chars = 1200 bytes but only 400 characters. This is
+    // well under 1024 *characters*, so a naive `.length` check would let it through — proving the
+    // guard measures UTF-8 bytes, not characters. With the "/" separator plus the generated
+    // filename it comfortably exceeds the 1024-byte limit.
+    const overLongFolder = '€'.repeat(400)
+
+    const promise = client.uploadS3(settings, 'file,content', '', overLongFolder, 'csv')
+
+    await expect(promise).rejects.toThrow(PayloadValidationError)
+    await expect(promise).rejects.toThrow('1024 bytes')
+    // Fails fast: no role assumption and no PUT are attempted.
+    expect(stsSend).not.toHaveBeenCalled()
+    expect(s3Send).not.toHaveBeenCalled()
+  })
+
+  it('does not leak the (potentially PII-laden) key content in the error message', async () => {
+    const client = newClient()
+    const secretFolder = 'super-secret-pii-'.repeat(80) // > 1024 bytes
+
+    const error = await client.uploadS3(settings, 'file,content', '', secretFolder, 'csv').catch((e) => e as Error)
+
+    expect(error).toBeInstanceOf(PayloadValidationError)
+    expect(error.message).not.toContain('super-secret-pii')
+  })
+
+  it('proceeds to PUT for an object key at/below 1024 bytes', async () => {
+    const client = newClient()
+
+    const result = await client.uploadS3(settings, 'file,content', 'export', 'my-folder', 'csv')
+
+    expect(result).toEqual({ statusCode: 200, message: 'Upload successful' })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -3,8 +3,18 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts'
 import { S3Client, PutObjectCommandInput, PutObjectCommand, _Error as AWSError } from '@aws-sdk/client-s3'
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import * as process from 'process'
-import { ErrorCodes, IntegrationError, RetryableError, APIError, RequestTimeoutError } from '@segment/actions-core'
+import {
+  ErrorCodes,
+  IntegrationError,
+  RetryableError,
+  APIError,
+  RequestTimeoutError,
+  PayloadValidationError
+} from '@segment/actions-core'
 import { Credentials } from './types'
+
+// AWS enforces a hard limit of 1024 bytes (UTF-8) on S3 object keys.
+const MAX_S3_OBJECT_KEY_BYTES = 1024
 
 export class Client {
   roleArn: string
@@ -77,6 +87,21 @@ export class Client {
       : s3_aws_folder_name?.endsWith('/')
       ? s3_aws_folder_name
       : `${s3_aws_folder_name}/`
+    const contentType = fileExtension === 'csv' ? 'text/csv' : 'text/plain'
+    const objectKey = folderName ? `${folderName}${filename_prefix}` : filename_prefix
+
+    // Reject over-long keys up front with a clear, non-retryable validation error, rather than
+    // letting the PUT fail late and opaquely (and storm retries) with a raw AWS error.
+    // Measure bytes, not characters: multi-byte UTF-8 chars count for more than one byte.
+    const objectKeyBytes = Buffer.byteLength(objectKey, 'utf8')
+    if (objectKeyBytes > MAX_S3_OBJECT_KEY_BYTES) {
+      // Do not include the key content in the message — it may contain PII.
+      throw new PayloadValidationError(
+        `S3 object key exceeds the AWS limit of ${MAX_S3_OBJECT_KEY_BYTES} bytes (got ${objectKeyBytes} bytes). ` +
+          `Shorten the folder name and/or filename prefix.`
+      )
+    }
+
     const credentials = await this.assumeRole()
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const s3Client = new S3Client({
@@ -87,8 +112,6 @@ export class Client {
         sessionToken: credentials.sessionToken
       }
     })
-    const contentType = fileExtension === 'csv' ? 'text/csv' : 'text/plain'
-    const objectKey = folderName ? `${folderName}${filename_prefix}` : filename_prefix
     const uploadParams: PutObjectCommandInput = {
       Bucket: bucketName,
       Key: objectKey,


### PR DESCRIPTION
## Summary

S3 object keys have a hard AWS limit of **1024 bytes** (UTF-8). `actions-s3` built the key (`folderName` + `filename_prefix`) with no length check, so an over-long key failed opaquely at PUT time with a raw AWS error — and, because that error code isn't handled specially, it was thrown as a **`RetryableError`**, storming retries.

This adds a guard in `uploadS3()` that measures the key's UTF-8 **byte** length (`Buffer.byteLength(objectKey, 'utf8')`, not `.length`) and throws a non-retryable **`PayloadValidationError`** when it exceeds 1024 bytes. The guard runs **before** `assumeRole()`, so it fails fast without making any AWS/STS call, and the error message omits the key content to avoid leaking PII.

Keys already under the limit are untouched — no behaviour change for working configs.

https://twilio-engineering.atlassian.net/browse/STRATCONN-6990

## Testing

New unit tests in `syncToS3/__tests__/client.test.ts` (mocked STS + S3 client):

- Object key > 1024 bytes built from multi-byte (`€`) chars → `PayloadValidationError`, and asserts **neither STS nor the PUT** is attempted. Uses 400 `€` chars (400 chars / 1200 bytes) to prove the guard measures **bytes, not characters**.
- Over-limit key of secret content → error message does **not** leak the key content (PII-safe).
- Normal short key → proceeds to PUT, returns `{ statusCode: 200 }`.

Full `s3/syncToS3` suite passes (40/40). ESLint clean.

- [x] Added unit tests for new functionality
- [x] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change. — _No new fields; over-limit keys already failed today, just opaquely. No behaviour change for keys under the limit._

### e2e testing
<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/b28eed30-55c9-4754-9722-80d802441c3a" />
<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/7743a5bf-9c97-4ccd-ab8b-e05db9bd9b43" />



## Security Review

- [x] **Reviewed all field definitions** for sensitive data — no field changes in this PR. The new error message deliberately excludes the object key content to avoid logging PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
