### PR TITLE
[Memora] Merge overlapping profiles within a batch before upsert

### DIFF
--- a/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/__tests__/index.test.ts
@@ -1603,6 +1603,20 @@ describe('Memora.upsertProfile', () => {
       expect(histogramValue('batch_largest_group')).toBe(2)
     })
 
+    it('should sum overlapping events across multiple distinct groups', async () => {
+      // Two groups of two, plus a singleton: overlapping = 4, largest group = 2
+      await runBatch([
+        profile({ 'Contact.$.email': 'a@example.com' }),
+        profile({ 'Contact.$.email': 'solo@example.com' }),
+        profile({ 'Contact.$.email': 'b@example.com' }),
+        profile({ 'Contact.$.email': 'a@example.com' }),
+        profile({ 'Contact.$.email': 'b@example.com' })
+      ])
+
+      expect(histogramValue('batch_overlapping_events')).toBe(4)
+      expect(histogramValue('batch_largest_group')).toBe(2)
+    })
+
     it('should not treat the same value under different identifier keys as an overlap', async () => {
       await runBatch([
         profile({ 'Contact.$.email': 'shared-value' }),
@@ -1666,27 +1680,121 @@ describe('Memora.upsertProfile', () => {
       expect(warning).not.toContain('secret@example.com')
     })
 
-    // Regression: an identifier value of `{ toString: null }` is expressible in plain
-    // JSON and makes String() throw. The metric ran outside the request try/catch, so
-    // one such event rejected the whole batch before the upsert was attempted, with no
-    // status code to mark it non-retryable. Delivery must survive; the batch forfeits
-    // its overlap metrics, which is the accepted tradeoff.
-    it('should still deliver the batch when an identifier value cannot be coerced to a string', async () => {
+    // Regression: an identifier value of `{ toString: null }` is expressible in plain JSON
+    // and used to make String() throw, which abandoned merging for the ENTIRE batch and
+    // reintroduced the duplicate-entry shape this feature exists to prevent. The identity
+    // guard makes the coercion total, so the bad value is simply ignored and the rest of
+    // the batch still merges.
+    it('should keep merging the rest of the batch when one identifier value is uncoercible', async () => {
       const hostile = JSON.parse('{"toString":null}')
 
       const mockRequestFn = await runBatch([
-        profile({ 'Contact.$.email': 'ok1@example.com' }),
-        profile({ 'Contact.$.email': hostile }),
-        profile({ 'Contact.$.email': 'ok2@example.com' })
+        profile({ 'Contact.$.email': 'dupe@example.com' }),
+        profile({ 'Contact.$.email': 'dupe@example.com' }),
+        profile({ 'Contact.$.email': hostile })
       ])
 
-      // The bulk upsert must still have been sent, with all three profiles
       expect(mockRequestFn).toHaveBeenCalledTimes(1)
-      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(3)
+      // The two duplicates still collapse; the uncoercible one stands alone
+      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(2)
 
-      // Metrics for this batch are forfeited rather than emitted, and the failure is logged
-      expect(mockStatsClient.histogram).not.toHaveBeenCalled()
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to compute identifier overlap'))
+      // Grouping no longer fails, so metrics are still emitted
+      expect(mockStatsClient.histogram).toHaveBeenCalled()
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to merge overlapping profiles'))
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Ignored 1 identifier value(s) that could not identify anyone')
+      )
+    })
+
+    it('should not group on values that cannot identify anyone', async () => {
+      // Each case: three DIFFERENT people sharing one unusable identifier value
+      const cases: Array<[string, unknown[]]> = [
+        ['objects', [{ city: 'SF' }, { city: 'NYC' }, { city: 'LA' }]],
+        ['booleans', [true, true, true]],
+        ['NaN', [NaN, NaN, NaN]],
+        ['arrays', [['a'], ['b'], ['c']]]
+      ]
+
+      for (const [label, values] of cases) {
+        jest.clearAllMocks()
+        const mockRequestFn = await runBatch([
+          {
+            memora_store: 'test-store-id',
+            profile_identifiers: { 'Contact.$.email': `a-${label}@example.com`, 'Contact.$.x': values[0] },
+            profile_traits: { 'Contact.$.firstName': 'A' }
+          },
+          {
+            memora_store: 'test-store-id',
+            profile_identifiers: { 'Contact.$.email': `b-${label}@example.com`, 'Contact.$.x': values[1] },
+            profile_traits: { 'Contact.$.firstName': 'B' }
+          },
+          {
+            memora_store: 'test-store-id',
+            profile_identifiers: { 'Contact.$.email': `c-${label}@example.com`, 'Contact.$.x': values[2] },
+            profile_traits: { 'Contact.$.firstName': 'C' }
+          }
+        ])
+
+        // Three distinct people must stay three profiles
+        expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(3)
+        expect(histogramValue('batch_largest_group')).toBe(1)
+      }
+    })
+
+    it('should still merge through a usable identifier when another value is unusable', async () => {
+      // The guard is per value, not per event: the shared email must still merge these two
+      const mockRequestFn = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'same@example.com', 'Contact.$.addr': { city: 'SF' } },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'same@example.com', 'Contact.$.addr': { city: 'NY' } },
+          profile_traits: { 'Contact.$.lastName': 'B' }
+        }
+      ])
+
+      const sent = mockRequestFn.mock.calls[0][1].json.profiles
+      expect(sent).toHaveLength(1)
+      // The unusable value is excluded from GROUPING but still sent as data
+      expect(sent[0].traits.Contact.addr).toEqual({ city: 'NY' })
+      expect(sent[0].traits.Contact.firstName).toBe('A')
+      expect(sent[0].traits.Contact.lastName).toBe('B')
+    })
+
+    it('should report non-scalar identifiers via a counter', async () => {
+      await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com', 'Contact.$.addr': { city: 'SF' } },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        }
+      ])
+
+      expect(mockStatsClient.incr).toHaveBeenCalledWith(
+        'memora.upsert_profile.non_scalar_identifiers',
+        1,
+        expect.arrayContaining(['env:test'])
+      )
+    })
+
+    it('should not count an absent identifier as unusable', async () => {
+      await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com', 'Contact.$.phone': null as never },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        }
+      ])
+
+      expect(mockStatsClient.incr).not.toHaveBeenCalledWith(
+        'memora.upsert_profile.non_scalar_identifiers',
+        expect.anything(),
+        expect.anything()
+      )
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('could not identify anyone'))
     })
 
     it('should deliver the batch even if the stats client itself throws', async () => {
@@ -1706,8 +1814,384 @@ describe('Memora.upsertProfile', () => {
       )
 
       expect(mockRequestFn).toHaveBeenCalledTimes(1)
-      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(2)
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to compute identifier overlap'))
+      // Merging is unaffected by the stats failure: both events share an email, so one profile
+      expect(mockRequestFn.mock.calls[0][1].json.profiles).toHaveLength(1)
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to report identifier overlap'))
+    })
+  })
+
+  describe('merging overlapping profiles', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      crit: jest.fn(),
+      log: jest.fn(),
+      level: ''
+    }
+
+    const runBatch = async (payloads: Payload[]) => {
+      const mockRequestFn = jest.fn().mockResolvedValue({ status: 202, data: {}, headers: { get: () => null } })
+      const multiStatus = await Destination.actions.upsertProfile.performBatch!(
+        mockRequestFn as unknown as RequestClient,
+        { payload: payloads, settings: defaultSettings, logger: mockLogger as any }
+      )
+      return { sent: mockRequestFn.mock.calls[0]?.[1]?.json?.profiles, multiStatus, mockRequestFn }
+    }
+
+    // Look profiles up by their contents. Position within the request body is deterministic
+    // but not meaningful -- Memora matches profiles by identifier, not by slot -- so asserting
+    // on order would fail on a harmless reordering of the bucketing loop.
+    const findProfile = (sent: any[], predicate: (contact: any) => boolean) =>
+      sent.find((p: any) => predicate(p.traits.Contact))
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      nock.cleanAll()
+    })
+
+    it('should merge events that share an identifier into a single profile', async () => {
+      const ids = { 'Contact.$.email': 'email1@example.com', 'Contact.$.phone': '+15550001' }
+      const { sent } = await runBatch([
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'A' } },
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.lastName': 'B' } },
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.city': 'SF' } }
+      ])
+
+      expect(sent).toHaveLength(1)
+      // Non-conflicting traits from every event survive the merge
+      expect(sent[0].traits.Contact).toEqual({
+        email: 'email1@example.com',
+        phone: '+15550001',
+        firstName: 'A',
+        lastName: 'B',
+        city: 'SF'
+      })
+    })
+
+    it('should let the later event win on a conflicting trait', async () => {
+      const ids = { 'Contact.$.email': 'dupe@example.com' }
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: ids,
+          profile_traits: { 'Contact.$.firstName': 'Stale', 'Contact.$.city': 'SF' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: ids,
+          profile_traits: { 'Contact.$.firstName': 'Fresh' }
+        }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact.firstName).toBe('Fresh')
+      // A trait only the earlier event set is preserved rather than dropped wholesale
+      expect(sent[0].traits.Contact.city).toBe('SF')
+    })
+
+    it('should let the later event win on a conflicting identifier', async () => {
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'dupe@example.com', 'Contact.$.phone': '+15550001' },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'dupe@example.com', 'Contact.$.phone': '+15559999' },
+          profile_traits: { 'Contact.$.firstName': 'B' }
+        }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact.phone).toBe('+15559999')
+      expect(sent[0].traits.Contact.firstName).toBe('B')
+    })
+
+    it('should merge transitively linked events into one profile', async () => {
+      const pair = { 'Contact.$.email': 'email1@example.com', 'Contact.$.phone': '+15550001' }
+      const { sent } = await runBatch([
+        { memora_store: 'test-store-id', profile_identifiers: pair, profile_traits: { 'Contact.$.a': '1' } },
+        { memora_store: 'test-store-id', profile_identifiers: pair, profile_traits: { 'Contact.$.b': '2' } },
+        { memora_store: 'test-store-id', profile_identifiers: pair, profile_traits: { 'Contact.$.c': '3' } },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'email1@example.com' },
+          profile_traits: { 'Contact.$.d': '4' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.phone': '+15550001' },
+          profile_traits: { 'Contact.$.e': '5' }
+        }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact).toMatchObject({ a: '1', b: '2', c: '3', d: '4', e: '5' })
+    })
+
+    // Guards the `find()` call in the bucketing loop. Every other fixture unions into
+    // index 0's root, so parent chains never exceed depth 1 and reading `parent[index]`
+    // directly would pass. Here root 0 is ABSORBED under a later root, so only a true
+    // find() resolves all four events to one profile.
+    it('should merge a group whose root was absorbed by a later union', async () => {
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.a': '1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com', 'Contact.$.phone': '+1555' },
+          profile_traits: { 'Contact.$.b': '2' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.externalId': 'ext-1' },
+          profile_traits: { 'Contact.$.c': '3' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.phone': '+1555', 'Contact.$.externalId': 'ext-1' },
+          profile_traits: { 'Contact.$.d': '4' }
+        }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact).toMatchObject({ a: '1', b: '2', c: '3', d: '4' })
+    })
+
+    it('should merge two independent groups without leaking traits between them', async () => {
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'alice@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'Alice', 'Contact.$.city': 'SF' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'alice@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'Alice2' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'bob@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'Bob', 'Contact.$.country': 'UK' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'bob@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'Bob2' }
+        }
+      ])
+
+      expect(sent).toHaveLength(2)
+
+      const alice = findProfile(sent, (c) => c.email === 'alice@example.com')
+      const bob = findProfile(sent, (c) => c.email === 'bob@example.com')
+
+      // Each group applies later-wins independently
+      expect(alice.traits.Contact).toEqual({ email: 'alice@example.com', firstName: 'Alice2', city: 'SF' })
+      expect(bob.traits.Contact).toEqual({ email: 'bob@example.com', firstName: 'Bob2', country: 'UK' })
+
+      // No cross-contamination: Alice must not acquire Bob's country, nor Bob Alice's city
+      expect(alice.traits.Contact.country).toBeUndefined()
+      expect(bob.traits.Contact.city).toBeUndefined()
+    })
+
+    it('should merge two groups whose events are interleaved in the batch', async () => {
+      // Members are NOT contiguous: A, B, A, B
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.a1': 'yes' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com' },
+          profile_traits: { 'Contact.$.b1': 'yes' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.a2': 'yes' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com' },
+          profile_traits: { 'Contact.$.b2': 'yes' }
+        }
+      ])
+
+      expect(sent).toHaveLength(2)
+      expect(findProfile(sent, (c) => c.email === 'a@example.com').traits.Contact).toEqual({
+        email: 'a@example.com',
+        a1: 'yes',
+        a2: 'yes'
+      })
+      expect(findProfile(sent, (c) => c.email === 'b@example.com').traits.Contact).toEqual({
+        email: 'b@example.com',
+        b1: 'yes',
+        b2: 'yes'
+      })
+    })
+
+    it('should merge two transitively-linked groups that are interleaved', async () => {
+      // Group A linked via email+phone, group B via userId+externalId, interleaved.
+      // Neither group shares any identifier value with the other.
+      const { sent, multiStatus } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com', 'Contact.$.phone': '+1111' },
+          profile_traits: { 'Contact.$.a1': '1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.userId': 'u-b', 'Contact.$.externalId': 'x-b' },
+          profile_traits: { 'Contact.$.b1': '1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.phone': '+1111' },
+          profile_traits: { 'Contact.$.a2': '2' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.externalId': 'x-b' },
+          profile_traits: { 'Contact.$.b2': '2' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.a3': '3' }
+        }
+      ])
+
+      expect(sent).toHaveLength(2)
+      const groupA = findProfile(sent, (c) => c.a1 !== undefined)
+      const groupB = findProfile(sent, (c) => c.b1 !== undefined)
+
+      expect(groupA.traits.Contact).toMatchObject({ a1: '1', a2: '2', a3: '3' })
+      expect(groupB.traits.Contact).toMatchObject({ b1: '1', b2: '2' })
+      // Group A's traits must not appear on group B
+      expect(groupB.traits.Contact.a1).toBeUndefined()
+      expect(groupA.traits.Contact.b1).toBeUndefined()
+
+      // All five original events still get their own result
+      expect(multiStatus.length()).toBe(5)
+      for (let i = 0; i < 5; i++) {
+        expect(multiStatus.isSuccessResponseAtIndex(i)).toBe(true)
+      }
+    })
+
+    it('should handle two merged groups alongside an unmergeable singleton', async () => {
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.n': 'a1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'solo@example.com' },
+          profile_traits: { 'Contact.$.n': 'solo' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com' },
+          profile_traits: { 'Contact.$.n': 'b1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.n': 'a2' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com' },
+          profile_traits: { 'Contact.$.n': 'b2' }
+        }
+      ])
+
+      expect(sent).toHaveLength(3)
+      expect(sent.map((p: any) => p.traits.Contact.n).sort()).toEqual(['a2', 'b2', 'solo'])
+    })
+
+    it('should leave non-overlapping events as separate profiles', async () => {
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'a@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'A' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'b@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'B' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: { 'Contact.$.email': 'c@example.com' },
+          profile_traits: { 'Contact.$.firstName': 'C' }
+        }
+      ])
+
+      expect(sent).toHaveLength(3)
+      expect(sent.map((p: any) => p.traits.Contact.firstName).sort()).toEqual(['A', 'B', 'C'])
+    })
+
+    it('should merge trait groups independently of each other', async () => {
+      const ids = { 'Contact.$.email': 'dupe@example.com' }
+      const { sent } = await runBatch([
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: ids,
+          profile_traits: { 'Contact.$.firstName': 'A', 'PurchaseHistory.$.lastOrder': 'o1' }
+        },
+        {
+          memora_store: 'test-store-id',
+          profile_identifiers: ids,
+          profile_traits: { 'PurchaseHistory.$.lastOrder': 'o2', 'PurchaseHistory.$.total': '99' }
+        }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact.firstName).toBe('A')
+      expect(sent[0].traits.PurchaseHistory).toEqual({ lastOrder: 'o2', total: '99' })
+    })
+
+    it('should report success for every original event index when events are merged', async () => {
+      const ids = { 'Contact.$.email': 'dupe@example.com' }
+      const { sent, multiStatus } = await runBatch([
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'A' } },
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'B' } },
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'C' } }
+      ])
+
+      // Three events collapse into one upstream profile, but each event still gets a result
+      expect(sent).toHaveLength(1)
+      expect(multiStatus.length()).toBe(3)
+      for (let i = 0; i < 3; i++) {
+        expect(multiStatus.isSuccessResponseAtIndex(i)).toBe(true)
+      }
+    })
+
+    it('should merge valid events while still reporting invalid ones as errors', async () => {
+      const ids = { 'Contact.$.email': 'dupe@example.com' }
+      const { sent, multiStatus } = await runBatch([
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'A' } },
+        { memora_store: 'test-store-id', profile_identifiers: {}, profile_traits: { 'Contact.$.firstName': 'Bad' } },
+        { memora_store: 'test-store-id', profile_identifiers: ids, profile_traits: { 'Contact.$.firstName': 'C' } }
+      ])
+
+      expect(sent).toHaveLength(1)
+      expect(sent[0].traits.Contact.firstName).toBe('C')
+      expect(multiStatus.isSuccessResponseAtIndex(0)).toBe(true)
+      expect(multiStatus.isErrorResponseAtIndex(1)).toBe(true)
+      expect(multiStatus.isSuccessResponseAtIndex(2)).toBe(true)
     })
   })
 

