### PR TITLE
Facebook Custom Audiences: add optional Audience Label field (create-time)

### DIFF
--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/audience-creation.test.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/__tests__/audience-creation.test.ts
@@ -23,7 +23,8 @@ const baseCreateAudienceInput = () => ({
   audienceName: '',
   audienceSettings: {
     engageAdAccountId: adAccountId,
-    audienceDescription: 'We are the Mario Brothers and plumbing is our game.'
+    audienceDescription: 'We are the Mario Brothers and plumbing is our game.',
+    audienceLabel: undefined as string | undefined
   },
   features: {}
 })
@@ -42,8 +43,12 @@ describe('Facebook Custom Audiences', () => {
     })
 
     it('should create a new Facebook Audience', async () => {
+      let requestBody: Record<string, unknown> = {}
       nock(`${BASE_URL}/${API_VERSION}/act_${adAccountId}`)
-        .post('/customaudiences')
+        .post('/customaudiences', (body) => {
+          requestBody = body
+          return true
+        })
         .reply(200, { id: '88888888888888888' })
 
       const input = baseCreateAudienceInput()
@@ -51,6 +56,33 @@ describe('Facebook Custom Audiences', () => {
 
       const r = await testDestination.createAudience(input)
       expect(r).toEqual({ externalId: '88888888888888888' })
+      expect(requestBody).not.toHaveProperty('audience_labels')
+    })
+
+    it('should include audience_labels when an audience label is set', async () => {
+      let requestBody: Record<string, unknown> = {}
+      nock(`${BASE_URL}/${API_VERSION}/act_${adAccountId}`)
+        .post('/customaudiences', (body) => {
+          requestBody = body
+          return true
+        })
+        .reply(200, { id: '88888888888888888' })
+
+      const input = baseCreateAudienceInput()
+      input.audienceName = 'The Super Mario Brothers Fans'
+      input.audienceSettings.audienceLabel = 'HIGH_VALUE_CUSTOMERS'
+
+      const r = await testDestination.createAudience(input)
+      expect(r).toEqual({ externalId: '88888888888888888' })
+      expect(requestBody.audience_labels).toEqual(['HIGH_VALUE_CUSTOMERS'])
+    })
+
+    it('should reject an audience label value outside the predefined choices', async () => {
+      const input = baseCreateAudienceInput()
+      input.audienceName = 'The Super Mario Brothers Fans'
+      input.audienceSettings.audienceLabel = 'NOT_A_REAL_LABEL'
+
+      await expect(testDestination.createAudience(input)).rejects.toThrow()
     })
 
     it('should use error_user_title and error_user_msg when both are present', async () => {
@@ -70,7 +102,7 @@ describe('Facebook Custom Audiences', () => {
       input.audienceName = 'Restricted Audience'
 
       await expect(testDestination.createAudience(input)).rejects.toThrow(
-        "error_user_title: \"Update Restricted Fields and Rule\". error_user_msg: \"This custom audience has integrity restrictions.\". fbmessage: \"Invalid parameter\". message: \"Bad Request\". code: \"100\""
+        'error_user_title: "Update Restricted Fields and Rule". error_user_msg: "This custom audience has integrity restrictions.". fbmessage: "Invalid parameter". message: "Bad Request". code: "100"'
       )
     })
 

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/fields.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/fields.ts
@@ -13,3 +13,27 @@ export const audienceDescription: GlobalSetting = {
   description: 'A brief description about your audience.',
   required: true
 }
+
+// Values per Meta's Audience Labels partner integration guide. Meta's public
+// Marketing API guide lists the last "Customers" value as CUSTOMERS instead of
+// GENERAL_CUSTOMERS - GENERAL_CUSTOMERS confirmed correct via a live v24.0
+// createAudience call (STRATCONN-7008), accepted and persisted by the API.
+export const audienceLabel: GlobalSetting = {
+  type: 'string',
+  label: 'Audience Label',
+  description:
+    "Optionally categorize this audience with one of Meta's predefined labels. Sent to Facebook when the audience is created; does not apply retroactively to existing audiences.",
+  required: false,
+  choices: [
+    { label: 'Qualified Leads', value: 'QUALIFIED_LEADS' },
+    { label: 'Disqualified Leads', value: 'DISQUALIFIED_LEADS' },
+    { label: 'App Users', value: 'APP_USERS' },
+    { label: 'Trial Users', value: 'TRIAL_USERS' },
+    { label: 'Engaged Users', value: 'ENGAGED_USERS' },
+    { label: 'High Value Customers', value: 'HIGH_VALUE_CUSTOMERS' },
+    { label: 'Low Value Customers', value: 'LOW_VALUE_CUSTOMERS' },
+    { label: 'At Risk', value: 'AT_RISK' },
+    { label: 'Disengaged', value: 'DISENGAGED' },
+    { label: 'General Customers', value: 'GENERAL_CUSTOMERS' }
+  ]
+}

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/functions.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/functions.ts
@@ -1,6 +1,13 @@
 import { RequestClient, ErrorCodes, Features } from '@segment/actions-core'
 import { StatsContext } from '@segment/actions-core/destination-kit'
-import { ParsedFacebookError, NonFacebookError, FacebookResponseError, CreateAudienceRequest, CreateAudienceResponse, GetAudienceResponse } from './types'
+import {
+  ParsedFacebookError,
+  NonFacebookError,
+  FacebookResponseError,
+  CreateAudienceRequest,
+  CreateAudienceResponse,
+  GetAudienceResponse
+} from './types'
 import { API_VERSION, BASE_URL, FACEBOOK_CUSTOM_AUDIENCE_FLAGON, CANARY_API_VERSION } from './constants'
 
 export function parseFacebookError(error: FacebookResponseError): ParsedFacebookError {
@@ -18,7 +25,7 @@ export function parseFacebookError(error: FacebookResponseError): ParsedFacebook
       } = {}
     } = {},
     message: outerMessage
-  } = (error ?? {})
+  } = error ?? {}
 
   const parts = [
     error_user_title && `error_user_title: "${error_user_title}"`,
@@ -28,7 +35,8 @@ export function parseFacebookError(error: FacebookResponseError): ParsedFacebook
     code && `code: "${code}"`
   ]
 
-  const message = parts.filter(Boolean).join('. ').trim() || 'An unknown error occurred while communicating with Facebook API.'
+  const message =
+    parts.filter(Boolean).join('. ').trim() || 'An unknown error occurred while communicating with Facebook API.'
 
   return {
     message,
@@ -37,7 +45,15 @@ export function parseFacebookError(error: FacebookResponseError): ParsedFacebook
   }
 }
 
