### PR TITLE
STRATCONN-6846 - [Vibe Conversions] - Fix required ip/ts, drop unsupported email field

### DIFF
--- a/packages/destination-actions/src/destinations/vibe-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/vibe-conversions/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,7 +6,6 @@ Object {
   "aid": "pixel_123",
   "ed": "{\\"purchase_id\\":\\"pid_123\\",\\"price_usd\\":50.5}",
   "eid": "msg_fixed_2",
-  "em": "joe@gmail.com",
   "gid": "GA.234.234234",
   "ip": "8.8.8.8",
   "ts": 1782950400000,

--- a/packages/destination-actions/src/destinations/vibe-conversions/metadata.json
+++ b/packages/destination-actions/src/destinations/vibe-conversions/metadata.json
@@ -110,7 +110,7 @@
           "label": "Timestamp",
           "description": "Timestamp of the event, in ISO 8601 format or UNIX milliseconds. Must be within the last 7 days. Sent to Vibe as UNIX milliseconds.",
           "type": "datetime",
-          "required": false,
+          "required": true,
           "multiple": false,
           "allowNull": false,
           "dynamic": false,
@@ -134,9 +134,9 @@
         },
         "ip": {
           "label": "IP Address",
-          "description": "IP address of the user who performed the action. Must be IPv4. Required if Email is not provided.",
+          "description": "IP address of the user who performed the action. Must be IPv4.",
           "type": "string",
-          "required": false,
+          "required": true,
           "multiple": false,
           "allowNull": false,
           "dynamic": false,
@@ -156,42 +156,6 @@
           "disabledInputMethods": null,
           "displayMode": null,
           "format": null,
-          "additionalProperties": false
-        },
-        "em": {
-          "label": "Email",
-          "description": "User email address. Required if IP Address is not provided.",
-          "type": "string",
-          "required": false,
-          "multiple": false,
-          "allowNull": false,
-          "dynamic": false,
-          "default": {
-            "@if": {
-              "exists": {
-                "@path": "$.context.traits.email"
-              },
-              "then": {
-                "@path": "$.context.traits.email"
-              },
-              "else": {
-                "@path": "$.properties.email"
-              }
-            }
-          },
-          "choices": null,
-          "placeholder": null,
-          "properties": null,
-          "category": null,
-          "depends_on": null,
-          "readOnly": null,
-          "hidden": null,
-          "minimum": null,
-          "maximum": null,
-          "defaultObjectUI": null,
-          "disabledInputMethods": null,
-          "displayMode": null,
-          "format": "email",
           "additionalProperties": false
         },
         "ed": {
@@ -369,19 +333,6 @@
         "ip": {
           "@path": "$.context.ip"
         },
-        "em": {
-          "@if": {
-            "exists": {
-              "@path": "$.context.traits.email"
-            },
-            "then": {
-              "@path": "$.context.traits.email"
-            },
-            "else": {
-              "@path": "$.properties.email"
-            }
-          }
-        },
         "ed": {
           "purchase_id": {
             "@path": "$.properties.purchase_id"
@@ -415,19 +366,6 @@
         "ip": {
           "@path": "$.context.ip"
         },
-        "em": {
-          "@if": {
-            "exists": {
-              "@path": "$.context.traits.email"
-            },
-            "then": {
-              "@path": "$.context.traits.email"
-            },
-            "else": {
-              "@path": "$.properties.email"
-            }
-          }
-        },
         "ed": {
           "purchase_id": {
             "@path": "$.properties.purchase_id"
@@ -460,19 +398,6 @@
         },
         "ip": {
           "@path": "$.context.ip"
-        },
-        "em": {
-          "@if": {
-            "exists": {
-              "@path": "$.context.traits.email"
-            },
-            "then": {
-              "@path": "$.context.traits.email"
-            },
-            "else": {
-              "@path": "$.properties.email"
-            }
-          }
         },
         "ed": {
           "purchase_id": {

--- a/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/__tests__/index.test.ts
@@ -125,27 +125,7 @@ describe('VibeConversions.trackConversion', () => {
     ).rejects.toThrowError('`ip` (IP Address) must be a valid IPv4 address.')
   })
 
-  it('uses email when IP is not present', async () => {
-    nock(BASE_URL).post('/s2s-conversion/events/segment').reply(200, {})
-
-    const event = createTestEvent({
-      timestamp: RECENT_ISO,
-      context: { traits: { email: 'joe@gmail.com' } }
-    })
-
-    const responses = await testDestination.testAction('trackConversion', {
-      event,
-      settings,
-      useDefaultMappings: true,
-      mapping: { a: 'signup', ip: undefined }
-    })
-
-    const body = JSON.parse(responses[0].options.body as string)
-    expect(body.em).toBe('joe@gmail.com')
-    expect(body.ip).toBeUndefined()
-  })
-
-  it('throws a PayloadValidationError when both IP and email are missing', async () => {
+  it('throws a PayloadValidationError when IP is missing', async () => {
     const event = createTestEvent({
       timestamp: RECENT_ISO,
       context: {}
@@ -156,9 +136,22 @@ describe('VibeConversions.trackConversion', () => {
         event,
         settings,
         useDefaultMappings: true,
-        mapping: { a: 'lead', ip: undefined, em: undefined }
+        mapping: { a: 'lead', ip: undefined }
       })
-    ).rejects.toThrowError('Either `ip` (IP Address) or `em` (Email) is required.')
+    ).rejects.toThrowError()
+  })
+
+  it('throws a PayloadValidationError when timestamp is missing', async () => {
+    const event = createTestEvent({ context: {} })
+
+    await expect(
+      testDestination.testAction('trackConversion', {
+        event,
+        settings,
+        useDefaultMappings: true,
+        mapping: { a: 'purchase', ts: undefined }
+      })
+    ).rejects.toThrowError()
   })
 
   it('throws a PayloadValidationError when the timestamp is older than 7 days', async () => {

--- a/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/generated-types.ts
@@ -12,15 +12,11 @@ export interface Payload {
   /**
    * Timestamp of the event, in ISO 8601 format or UNIX milliseconds. Must be within the last 7 days. Sent to Vibe as UNIX milliseconds.
    */
-  ts?: string | number
+  ts: string | number
   /**
-   * IP address of the user who performed the action. Must be IPv4. Required if Email is not provided.
+   * IP address of the user who performed the action. Must be IPv4.
    */
-  ip?: string
-  /**
-   * User email address. Required if IP Address is not provided.
-   */
-  em?: string
+  ip: string
   /**
    * Additional event data to send with the event.
    */

--- a/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/index.ts
+++ b/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/index.ts
@@ -29,29 +29,15 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'Timestamp of the event, in ISO 8601 format or UNIX milliseconds. Must be within the last 7 days. Sent to Vibe as UNIX milliseconds.',
       type: 'datetime',
-      required: false,
+      required: true,
       default: { '@path': '$.timestamp' }
     },
     ip: {
       label: 'IP Address',
-      description: 'IP address of the user who performed the action. Must be IPv4. Required if Email is not provided.',
+      description: 'IP address of the user who performed the action. Must be IPv4.',
       type: 'string',
-      required: false,
+      required: true,
       default: { '@path': '$.context.ip' }
-    },
-    em: {
-      label: 'Email',
-      description: 'User email address. Required if IP Address is not provided.',
-      type: 'string',
-      format: 'email',
-      required: false,
-      default: {
-        '@if': {
-          exists: { '@path': '$.context.traits.email' },
-          then: { '@path': '$.context.traits.email' },
-          else: { '@path': '$.properties.email' }
-        }
-      }
     },
     ed: {
       label: 'Event Data',

--- a/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/types.ts
+++ b/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/types.ts
@@ -11,11 +11,9 @@ export interface ConversionEventRequest {
   // Vibe pixel ID associated with the advertiser (from settings).
   aid: string
   // UNIX timestamp of the event in milliseconds.
-  ts?: number
-  // IP address of the user (IPv4). Required if `em` is absent.
-  ip?: string
-  // User email address. Required if `ip` is absent.
-  em?: string
+  ts: number
+  // IP address of the user (IPv4).
+  ip: string
   // Event data serialized to a JSON string.
   ed?: string
   // Google Analytics ID for cross-platform attribution.

--- a/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/vibe-conversions/trackConversion/utils.ts
@@ -29,10 +29,7 @@ function serializeEventData(ed: Payload['ed']): string | undefined {
 }
 
 // Convert an ISO8601 / epoch timestamp to UNIX milliseconds.
-function toUnixMs(ts: Payload['ts']): number | undefined {
-  if (ts === undefined || ts === null || ts === '') {
-    return undefined
-  }
+function toUnixMs(ts: Payload['ts']): number {
   const ms = typeof ts === 'number' ? ts : new Date(ts).getTime()
   if (Number.isNaN(ms)) {
     throw new PayloadValidationError('`ts` (timestamp) is not a valid date.')
@@ -42,22 +39,18 @@ function toUnixMs(ts: Payload['ts']): number | undefined {
 
 // Build a single typed request body from a payload, applying validation and transforms.
 export function buildConversionEvent(payload: Payload, settings: Settings): ConversionEventRequest {
-  const { a, eid, ts, ip, em, ed, gid, ua, url } = payload
+  const { a, eid, ts, ip, ed, gid, ua, url } = payload
 
   if (!isEventType(a)) {
     throw new PayloadValidationError(`\`a\` (Event Type) must be one of: ${EVENT_TYPES.join(', ')}.`)
   }
 
-  if (!ip && !em) {
-    throw new PayloadValidationError('Either `ip` (IP Address) or `em` (Email) is required.')
-  }
-
-  if (ip && isIP(ip) !== 4) {
+  if (isIP(ip) !== 4) {
     throw new PayloadValidationError('`ip` (IP Address) must be a valid IPv4 address.')
   }
 
   const tsMs = toUnixMs(ts)
-  if (tsMs !== undefined && Date.now() - tsMs > MAX_EVENT_AGE_MS) {
+  if (Date.now() - tsMs > MAX_EVENT_AGE_MS) {
     throw new PayloadValidationError('`ts` (timestamp) must be within the last 7 days.')
   }
 
@@ -66,8 +59,7 @@ export function buildConversionEvent(payload: Payload, settings: Settings): Conv
     eid,
     aid: settings.aid,
     ts: tsMs,
-    ip: ip || undefined,
-    em: em || undefined,
+    ip,
     ed: serializeEventData(ed),
     gid: gid || undefined,
     ua: ua || undefined,


### PR DESCRIPTION
Fixes a partner-reported 400 on `vibe-conversions` trackConversion: server-side events with no `context.ip` fell back to sending `em` (email), but Vibe's API has no email field and requires `ip`. Verified against [Vibe's public API docs](https://developers.vibe.co/reference/trackconversionevent).

- `ip` and `ts` are now required fields
- `em` field removed entirely (was never actually supported by Vibe's live API, only present in the partner's PRD)
- Tests and metadata regenerated accordingly

STRATCONN-6846

🤖 Generated with [Claude Code](https://claude.com/claude-code)