### PR TITLE
[STRATCONN-6709 : Google enhanced conversion] [Data Manager] upgraded the data manager API for getaudience functionality 

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -14,7 +14,9 @@ import {
   OfflineUserJobPayload,
   AddOperationPayload,
   KeyValuePairList,
-  KeyValueItem
+  KeyValueItem,
+  DataManagerUserList,
+  PartnerLinkResponse
 } from './types'
 import {
   ModifiedResponse,
@@ -48,6 +50,9 @@ export const CANARY_API_VERSION = GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION
 export const FLAGON_NAME = 'google-enhanced-canary-version'
 export const FLAGON_NAME_PHONE_VALIDATION_CHECK = 'google-enhanced-phone-validation-check'
 import { PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber'
+export const FLAGON_NAME_DATA_MANAGER_API = 'actions-google-ec-data-manager-api'
+export const DATA_MANAGER_BASE_URL = 'https://datamanager.googleapis.com/v1'
+const PARTNER_ACCOUNT_ID = '262932431'
 
 const phoneUtil = PhoneNumberUtil.getInstance()
 
@@ -308,6 +313,112 @@ export async function getListIds(
         code: (err as GoogleAdsError).response?.status + '' ?? '500'
       }
     }
+  }
+}
+
+export async function getDataManagerAudience(
+  request: RequestClient,
+  settings: CreateAudienceInput['settings'],
+  externalId: string,
+  auth: CreateAudienceInput['settings']['oauth'],
+  statsContext?: StatsContext
+): Promise<DataManagerUserList> {
+  if (
+    !auth?.refresh_token ||
+    !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID ||
+    !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET
+  ) {
+    throw new PayloadValidationError('Oauth credentials missing.')
+  }
+
+  const statsClient = statsContext?.statsClient
+  const statsTags = statsContext?.tags
+
+  const tokenRes = await request<RefreshTokenResponse>('https://www.googleapis.com/oauth2/v4/token', {
+    method: 'POST',
+    body: new URLSearchParams({
+      refresh_token: auth.refresh_token,
+      client_id: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID,
+      client_secret: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET,
+      grant_type: 'refresh_token'
+    })
+  })
+
+  const accessToken = tokenRes.data.access_token
+
+  const customerId = settings.customerId?.replace(/-/g, '')
+  const loginCustomerId = settings.loginCustomerId?.replace(/-/g, '')
+
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${accessToken}`
+  }
+  if (loginCustomerId) {
+    headers['login-account'] = `accountTypes/GOOGLE_ADS/accounts/${loginCustomerId}`
+  }
+
+  const response = await request(
+    `${DATA_MANAGER_BASE_URL}/accountTypes/GOOGLE_ADS/accounts/${customerId}/userLists/${externalId}`,
+    {
+      method: 'get',
+      headers
+    }
+  )
+
+  const userList = response.data as DataManagerUserList
+  if (!userList?.id) {
+    statsClient?.incr('getDataManagerAudience.error', 1, statsTags)
+    throw new IntegrationError('Failed to retrieve user list from Data Manager.', 'INVALID_RESPONSE', 400)
+  }
+
+  statsClient?.incr('getDataManagerAudience.success', 1, statsTags)
+  return userList
+}
+
+export async function exchangeForAccessToken(request: RequestClient, refreshToken: string): Promise<string> {
+  if (!process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID || !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET) {
+    throw new PayloadValidationError('OAuth client credentials (client ID / client secret) are not configured.')
+  }
+
+  const res = await request<RefreshTokenResponse>('https://www.googleapis.com/oauth2/v4/token', {
+    method: 'POST',
+    body: new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID,
+      client_secret: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET,
+      grant_type: 'refresh_token'
+    })
+  })
+
+  return res.data.access_token
+}
+
+export async function createDataManagerPartnerLink(
+  request: RequestClient,
+  customerId: string,
+  customerAccessToken: string,
+  loginCustomerId?: string
+): Promise<PartnerLinkResponse> {
+  const owningAccountId = loginCustomerId || customerId
+  const url = `${DATA_MANAGER_BASE_URL}/accountTypes/GOOGLE_ADS/accounts/${customerId}/partnerLinks`
+  try {
+    const response = await request<PartnerLinkResponse>(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${customerAccessToken}`,
+        'login-account': `accountTypes/GOOGLE_ADS/accounts/${owningAccountId}`
+      },
+      json: {
+        owningAccount: { accountId: owningAccountId, accountType: 'GOOGLE_ADS' },
+        partnerAccount: { accountId: PARTNER_ACCOUNT_ID, accountType: 'DATA_PARTNER' }
+      }
+    })
+    return response.data
+  } catch (err: any) {
+    // 409 ALREADY_EXISTS means the link is already established — treat as success
+    if (err?.response?.status === 409) {
+      return err.response.data as PartnerLinkResponse
+    }
+    throw err
   }
 }
 
@@ -972,7 +1083,11 @@ const extractBatchUserIdentifiers = (
 }
 
 // Helper function to determine operation type
