### PR TITLE
[ STRATCONN-6708 : Data Manager API ]  Upgraded createaudience to use data manager API

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -14,7 +14,9 @@ import {
   OfflineUserJobPayload,
   AddOperationPayload,
   KeyValuePairList,
-  KeyValueItem
+  KeyValueItem,
+  PartnerLinkResponse,
+  DataManagerUserList
 } from './types'
 import {
   ModifiedResponse,
@@ -46,6 +48,9 @@ import {
 export const API_VERSION = GOOGLE_ENHANCED_CONVERSIONS_API_VERSION
 export const CANARY_API_VERSION = GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION
 export const FLAGON_NAME = 'google-enhanced-canary-version'
+export const FLAGON_NAME_DATA_MANAGER_API = 'actions-google-ec-data-manager-api'
+export const DATA_MANAGER_BASE_URL = 'https://datamanager.googleapis.com/v1'
+export const PARTNER_ACCOUNT_ID = '262932431'
 export const FLAGON_NAME_PHONE_VALIDATION_CHECK = 'google-enhanced-phone-validation-check'
 import { PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber'
 
@@ -76,6 +81,14 @@ export class GoogleAdsError extends HTTPError {
     data: GoogleAdsErrorData
   }
 }
+
+export const UPLOAD_KEY_TYPE_MAP: Record<string, string> = {
+  CONTACT_INFO: 'CONTACT_ID',
+  CRM_ID: 'USER_ID',
+  MOBILE_ADVERTISING_ID: 'MOBILE_ID'
+}
+
+const MEMBERSHIP_DURATION = `${540 * 86400}s`
 
 export function formatCustomVariables(
   customVariables: object,
@@ -690,6 +703,134 @@ const processOperations = async (
   }
 }
 
+export async function exchangeForAccessToken(request: RequestClient, refreshToken: string): Promise<string> {
+  if (!process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID || !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET) {
+    throw new PayloadValidationError('OAuth client credentials (client ID / client secret) are not configured.')
+  }
+
+  const res = await request<RefreshTokenResponse>('https://www.googleapis.com/oauth2/v4/token', {
+    method: 'POST',
+    body: new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID,
+      client_secret: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET,
+      grant_type: 'refresh_token'
+    })
+  })
+
+  return res.data.access_token
+}
+
+export async function createDataManagerPartnerLink(
+  request: RequestClient,
+  customerId: string,
+  customerAccessToken: string,
+  loginCustomerId?: string
+): Promise<PartnerLinkResponse> {
+  const owningAccountId = loginCustomerId || customerId
+  const url = `${DATA_MANAGER_BASE_URL}/accountTypes/GOOGLE_ADS/accounts/${customerId}/partnerLinks`
+  try {
+    const response = await request<PartnerLinkResponse>(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${customerAccessToken}`,
+        'login-account': `accountTypes/GOOGLE_ADS/accounts/${owningAccountId}`
+      },
+      json: {
+        owningAccount: { accountId: owningAccountId, accountType: 'GOOGLE_ADS' },
+        partnerAccount: { accountId: PARTNER_ACCOUNT_ID, accountType: 'DATA_PARTNER' }
+      }
+    })
+    return response.data
+  } catch (err: any) {
+    // 409 ALREADY_EXISTS means the link is already established — treat as success
+    if (err?.response?.status === 409) {
+      return err.response.data as PartnerLinkResponse
+    }
+    throw err
+  }
+}
+
+export async function createDataManagerAudience(
+  request: RequestClient,
+  input: CreateAudienceInput,
+  auth: CreateAudienceInput['settings']['oauth'],
+  statsContext?: StatsContext
+): Promise<string> {
+  if (input.audienceSettings.external_id_type === 'MOBILE_ADVERTISING_ID' && !input.audienceSettings.app_id) {
+    throw new PayloadValidationError('App ID is required when external ID type is mobile advertising ID.')
+  }
+
+  if (
+    !auth?.refresh_token ||
+    !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID ||
+    !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET
+  ) {
+    throw new PayloadValidationError('Oauth credentials missing.')
+  }
+
+  const statsClient = statsContext?.statsClient
+  const statsTags = statsContext?.tags
+
+  const tokenRes = await request<RefreshTokenResponse>('https://www.googleapis.com/oauth2/v4/token', {
+    method: 'POST',
+    body: new URLSearchParams({
+      refresh_token: auth.refresh_token,
+      client_id: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID,
+      client_secret: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET,
+      grant_type: 'refresh_token'
+    })
+  })
+
+  const accessToken = tokenRes.data.access_token
+
+  const customerId = input.settings.customerId?.replace(/-/g, '')
+  const loginCustomerId = input.settings.loginCustomerId?.replace(/-/g, '')
+
+  const uploadKeyType =
+    UPLOAD_KEY_TYPE_MAP[input.audienceSettings.external_id_type ?? ''] ?? input.audienceSettings.external_id_type
+
+  const ingestedUserListInfo: Record<string, unknown> = {
+    uploadKeyTypes: [uploadKeyType]
+  }
+  if (uploadKeyType === 'MOBILE_ID' && input.audienceSettings.app_id) {
+    ingestedUserListInfo.mobileIdInfo = { appId: input.audienceSettings.app_id }
+  }
+
+  const body: Record<string, unknown> = {
+    displayName: input.audienceName,
+    membershipDuration: MEMBERSHIP_DURATION,
+    ingestedUserListInfo
+  }
+
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${accessToken}`
+  }
+  if (loginCustomerId) {
+    // Equivalent of login-customer-id in Google Ads API — identifies the MCC managing the account
+    headers['login-account'] = `accountTypes/GOOGLE_ADS/accounts/${loginCustomerId}`
+  }
+
+  const response = await request(`${DATA_MANAGER_BASE_URL}/accountTypes/GOOGLE_ADS/accounts/${customerId}/userLists`, {
+    method: 'post',
+    headers,
+    json: body
+  })
+
+  const userList = response.data as DataManagerUserList
+  if (!userList?.id) {
+    statsClient?.incr('createDataManagerAudience.error', 1, statsTags)
+    throw new IntegrationError(
+      'Failed to receive a created user list id from Data Manager API.',
+      'INVALID_RESPONSE',
+      400
+    )
+  }
+
+  statsClient?.incr('createDataManagerAudience.success', 1, statsTags)
+  return userList.id
+}
+
 export const handleUpdate = async (
   request: RequestClient,
   settings: CreateAudienceInput['settings'],
@@ -972,7 +1113,11 @@ const extractBatchUserIdentifiers = (
 }
 
 // Helper function to determine operation type
-const determineOperationType = (payload: UserListPayload, syncMode?: string, audienceMembership?: AudienceMembership) => {
+const determineOperationType = (
+  payload: UserListPayload,
+  syncMode?: string,
+  audienceMembership?: AudienceMembership
+) => {
   if (
     payload.event_name === 'Audience Entered' ||
     syncMode === 'add' ||

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -5,7 +5,15 @@ import uploadCallConversion from './uploadCallConversion'
 import uploadClickConversion from './uploadClickConversion'
 import uploadConversionAdjustment from './uploadConversionAdjustment'
 import { CreateAudienceInput, GetAudienceInput, UserListResponse } from './types'
-import { createGoogleAudience, getGoogleAudience, verifyCustomerId } from './functions'
+import {
+  createGoogleAudience,
+  getGoogleAudience,
+  verifyCustomerId,
+  exchangeForAccessToken,
+  createDataManagerPartnerLink,
+  createDataManagerAudience,
+  FLAGON_NAME_DATA_MANAGER_API
+} from './functions'
 import uploadCallConversion2 from './uploadCallConversion2'
 import userList from './userList'
 import uploadClickConversion2 from './uploadClickConversion2'
@@ -151,15 +159,38 @@ const destination: AudienceDestinationDefinition<Settings> = {
       createAudienceInput.settings.customerId = verifyCustomerId(createAudienceInput.settings.customerId)
       const auth = createAudienceInput.settings.oauth
 
+      const useDataManagerAPI = createAudienceInput.features?.[FLAGON_NAME_DATA_MANAGER_API]
+
+      const customerId = createAudienceInput.settings.customerId
+      const loginCustomerId = createAudienceInput.settings.loginCustomerId?.trim().replace(/-/g, '') || undefined
+
+      // Best-effort partner link creation — errors must not block audience creation
+      if (auth?.refresh_token) {
+        try {
+          const customerDataManagerAccessToken = await exchangeForAccessToken(request, auth.refresh_token)
+          await createDataManagerPartnerLink(request, customerId, customerDataManagerAccessToken, loginCustomerId)
+        } catch (_) {
+          // intentionally swallowed
+        }
+      }
       let userListId
       try {
-        userListId = await createGoogleAudience(
-          request,
-          createAudienceInput,
-          auth,
-          createAudienceInput.features,
-          createAudienceInput.statsContext
-        )
+        if (useDataManagerAPI) {
+          userListId = await createDataManagerAudience(
+            request,
+            createAudienceInput,
+            auth,
+            createAudienceInput.statsContext
+          )
+        } else {
+          userListId = await createGoogleAudience(
+            request,
+            createAudienceInput,
+            auth,
+            createAudienceInput.features,
+            createAudienceInput.statsContext
+          )
+        }
       } catch (err) {
         let status = err.status || err.code
         if (!status && err.response && err.response.status) {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -104,14 +104,14 @@ export interface ClickConversionRequestObjectInterface {
 export type KeyValuePairList = Array<KeyValueItem>
 
 export type KeyValueItem = {
-  sessionAttributeKey: 
-    'gad_source' 
-  | 'gad_campaignid' 
-  | 'landing_page_url' 
-  | 'session_start_time_usec' 
-  | 'landing_page_referrer' 
-  | 'landing_page_user_agent'
-  sessionAttributeValue?: string 
+  sessionAttributeKey:
+    | 'gad_source'
+    | 'gad_campaignid'
+    | 'landing_page_url'
+    | 'session_start_time_usec'
+    | 'landing_page_referrer'
+    | 'landing_page_user_agent'
+  sessionAttributeValue?: string
 }
 
 export interface ConversionActionId {
@@ -157,6 +157,7 @@ export interface CreateAudienceInput {
   audienceName: string
   settings: {
     customerId?: string
+    loginCustomerId?: string
     conversionTrackingId?: string
     oauth?: {
       refresh_token?: string
@@ -169,6 +170,31 @@ export interface CreateAudienceInput {
   }
   statsContext?: StatsContext
   features?: Features
+}
+
+export interface DataManagerUserList {
+  name: string
+  id: string
+  displayName?: string
+  membershipDuration?: string
+  membershipStatus?: string
+  ingestedUserListInfo?: {
+    uploadKeyTypes?: string[]
+    mobileIdInfo?: { appId?: string }
+  }
+}
+
+export interface PartnerLinkResponse {
+  name: string
+  partnerLinkId: string
+  owningAccount: {
+    accountId: string
+    accountType: string
+  }
+  partnerAccount: {
+    accountId: string
+    accountType: string
+  }
 }
 
 export interface GetAudienceInput {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

 https://twilio-engineering.atlassian.net/browse/STRATCONN-6708
 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. This PR introduces upgradation of createAudience for data manager API .
2. It creates the partnerlink before create audience if not created and then createAudience in google ads account .
3. Document highlighting the Upgradation of google ads api to data manager API https://docs.google.com/document/d/1RNkv9UI_oU3c2XGDRmVCfo0aYNE97dynL29XIFCkYHY/edit?tab=t.0
4. Google docs for partnerlink api -->  https://developers.google.com/data-manager/api/devguides/accounts/partner-links/create-partner-link
5. Google docs for create userlist -->  
https://developers.google.com/data-manager/api/reference/rest/v1/accountTypes.accounts.userLists#UserList


## Testing

Tested done in staging 

Rollout using the flagon deployment for version .
https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-ec-data-manager-api


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