--- a/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
+++ b/packages/destination-actions/src/destinations/memora/upsertProfile/index.ts
@@ -197,15 +197,38 @@ async function upsertProfiles(
     return { rawResponse: undefined, multiStatus: multiStatusResponse }
   }
 
+  // Events sharing an identifier value resolve to one profile upstream, and sending them
+  // as separate entries of the same bulk request is what Memora chokes on. Collapse each
+  // group into a single profile before sending. A failure here must never cost events, so
+  // fall back to the previous behaviour of sending them unmerged.
+  let profilesToSend = validProfiles
+  let overlapStats: IdentifierOverlapStats | undefined
+  try {
+    const { groups, stats } = computeIdentifierGroups(validIdentifiers)
+    overlapStats = stats
+    profilesToSend = groups.map((positions) => ({
+      traits: mergeTraitGroups(positions.map((position) => validProfiles[position].traits))
+    }))
+  } catch (error) {
+    logger?.warn?.(
+      `Failed to merge overlapping profiles, sending them unmerged: ${
+        error instanceof Error ? error.message : String(error)
+      }. ${tagStr}`
+    )
+    profilesToSend = validProfiles
+  }
+
   // Observability must never affect delivery: a throw here would reject the whole
   // batch before the upsert is even attempted, with no status code to mark it
   // non-retryable. Nothing in this block is worth losing events over.