-const determineOperationType = (payload: UserListPayload, syncMode?: string, audienceMembership?: AudienceMembership) => {
+const determineOperationType = (
+  payload: UserListPayload,
+  syncMode?: string,
+  audienceMembership?: AudienceMembership
+) => {
   if (
     payload.event_name === 'Audience Entered' ||
     syncMode === 'add' ||

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/index.ts
@@ -5,7 +5,15 @@ import uploadCallConversion from './uploadCallConversion'
 import uploadClickConversion from './uploadClickConversion'
 import uploadConversionAdjustment from './uploadConversionAdjustment'
 import { CreateAudienceInput, GetAudienceInput, UserListResponse } from './types'
-import { createGoogleAudience, getGoogleAudience, verifyCustomerId } from './functions'
+import {
+  createGoogleAudience,
+  getGoogleAudience,
+  verifyCustomerId,
+  getDataManagerAudience,
+  exchangeForAccessToken,
+  createDataManagerPartnerLink,
+  FLAGON_NAME_DATA_MANAGER_API
+} from './functions'
 import uploadCallConversion2 from './uploadCallConversion2'
 import userList from './userList'
 import uploadClickConversion2 from './uploadClickConversion2'
@@ -189,6 +197,33 @@ const destination: AudienceDestinationDefinition<Settings> = {
         }
       }
       getAudienceInput.settings.customerId = verifyCustomerId(getAudienceInput.settings.customerId)
+
+      const customerId = getAudienceInput.settings.customerId
+      const loginCustomerId = getAudienceInput.settings.loginCustomerId?.trim().replace(/-/g, '') || undefined
+      const auth = getAudienceInput.settings.oauth
+
+      // Best-effort partner link creation — errors must not block audience creation
+      if (auth?.refresh_token) {
+        try {
+          const customerAccessToken = await exchangeForAccessToken(request, auth.refresh_token)
+          await createDataManagerPartnerLink(request, customerId, customerAccessToken, loginCustomerId)
+        } catch (_) {
+          // intentionally swallowed
+        }
+      }
+
+      const useDataManagerAPI = getAudienceInput.features?.[FLAGON_NAME_DATA_MANAGER_API]
+
+      if (useDataManagerAPI) {
+        const userList = await getDataManagerAudience(
+          request,
+          getAudienceInput.settings,
+          getAudienceInput.externalId,
+          getAudienceInput.settings.oauth,
+          getAudienceInput.statsContext
+        )
+        return { externalId: userList.id }
+      }
       const response: UserListResponse = await getGoogleAudience(
         request,
         getAudienceInput.settings,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -70,6 +70,19 @@ export interface CallConversionRequestObjectInterface {
   customVariables?: CustomVariableInterface[]
 }
 
+export interface PartnerLinkResponse {
+  name: string
+  partnerLinkId: string
+  owningAccount: {
+    accountId: string
+    accountType: string
+  }
+  partnerAccount: {
+    accountId: string
+    accountType: string
+  }
+}
+
 export interface ConversionAdjustmentRequestObjectInterface {
   adjustmentType: string
   adjustmentDateTime: string | undefined
@@ -104,14 +117,14 @@ export interface ClickConversionRequestObjectInterface {
 export type KeyValuePairList = Array<KeyValueItem>
 
 export type KeyValueItem = {
-  sessionAttributeKey: 
-    'gad_source' 
-  | 'gad_campaignid' 
-  | 'landing_page_url' 
-  | 'session_start_time_usec' 
-  | 'landing_page_referrer' 
-  | 'landing_page_user_agent'
-  sessionAttributeValue?: string 
+  sessionAttributeKey:
+    | 'gad_source'
+    | 'gad_campaignid'
+    | 'landing_page_url'
+    | 'session_start_time_usec'
+    | 'landing_page_referrer'
+    | 'landing_page_user_agent'
+  sessionAttributeValue?: string
 }
 
 export interface ConversionActionId {
@@ -153,10 +166,23 @@ export interface UserListResponse {
   fieldMask: string
 }
 
+export interface DataManagerUserList {
+  name: string
+  id: string
+  displayName?: string
+  membershipDuration?: string
+  membershipStatus?: string
+  ingestedUserListInfo?: {
+    uploadKeyTypes?: string[]
+    mobileIdInfo?: { appId?: string }
+  }
+}
+
 export interface CreateAudienceInput {
   audienceName: string
   settings: {
     customerId?: string
+    loginCustomerId?: string
     conversionTrackingId?: string
     oauth?: {
       refresh_token?: string
@@ -175,6 +201,7 @@ export interface GetAudienceInput {
   externalId: string
   settings: {
     customerId?: string
+    loginCustomerId?: string
     conversionTrackingId?: string
     oauth?: {
       refresh_token?: string


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

 https://twilio-engineering.atlassian.net/browse/STRATCONN-6709
 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. This PR introduces upgradation of getAudience for data manager API .
2. It creates the partnerlink before get audience if not created and then getaudience in google ads account .
3. Document highlighting the Upgradation of google ads api to data manager API https://docs.google.com/document/d/1RNkv9UI_oU3c2XGDRmVCfo0aYNE97dynL29XIFCkYHY/edit?tab=t.0
4. Google docs for partnerlink api -->  https://developers.google.com/data-manager/api/devguides/accounts/partner-links/create-partner-link
5. Google docs for get  userlist -->  https://developers.google.com/data-manager/api/reference/rest/v1/accountTypes.accounts.userLists/get
https://developers.google.com/data-manager/api/reference/rest/v1/accountTypes.accounts.userLists#UserList


## Testing

Tested done in staging 

Rollout using the flagon deployment for version .
https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-ec-data-manager-api


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