-export async function createAudience(request: RequestClient, name: string, adAccountId: string, description?: string, features?: Features, statsContext?: StatsContext): Promise<{ data?: { externalId: string }, error?: NonFacebookError }> {
+export async function createAudience(
+  request: RequestClient,
+  name: string,
+  adAccountId: string,
+  description?: string,
+  features?: Features,
+  statsContext?: StatsContext,
+  audienceLabel?: string
+): Promise<{ data?: { externalId: string }; error?: NonFacebookError }> {
   if (!name) {
     return { error: { message: 'Missing audience name value', code: ErrorCodes.CREATE_AUDIENCE_FAILED } }
   }
@@ -51,7 +67,8 @@ export async function createAudience(request: RequestClient, name: string, adAcc
     name,
     subtype: 'CUSTOM',
     customer_file_source: 'BOTH_USER_AND_PARTNER_PROVIDED',
-    ...(description ? { description } : {})
+    ...(description ? { description } : {}),
+    ...(audienceLabel ? { audience_labels: [audienceLabel] } : {})
   }
 
   try {
@@ -66,19 +83,23 @@ export async function createAudience(request: RequestClient, name: string, adAcc
       return {
         error: {
           message: 'Invalid response from create audience request',
-          code: ErrorCodes.CREATE_AUDIENCE_FAILED 
+          code: ErrorCodes.CREATE_AUDIENCE_FAILED
         }
       }
     }
     return { data: { externalId: id } }
-  } 
-  catch (error) {
+  } catch (error) {
     const { message } = parseFacebookError(error as FacebookResponseError)
     return { error: { message, code: ErrorCodes.CREATE_AUDIENCE_FAILED } }
   }
 }
 
-export async function getAudience(request: RequestClient, externalId: string, features?: Features, statsContext?: StatsContext): Promise<{ data?: { externalId?: string; name: string}, error?: NonFacebookError }> {
+export async function getAudience(
+  request: RequestClient,
+  externalId: string,
+  features?: Features,
+  statsContext?: StatsContext
+): Promise<{ data?: { externalId?: string; name: string }; error?: NonFacebookError }> {
   const url = `${BASE_URL}/${getApiVersion(features, statsContext)}/${externalId}?fields=id,name`
 
   try {
@@ -86,10 +107,15 @@ export async function getAudience(request: RequestClient, externalId: string, fe
     const { id, name } = response.data
 
     if (!id) {
-      return { error: { message: 'Invalid response from get audience request', code: ErrorCodes.GET_AUDIENCE_FAILED }}
+      return { error: { message: 'Invalid response from get audience request', code: ErrorCodes.GET_AUDIENCE_FAILED } }
     }
     if (externalId !== id) {
-      return { error: { message: `Audience not found. Audience ID mismatch. Expected: ${externalId}, Received: ${id}`, code: ErrorCodes.GET_AUDIENCE_FAILED } }
+      return {
+        error: {
+          message: `Audience not found. Audience ID mismatch. Expected: ${externalId}, Received: ${id}`,
+          code: ErrorCodes.GET_AUDIENCE_FAILED
+        }
+      }
     }
     return {
       data: {

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/generated-types.ts
@@ -17,4 +17,8 @@ export interface AudienceSettings {
    * A brief description about your audience.
    */
   audienceDescription: string
+  /**
+   * Optionally categorize this audience with one of Meta's predefined labels. Sent to Facebook when the audience is created; does not apply retroactively to existing audiences.
+   */
+  audienceLabel?: string
 }

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/index.ts
@@ -1,7 +1,7 @@
 import type { AudienceDestinationDefinition } from '@segment/actions-core'
 import { IntegrationError, ErrorCodes } from '@segment/actions-core'
 import type { Settings, AudienceSettings } from './generated-types'
-import { adAccountId, audienceDescription } from './fields'
+import { adAccountId, audienceDescription, audienceLabel } from './fields'
 import sync from './sync'
 import { createAudience, getAudience } from './functions'
 import { presets } from './presets'
@@ -14,10 +14,10 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   authentication: {
     scheme: 'oauth2',
     fields: {
-      retlAdAccountId: 
-      {
+      retlAdAccountId: {
         ...adAccountId,
-        description: 'Your advertiser account id. Read [more](https://www.facebook.com/business/help/1492627900875762). This is required to set up the connection, but can be overriden using the Engage Audience setting named "Advertiser Account ID".' 
+        description:
+          'Your advertiser account id. Read [more](https://www.facebook.com/business/help/1492627900875762). This is required to set up the connection, but can be overriden using the Engage Audience setting named "Advertiser Account ID".'
       }
     }
   },
@@ -30,42 +30,45 @@ const destination: AudienceDestinationDefinition<Settings, AudienceSettings> = {
   },
   audienceFields: {
     engageAdAccountId: {
-        ...adAccountId,
-        description: 'Your advertiser account id. Read [more](https://www.facebook.com/business/help/1492627900875762). This overrides the main Destination settings named "Advertiser Account ID".',
-        required: false
-      },
-    audienceDescription
+      ...adAccountId,
+      description:
+        'Your advertiser account id. Read [more](https://www.facebook.com/business/help/1492627900875762). This overrides the main Destination settings named "Advertiser Account ID".',
+      required: false
+    },
+    audienceDescription,
+    audienceLabel
   },
   audienceConfig: {
     mode: {
       type: 'synced',
       full_audience_sync: false
     },
-    async createAudience(request, createAudienceInput ) {
-      const { 
+    async createAudience(request, createAudienceInput) {
+      const {
         audienceName,
-        audienceSettings: { 
-          engageAdAccountId, 
-          audienceDescription 
-        } = {},
-        settings: { retlAdAccountId } = {}, 
+        audienceSettings: { engageAdAccountId, audienceDescription, audienceLabel } = {},
+        settings: { retlAdAccountId } = {},
         features,
         statsContext
       } = createAudienceInput
 
       const addAccountId = (engageAdAccountId ?? retlAdAccountId) as string
-      const { data: { externalId: id } = {}, error } = await createAudience(request, audienceName, addAccountId, audienceDescription, features, statsContext)
+      const { data: { externalId: id } = {}, error } = await createAudience(
+        request,
+        audienceName,
+        addAccountId,
+        audienceDescription,
+        features,
+        statsContext,
+        audienceLabel
+      )
       if (error) {
         throw new IntegrationError(error.message, ErrorCodes.CREATE_AUDIENCE_FAILED, 400)
       }
       return { externalId: id as string }
     },
     async getAudience(request, getAudienceInput) {
-      const { 
-        externalId,
-        features, 
-        statsContext 
-      } = getAudienceInput
+      const { externalId, features, statsContext } = getAudienceInput
       const { data: { externalId: id } = {}, error } = await getAudience(request, externalId, features, statsContext)
       if (error) {
         throw new IntegrationError(error.message, ErrorCodes.GET_AUDIENCE_FAILED, 400)

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/metadata.json
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/metadata.json
@@ -43,6 +43,57 @@
         "choices": null,
         "default": null,
         "depends_on": null
+      },
+      "audienceLabel": {
+        "label": "Audience Label",
+        "description": "Optionally categorize this audience with one of Meta's predefined labels. Sent to Facebook when the audience is created; does not apply retroactively to existing audiences.",
+        "type": "string",
+        "required": false,
+        "multiple": false,
+        "choices": [
+          {
+            "label": "Qualified Leads",
+            "value": "QUALIFIED_LEADS"
+          },
+          {
+            "label": "Disqualified Leads",
+            "value": "DISQUALIFIED_LEADS"
+          },
+          {
+            "label": "App Users",
+            "value": "APP_USERS"
+          },
+          {
+            "label": "Trial Users",
+            "value": "TRIAL_USERS"
+          },
+          {
+            "label": "Engaged Users",
+            "value": "ENGAGED_USERS"
+          },
+          {
+            "label": "High Value Customers",
+            "value": "HIGH_VALUE_CUSTOMERS"
+          },
+          {
+            "label": "Low Value Customers",
+            "value": "LOW_VALUE_CUSTOMERS"
+          },
+          {
+            "label": "At Risk",
+            "value": "AT_RISK"
+          },
+          {
+            "label": "Disengaged",
+            "value": "DISENGAGED"
+          },
+          {
+            "label": "General Customers",
+            "value": "GENERAL_CUSTOMERS"
+          }
+        ],
+        "default": null,
+        "depends_on": null
       }
     },
     "supportsAudienceFunctions": true

--- a/packages/destination-actions/src/destinations/facebook-custom-audiences/types.ts
+++ b/packages/destination-actions/src/destinations/facebook-custom-audiences/types.ts
@@ -5,6 +5,7 @@ export interface CreateAudienceRequest {
   subtype: 'CUSTOM'
   description?: string
   customer_file_source: 'BOTH_USER_AND_PARTNER_PROVIDED'
+  audience_labels?: string[]
 }
 
 export interface CreateAudienceResponse {
@@ -30,12 +31,12 @@ export interface FacebookResponseError {
         error_user_msg?: string
       }
     }
-  },
+  }
   message?: string
 }
 
-export interface NonFacebookError { 
-  message: string 
+export interface NonFacebookError {
+  message: string
   code: keyof typeof ErrorCodes | string
 }
 


### PR DESCRIPTION
## Summary
- Adds Meta's Audience Labels feature to Facebook Custom Audiences (Actions): a new optional "Audience Label" dropdown (10 predefined values) in the Engage audience settings, sent to Facebook as `audience_labels` on the create-audience call.
- Create-time only — updating the label on an already-created audience is out of scope. Our framework has no `updateAudience` hook (`createAudience`/`getAudience` are the only two lifecycle methods), so this is a deliberate scoping decision, not a limitation of this PR's implementation. Backend confirmed: editing this field on an existing audience via Settings Save is a Segment-side DB write only (a read-only `getAudience` existence check + `updateIntegrationInstance`), it never reaches Facebook.
- Field is optional (`required: false`) and additive — no change to existing request bodies when unset.

## Contract verification
- Confirmed via a real Graph API call (local `./bin/run serve`) that `audience_labels` is accepted and persisted on our pinned API version `v24.0` — no version bump required.
- `GENERAL_CUSTOMERS` confirmed as the correct enum value (Meta's public Marketing API guide lists a stale `CUSTOMERS` for the same slot; the partner integration doc is correct) — confirmed by creating a real test audience, reading it back, and deleting it afterward.
- All 10 enum values cross-checked verbatim against Meta's partner doc — exact match, no typos, no extras/omissions.

## STRATCONN-7008 / LAB-4006

## Test plan
- [x] Unit tests: label omitted (no regression to existing request body — asserted explicitly), label set (correctly included as `audience_labels: [value]`), invalid/out-of-enum value (rejected by schema validation against `choices`). Full destination suite: 99/99 passing.
- [x] `yarn typecheck`, `yarn validate`, lint — all clean.
- [x] Local real-API verification against Meta's Graph API (see Contract verification above).
- [x] Stage-tested end-to-end: field renders correctly in Engage UI with all 10 choices, metadata pushed correctly, destination connects successfully with a label selected, and — critically — the label is visibly confirmed in Meta's own Audience Manager dashboard ("Audience label: Qualified leads"). No regression to member sync event delivery observed in staging.
- Stage testing doc (screenshots + evidence): https://docs.google.com/document/d/1qYC8iiMEI0PGPh8Kup23aOo7Sh_8AB31v6DBKk05iKg/edit?usp=sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)