-  try {
-    reportIdentifierOverlap(computeIdentifierOverlap(validIdentifiers), statsTags, tagStr, logger, statsContext)
-  } catch (error) {
-    logger?.warn?.(
-      `Failed to compute identifier overlap: ${error instanceof Error ? error.message : String(error)}. ${tagStr}`
-    )
+  if (overlapStats) {
+    try {
+      reportIdentifierOverlap(overlapStats, statsTags, tagStr, logger, statsContext)
+    } catch (error) {
+      logger?.warn?.(
+        `Failed to report identifier overlap: ${error instanceof Error ? error.message : String(error)}. ${tagStr}`
+      )
+    }
   }
 
   try {
@@ -218,13 +241,17 @@ async function upsertProfiles(
       username: settings.username,
       password: settings.password,
       json: {
-        profiles: validProfiles
+        profiles: profilesToSend
       }
     })
 
     const twilioRequestId = response.headers?.get?.('twilio-request-id')
+    const mergeNote =
+      profilesToSend.length === validProfiles.length
+        ? ''
+        : ` (${validProfiles.length} event(s) merged into ${profilesToSend.length})`
     logger?.info?.(
-      `Bulk upsert completed successfully for ${validProfiles.length} profile(s)${
+      `Bulk upsert completed successfully for ${profilesToSend.length} profile(s)${mergeNote}${
         twilioRequestId ? `. twilio-request-id: ${twilioRequestId}` : ''
       }. ${tagStr}`
     )
@@ -273,6 +300,12 @@ interface IdentifierOverlapStats {
   overlappingEvents: number
   /** Size of the largest group of events collapsing into a single profile. */
   largestGroupSize: number
+  /**
+   * Identifier values that carried no usable identity and were therefore excluded from
+   * grouping. A non-zero count means a mapping is pointing an identifier at something
+   * that cannot identify anyone.
+   */
+  nonScalarIdentifiers: number
 }
 
 /**
@@ -284,7 +317,16 @@ interface IdentifierOverlapStats {
  * this a connected-components count over identifier values rather than a count of
  * distinct identifier tuples.
  */
-function computeIdentifierOverlap(identifierSets: Record<string, unknown>[]): IdentifierOverlapStats {
+interface IdentifierGrouping {
+  /**
+   * One entry per resolved profile, holding positions into the valid-profile arrays in
+   * ascending batch order, so a later event's traits overwrite an earlier one's on merge.
+   */
+  groups: number[][]
+  stats: IdentifierOverlapStats
+}
+
+function computeIdentifierGroups(identifierSets: Record<string, unknown>[]): IdentifierGrouping {
   const total = identifierSets.length
   const parent = Array.from({ length: total }, (_, i) => i)
 
@@ -307,10 +349,32 @@ function computeIdentifierOverlap(identifierSets: Record<string, unknown>[]): Id
 
   // `identifierKey=value` -> index of the first event that carried it
   const firstSeenAt = new Map<string, number>()
+  let nonScalarIdentifiers = 0
 
   identifierSets.forEach((identifiers, index) => {
     Object.entries(identifiers).forEach(([key, value]) => {
-      if (value === undefined || value === null) {
+      // Merging is destructive and irreversible, so it must require positive evidence that
+      // two events are the same person. `profile_identifiers` is an `additionalProperties:
+      // true` field whose values are typed `unknown` and are never type-checked -- AJV
+      // constrains only the keys, and the validation above checks presence, not type -- so
+      // anything the mapping produced arrives here intact.
+      //
+      // Only values with real identity cardinality qualify. Objects and arrays all coerce
+      // to the same '[object Object]' or comma-joined token; booleans have a two-value
+      // domain; 'NaN' and 'Infinity' are stable tokens shared by every event carrying them.
+      // Grouping on any of those merges unrelated people into one profile. Skipping is the
+      // safe failure: the event keeps its own profile, exactly as before merging existed.
+      //
+      // This is per VALUE, not per event -- an event with an unusable value still merges
+      // through its other identifiers, and the value itself is still sent as a trait.
+      const isIdentityValue =
+        typeof value === 'string' || typeof value === 'bigint' || (typeof value === 'number' && Number.isFinite(value))
+
+      if (!isIdentityValue) {
+        if (value !== undefined && value !== null) {
+          // null/undefined mean the identifier is simply absent, which is not a mapping fault.
+          nonScalarIdentifiers++
+        }
         return
       }
       const normalized = String(value).trim()
@@ -329,29 +393,60 @@ function computeIdentifierOverlap(identifierSets: Record<string, unknown>[]): Id
     })
   })
 
