### PR TITLE
[STRATCONN-6714 : Google enhanced conversion] [Perform/PerformBatch] upgraded the perform and perform batch function to use new Data Manager API 

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -14,7 +14,10 @@ import {
   OfflineUserJobPayload,
   AddOperationPayload,
   KeyValuePairList,
-  KeyValueItem
+  KeyValueItem,
+  PartnerLinkResponse,
+  DataManagerAudienceMember,
+  DataManagerIngestResponse
 } from './types'
 import {
   ModifiedResponse,
@@ -48,6 +51,9 @@ export const CANARY_API_VERSION = GOOGLE_ENHANCED_CONVERSIONS_CANARY_API_VERSION
 export const FLAGON_NAME = 'google-enhanced-canary-version'
 export const FLAGON_NAME_PHONE_VALIDATION_CHECK = 'google-enhanced-phone-validation-check'
 import { PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber'
+export const FLAGON_NAME_DATA_MANAGER_API = 'actions-google-ec-data-manager-api'
+export const DATA_MANAGER_BASE_URL = 'https://datamanager.googleapis.com/v1'
+const PARTNER_ACCOUNT_ID = '262932431'
 
 const phoneUtil = PhoneNumberUtil.getInstance()
 
@@ -690,6 +696,270 @@ const processOperations = async (
   }
 }
 
+function buildDataManagerDestination(customerId: string, userListId: string, loginCustomerId?: string) {
+  // loginAccount must match the authorization token (customer's GOOGLE_ADS token from extendRequest).
+  // For MCC setups: loginAccount = MCC, linkedAccount = sub-account the MCC manages, operatingAccount = sub-account.
+  const loginAccountId = loginCustomerId || customerId
+  const dest: Record<string, unknown> = {
+    loginAccount: { accountId: loginAccountId, accountType: 'GOOGLE_ADS' },
+    operatingAccount: { accountId: customerId, accountType: 'GOOGLE_ADS' },
+    productDestinationId: userListId
+  }
+  // linkedAccount: for MCC, this is the sub-account (customerId) that the MCC has access to via account link.
+  if (loginCustomerId) {
+    dest.linkedAccount = { accountId: customerId, accountType: 'GOOGLE_ADS' }
+  }
+  return dest
+}
+
+export async function removeAudienceMembers(
+  request: RequestClient,
+  customerId: string,
+  userListId: string,
+  members: DataManagerAudienceMember[],
+  loginCustomerId?: string,
+  customerAccessToken?: string,
+  statsContext?: StatsContext
+): Promise<DataManagerIngestResponse> {
+  const response = await request<DataManagerIngestResponse>(`${DATA_MANAGER_BASE_URL}/audienceMembers:remove`, {
+    method: 'POST',
+    // Only override auth if we have an explicit token; otherwise extendRequest's token is used.
+    ...(customerAccessToken && { headers: { authorization: `Bearer ${customerAccessToken}` } }),
+    json: {
+      destinations: [buildDataManagerDestination(customerId, userListId, loginCustomerId)],
+      audienceMembers: members,
+      encoding: 'HEX'
+    }
+  })
+  statsContext?.statsClient?.incr('success.dataManagerRemoveAudience', 1, statsContext?.tags)
+  return response.data
+}
+
+export async function ingestAudienceMembers(
+  request: RequestClient,
+  customerId: string,
+  userListId: string,
+  members: DataManagerAudienceMember[],
+  loginCustomerId?: string,
+  customerAccessToken?: string,
+  statsContext?: StatsContext
+): Promise<DataManagerIngestResponse> {
+  const response = await request<DataManagerIngestResponse>(`${DATA_MANAGER_BASE_URL}/audienceMembers:ingest`, {
+    method: 'POST',
+    // Only override auth if we have an explicit token; otherwise extendRequest's token is used.
+    ...(customerAccessToken && { headers: { authorization: `Bearer ${customerAccessToken}` } }),
+    json: {
+      destinations: [buildDataManagerDestination(customerId, userListId, loginCustomerId)],
+      audienceMembers: members,
+      encoding: 'HEX',
+      termsOfService: { customerMatchTermsOfServiceStatus: 'ACCEPTED' }
+    }
+  })
+  statsContext?.statsClient?.incr('success.dataManagerIngestAudience', 1, statsContext?.tags)
+  return response.data
+}
+
+function toDataManagerConsentStatus(value?: string): string | undefined {
+  if (value === 'GRANTED') return 'CONSENT_GRANTED'
+  if (value === 'DENIED') return 'CONSENT_DENIED'
+  return undefined
+}
+
+function buildAudienceMember(
+  payload: UserListPayload,
+  idType: string,
+  features?: Features,
+  statsContext?: StatsContext
+): DataManagerAudienceMember | null {
+  const consent = {
+    adUserData: toDataManagerConsentStatus(payload.ad_user_data_consent_state),
+    adPersonalization: toDataManagerConsentStatus(payload.ad_personalization_consent_state)
+  }
+
+  if (idType === 'MOBILE_ADVERTISING_ID') {
+    const mobileId = payload.mobile_advertising_id?.trim()
+    if (!mobileId) return null
+    return { mobileData: { mobileIds: [mobileId] }, consent }
+  }
+
+  if (idType === 'CRM_ID') {
+    const userId = payload.crm_id?.trim()
+    if (!userId) return null
+    return { userIdData: { userId }, consent }
+  }
+
+  // CONTACT_INFO
+  const userIdentifiers: NonNullable<DataManagerAudienceMember['userData']>['userIdentifiers'] = []
+
+  if (payload.email) {
+    userIdentifiers.push({
+      emailAddress: processHashing(payload.email, 'sha256', 'hex', commonEmailValidation)
+    })
+  }
+
+  if (payload.phone) {
+    userIdentifiers.push({
+      phoneNumber: processHashing(payload.phone, 'sha256', 'hex', (v) =>
+        formatPhone(v, payload.phone_country_code, features, statsContext)
+      )
+    })
+  }
+
+  // Docs require givenName + familyName + regionCode + postalCode in AddressInfo
+  if (payload.first_name && payload.last_name && (payload.country_code || payload.postal_code)) {
+    userIdentifiers.push({
+      address: {
+        givenName: processHashing(payload.first_name, 'sha256', 'hex'),
+        familyName: processHashing(payload.last_name, 'sha256', 'hex'),
+        regionCode: payload.country_code ?? '',
+        postalCode: payload.postal_code ?? ''
+      }
+    })
+  }
+
+  if (userIdentifiers.length === 0) return null
+  return { userData: { userIdentifiers }, consent }
+}
+
+export async function createDataManagerPartnerLink(
+  request: RequestClient,
+  customerId: string,
+  customerAccessToken: string,
+  loginCustomerId?: string
+): Promise<PartnerLinkResponse> {
+  const owningAccountId = loginCustomerId || customerId
+  const url = `${DATA_MANAGER_BASE_URL}/accountTypes/GOOGLE_ADS/accounts/${customerId}/partnerLinks`
+  try {
+    const response = await request<PartnerLinkResponse>(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${customerAccessToken}`,
+        'login-account': `accountTypes/GOOGLE_ADS/accounts/${owningAccountId}`
+      },
+      json: {
+        owningAccount: { accountId: owningAccountId, accountType: 'GOOGLE_ADS' },
+        partnerAccount: { accountId: PARTNER_ACCOUNT_ID, accountType: 'DATA_PARTNER' }
+      }
+    })
+    return response.data
+  } catch (err: any) {
+    // 409 ALREADY_EXISTS means the link is already established — treat as success
+    if (err?.response?.status === 409) {
+      return err.response.data as PartnerLinkResponse
+    }
+    throw err
+  }
+}
+
+export async function exchangeForAccessToken(request: RequestClient, refreshToken: string): Promise<string> {
+  if (!process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID || !process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET) {
+    throw new PayloadValidationError('OAuth client credentials (client ID / client secret) are not configured.')
+  }
+
+  const res = await request<RefreshTokenResponse>('https://www.googleapis.com/oauth2/v4/token', {
+    method: 'POST',
+    body: new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_ID,
+      client_secret: process.env.GOOGLE_ENHANCED_CONVERSIONS_CLIENT_SECRET,
+      grant_type: 'refresh_token'
+    })
+  })
+
+  return res.data.access_token
+}
+
+export async function handleDataManagerUpdate(
+  request: RequestClient,
+  settings: CreateAudienceInput['settings'],
+  audienceSettings: CreateAudienceInput['audienceSettings'],
+  payloads: UserListPayload[],
+  hookListId: string,
+  hookListType: string,
+  syncMode?: string,
+  features?: Features,
+  statsContext?: StatsContext,
+  audienceMembership?: AudienceMembership | AudienceMembership[]
+) {
+  const externalAudienceId: string | undefined = hookListId || payloads[0]?.external_audience_id
+  if (!externalAudienceId) {
+    throw new PayloadValidationError('External Audience ID is required.')
+  }
+
+  const customerId = settings.customerId!
+  const loginCustomerId = settings.loginCustomerId?.trim().replace(/-/g, '') || undefined
+  const idType = hookListType ?? audienceSettings.external_id_type
+
+  // Ensure the partner link exists — covers existing customers when the flag is first enabled.
+  // Best-effort: errors are swallowed so member sync can still proceed.
+  let customerAccessToken: string | undefined
+  if (settings.oauth?.refresh_token) {
+    try {
+      customerAccessToken = await exchangeForAccessToken(request, settings.oauth.refresh_token)
+      await createDataManagerPartnerLink(request, customerId, customerAccessToken, loginCustomerId)
+    } catch (_) {
+      // intentionally swallowed — partner link errors must not block member sync
+    }
+  }
+
+  const addMembers: DataManagerAudienceMember[] = []
+  const removeMembers: DataManagerAudienceMember[] = []
+
+  for (let i = 0; i < payloads.length; i++) {
+    const payload = payloads[i]
+    const member = buildAudienceMember(payload, idType, features, statsContext)
+    if (!member) continue
+
+    const membership = Array.isArray(audienceMembership) ? audienceMembership[i] : audienceMembership
+    if (
+      payload.event_name === 'Audience Entered' ||
+      syncMode === 'add' ||
+      (syncMode === 'mirror' && (payload.event_name === 'new' || payload.event_name === 'updated')) ||
+      membership === true
+    ) {
+      addMembers.push(member)
+    } else if (
+      payload.event_name === 'Audience Exited' ||
+      syncMode === 'delete' ||
+      (syncMode === 'mirror' && payload.event_name === 'deleted') ||
+      membership === false
+    ) {
+      removeMembers.push(member)
+    }
+  }
+
+  const results: DataManagerIngestResponse[] = []
+
+  if (addMembers.length > 0) {
+    const r = await ingestAudienceMembers(
+      request,
+      customerId,
+      externalAudienceId,
+      addMembers,
+      loginCustomerId,
+      customerAccessToken,
+      statsContext
+    )
+    results.push(r)
+  }
+
+  if (removeMembers.length > 0) {
+    const r = await removeAudienceMembers(
+      request,
+      customerId,
+      externalAudienceId,
+      removeMembers,
+      loginCustomerId,
+      customerAccessToken,
+      statsContext
+    )
+    results.push(r)
+  }
+
+  statsContext?.statsClient?.incr('success.dataManagerUpdateAudience', 1, statsContext?.tags)
+  return results
+}
+
 export const handleUpdate = async (
   request: RequestClient,
   settings: CreateAudienceInput['settings'],
@@ -972,7 +1242,11 @@ const extractBatchUserIdentifiers = (
 }
 
 // Helper function to determine operation type
-const determineOperationType = (payload: UserListPayload, syncMode?: string, audienceMembership?: AudienceMembership) => {
+const determineOperationType = (
+  payload: UserListPayload,
+  syncMode?: string,
+  audienceMembership?: AudienceMembership
+) => {
   if (
     payload.event_name === 'Audience Entered' ||
     syncMode === 'add' ||

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -104,14 +104,14 @@ export interface ClickConversionRequestObjectInterface {
 export type KeyValuePairList = Array<KeyValueItem>
 
 export type KeyValueItem = {
-  sessionAttributeKey: 
-    'gad_source' 
-  | 'gad_campaignid' 
-  | 'landing_page_url' 
-  | 'session_start_time_usec' 
-  | 'landing_page_referrer' 
-  | 'landing_page_user_agent'
-  sessionAttributeValue?: string 
+  sessionAttributeKey:
+    | 'gad_source'
+    | 'gad_campaignid'
+    | 'landing_page_url'
+    | 'session_start_time_usec'
+    | 'landing_page_referrer'
+    | 'landing_page_user_agent'
+  sessionAttributeValue?: string
 }
 
 export interface ConversionActionId {
@@ -157,6 +157,7 @@ export interface CreateAudienceInput {
   audienceName: string
   settings: {
     customerId?: string
+    loginCustomerId?: string
     conversionTrackingId?: string
     oauth?: {
       refresh_token?: string
@@ -169,6 +170,42 @@ export interface CreateAudienceInput {
   }
   statsContext?: StatsContext
   features?: Features
+}
+
+export interface PartnerLinkResponse {
+  name: string
+  partnerLinkId: string
+  owningAccount: {
+    accountId: string
+    accountType: string
+  }
+  partnerAccount: {
+    accountId: string
+    accountType: string
+  }
+}
+
+export interface DataManagerAudienceMember {
+  userData?: {
+    userIdentifiers: Array<{
+      emailAddress?: string
+      phoneNumber?: string
+      address?: {
+        givenName?: string
+        familyName?: string
+        regionCode: string
+        postalCode: string
+      }
+    }>
+  }
+  mobileData?: { mobileIds: string[] }
+  userIdData?: { userId: string }
+  consent?: { adUserData?: string; adPersonalization?: string }
+}
+
+export interface DataManagerIngestResponse {
+  requestId: string
+  fieldWarnings?: Array<{ field: string; description: string }>
 }
 
 export interface GetAudienceInput {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/userList/index.ts
@@ -7,7 +7,9 @@ import {
   getListIds,
   handleUpdate,
   processBatchPayload,
-  verifyCustomerId
+  verifyCustomerId,
+  FLAGON_NAME_DATA_MANAGER_API,
+  handleDataManagerUpdate
 } from '../functions'
 import { IntegrationError } from '@segment/actions-core'
 import { UserListResponse } from '../types'
@@ -309,6 +311,21 @@ const action: ActionDefinition<Settings, Payload> = {
   ) => {
     settings.customerId = verifyCustomerId(settings.customerId)
 
+    if (features?.[FLAGON_NAME_DATA_MANAGER_API]) {
+      return await handleDataManagerUpdate(
+        request,
+        settings,
+        audienceSettings,
+        [payload],
+        hookOutputs?.retlOnMappingSave?.outputs.id,
+        hookOutputs?.retlOnMappingSave?.outputs.external_id_type,
+        syncMode,
+        features,
+        statsContext,
+        audienceMembership
+      )
+    }
+
     return await handleUpdate(
       request,
       settings,
@@ -327,6 +344,21 @@ const action: ActionDefinition<Settings, Payload> = {
     { settings, audienceSettings, payload, hookOutputs, statsContext, syncMode, features, audienceMembership }
   ) => {
     settings.customerId = verifyCustomerId(settings.customerId)
+
+    if (features?.[FLAGON_NAME_DATA_MANAGER_API]) {
+      return await handleDataManagerUpdate(
+        request,
+        settings,
+        audienceSettings,
+        payload,
+        hookOutputs?.retlOnMappingSave?.outputs.id,
+        hookOutputs?.retlOnMappingSave?.outputs.external_id_type,
+        syncMode,
+        features,
+        statsContext,
+        audienceMembership
+      )
+    }
     return await processBatchPayload(
       request,
       settings,


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

 https://twilio-engineering.atlassian.net/browse/STRATCONN-6612
 

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

1. This PR introduces upgradation of Perform and Perform batch to new data manager API from traditional google ads API .
2. It add and remove the audiencemember to the google audience manager userlist .
3. Document highlighting the Upgradation of google ads api to data manager API https://docs.google.com/document/d/1RNkv9UI_oU3c2XGDRmVCfo0aYNE97dynL29XIFCkYHY/edit?tab=t.0
4. Google docs for perform and performbatch (Add functionality)  -->  https://developers.google.com/data-manager/api/reference/rest/v1/audienceMembers/ingest
5. Google docs for perform and perform batch( Remove functionality ) --> https://developers.google.com/data-manager/api/reference/rest/v1/audienceMembers/remove



## Testing

Tested done in staging 

Rollout using the flagon deployment for version .
https://flagon.segment.com/families/centrifuge-destinations/gates/actions-google-ec-data-manager-api


_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._


- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.

## Security Review

_Please ensure sensitive data is properly protected in your integration._

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'`

## New Destination Checklist

- [x] Extracted all action API versions to `verioning-info.ts` file. [example](https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/facebook-conversions-api/versioning-info.ts)