-  const groupSizes = new Map<number, number>()
+  // Bucket by true root. `find` is required here: union only ever repoints roots, so a
+  // node's parent may still be an absorbed intermediate. Ascending iteration keeps each
+  // bucket in batch order.
+  const byRoot = new Map<number, number[]>()
   for (let index = 0; index < total; index++) {
     const root = find(index)
-    groupSizes.set(root, (groupSizes.get(root) ?? 0) + 1)
+    const members = byRoot.get(root)
+    if (members) {
+      members.push(index)
+    } else {
+      byRoot.set(root, [index])
+    }
   }
 
   let overlappingEvents = 0
   let largestGroupSize = 0
-  groupSizes.forEach((size) => {
-    if (size > 1) {
-      overlappingEvents += size
+  byRoot.forEach((members) => {
+    if (members.length > 1) {
+      overlappingEvents += members.length
     }
-    if (size > largestGroupSize) {
-      largestGroupSize = size
+    if (members.length > largestGroupSize) {
+      largestGroupSize = members.length
     }
   })
 
   return {
-    events: total,
-    distinctProfiles: groupSizes.size,
-    overlappingEvents,
-    largestGroupSize
+    groups: Array.from(byRoot.values()),
+    stats: {
+      events: total,
+      distinctProfiles: byRoot.size,
+      overlappingEvents,
+      largestGroupSize,
+      nonScalarIdentifiers
+    }
   }
+}
+
+/**
+ * Merge the trait groups of every event that resolved to the same profile.
+ *
+ * Merging is per trait, not per trait group, so an earlier event's traits survive unless
+ * a later event sets the same trait. `perEvent` must be in ascending batch order: the
+ * last writer wins, which makes the later event authoritative on conflict.
+ */
+function mergeTraitGroups(
+  perEvent: Record<string, Record<string, unknown>>[]
+): Record<string, Record<string, unknown>> {
+  const merged: Record<string, Record<string, unknown>> = {}
+  perEvent.forEach((traitGroups) => {
+    Object.entries(traitGroups).forEach(([groupName, traits]) => {
+      merged[groupName] = { ...merged[groupName], ...traits }
+    })
+  })
+  return merged
 }
 
 // Identifier values are PII, so only counts are ever emitted — never the values themselves.
@@ -365,6 +460,16 @@ function reportIdentifierOverlap(
   const statsClient = statsContext?.statsClient
   statsClient?.histogram('memora.upsert_profile.batch_overlapping_events', stats.overlappingEvents, statsTags)
   statsClient?.histogram('memora.upsert_profile.batch_largest_group', stats.largestGroupSize, statsTags)
+
+  if (stats.nonScalarIdentifiers > 0) {
+    // Counts only -- identifier values are PII and never leave the process.
+    statsClient?.incr('memora.upsert_profile.non_scalar_identifiers', stats.nonScalarIdentifiers, statsTags)
+    logger?.warn?.(
+      `Ignored ${stats.nonScalarIdentifiers} identifier value(s) that could not identify anyone ` +
+        `(not a string, finite number, or bigint); those values were excluded from profile merging. ` +
+        `Check the identifier mapping. ${tagStr}`
+    )
+  }
 
   if (stats.overlappingEvents > 0) {
     logger?.warn?.(


### PR DESCRIPTION
Events that share an identifier value resolve to the same profile upstream, so sending them as separate entries of one bulk request is what breaks Memora. This groups each batch by shared identifier value and sends one merged profile per group instead of one entry per event.

### Grouping

A connected-components pass (union-find) over identifier values, so the relation is transitive: events carrying `{email1, phone1}`, `{email1}` and `{phone1}` all resolve to one profile even though the last two share nothing directly with each other.

Grouping happens after validation, over the profiles that will actually be sent, and is keyed on `identifierKey` + value so the same string under `Contact.$.email` and `Contact.$.externalId` does not falsely join.

### Merging

Each group folds into one profile in ascending batch order, so a **later event wins on a conflicting trait or identifier**. Merging is per trait rather than per trait group, so an earlier event's other traits survive:

```
event 1: { Contact.$.firstName: 'Stale', Contact.$.city: 'SF' }
event 2: { Contact.$.firstName: 'Fresh' }
merged:  { firstName: 'Fresh', city: 'SF' }
```

### Which values may drive a merge

Only strings, bigints and finite numbers. `profile_identifiers` is an `additionalProperties: true` field whose values are typed `unknown` and never type-checked — AJV constrains only the keys, and the action's validation checks presence rather than type — so whatever the mapping produced arrives intact.

| Excluded | Why it would merge unrelated people |
| --- | --- |
| objects, arrays | all coerce to `[object Object]` or a comma join |
| booleans | two-value domain |
| `NaN`, `Infinity` | stable tokens shared by every event carrying them |

Exclusion is **per value, not per event**: the event still merges through its other identifiers, and the value is still sent as a trait — it is only excluded from the grouping key. `memora.upsert_profile.non_scalar_identifiers` and a warning report how many were ignored, so a bad mapping surfaces instead of silently producing singletons. Counts only, never values.

### Behaviour preserved

- `MultiStatusResponse` unchanged: N events collapsing into M profiles still report a result at every original payload index, so retry and error reporting stay correct.
- Invalid events are still excluded and reported individually while the valid ones merge.
- If grouping or merging throws, delivery falls back to sending the profiles unmerged rather than costing events.
- Grouping is deterministic, so a retried batch produces a byte-identical body.
- No new or changed fields, so no subscription needs updating.

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

90 tests pass across the memora suites (20 new), snapshots unchanged, `tsc --noEmit` exit 0, ESLint 0 errors, `yarn validate` passes.

New coverage: single and transitive merges; later-wins pinned to the specific winning value rather than just the profile count; trait groups merging independently; a group whose union-find root is absorbed by a later union; two independent groups asserting no trait leakage between them; two groups whose members are interleaved rather than contiguous; two interleaved transitive chains; merged groups alongside unmergeable singletons; every original index reporting success when events collapse; and each excluded value type keeping distinct people apart.

Assertions look profiles up by their contents rather than by position, since order within the request body is not meaningful.

Not yet exercised against a real Memora store — all verification is unit-level with a mocked request client.

## Security Review

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

No field definitions added or changed. Identifier values are treated as PII throughout: grouping keys live in a local `Map` for the duration of the call, and every metric and log line carries counts only.
