### PR TITLE
STRATCONN-6987 (pt.2): cache STS assume-role credentials in actions-s3 to cut STS throttling

### DIFF
--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -1,5 +1,10 @@
-import { isAWSError } from '../syncToS3/client'
+import { Client, isAWSError, mapAWSError } from '../syncToS3/client'
 import { _Error as AWSError } from '@aws-sdk/client-s3'
+import { APIError, IntegrationError, RetryableError } from '@segment/actions-core'
+import { Settings } from '../generated-types'
+
+// Controllable STS send mock so tests can simulate assume-role failures.
+const mockStsSend = jest.fn()
 
 // Mock AWS SDK before any imports to avoid initialization issues
 jest.mock('@aws-sdk/client-s3', () => ({
@@ -11,7 +16,9 @@ jest.mock('@aws-sdk/client-s3', () => ({
 }))
 
 jest.mock('@aws-sdk/client-sts', () => ({
-  STSClient: jest.fn(),
+  STSClient: jest.fn().mockImplementation(() => ({
+    send: mockStsSend
+  })),
   AssumeRoleCommand: jest.fn()
 }))
 
@@ -58,5 +65,80 @@ describe('isAWSError', () => {
   it('should return false for an object without Message property', () => {
     const error = { Code: 'SomeError' }
     expect(isAWSError(error)).toBe(false)
+  })
+})
+
+describe('Client STS assume-role error handling', () => {
+  const settings: Settings = {
+    iam_role_arn: 'arn:aws:iam::123456789012:role/test',
+    s3_aws_bucket_name: 'test-bucket',
+    s3_aws_region: 'us-east-1',
+    iam_external_id: 'external-id'
+  }
+
+  const newClient = () => new Client('us-east-1', settings.iam_role_arn, settings.iam_external_id)
+  const upload = (client: Client) => client.uploadS3(settings, 'content', 'file', '', 'csv')
+
+  beforeEach(() => {
+    mockStsSend.mockReset()
+  })
+
+  // Regression: STS failures used to escape uploadS3's try/catch (assumeRole ran before it), so
+  // they reached the platform unwrapped (no status/code), got classified type:internal and were
+  // force-retried. They must now be mapped to a Segment error class with a status.
+  it('wraps a "could not load credentials" STS failure in a classified RetryableError', async () => {
+    mockStsSend.mockRejectedValue(new Error('Could not load credentials from any providers'))
+
+    const err = await upload(newClient()).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(RetryableError)
+    expect((err as Error).message).toContain('Could not load credentials from any providers')
+    expect((err as RetryableError).status).toBeDefined()
+  })
+
+  // Regression: permanent authorization failures from STS must NOT be force-retried.
+  it('maps a permanent STS access-denied failure to a non-retryable 403 error', async () => {
+    const stsError = Object.assign(new Error('User is not authorized to perform sts:AssumeRole'), {
+      name: 'AccessDenied',
+      $fault: 'client',
+      $metadata: { httpStatusCode: 403 }
+    })
+    mockStsSend.mockRejectedValue(stsError)
+
+    const err = await upload(newClient()).catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(APIError)
+    expect(err).not.toBeInstanceOf(RetryableError)
+    expect((err as APIError).status).toBe(403)
+  })
+})
+
+describe('mapAWSError', () => {
+  it('classifies access-denied AWS errors as non-retryable 403', () => {
+    const err = mapAWSError({ Code: 'AccessDenied', Message: 'nope' }, 'AWS PUT failed')
+    expect(err).toBeInstanceOf(APIError)
+    expect((err as APIError).status).toBe(403)
+  })
+
+  it('classifies throttling as 429', () => {
+    const err = mapAWSError({ name: 'ThrottlingException', message: 'slow down' }, 'Failed to assume AWS role')
+    expect(err).toBeInstanceOf(APIError)
+    expect((err as APIError).status).toBe(429)
+  })
+
+  it('classifies a client fault (4xx) as a non-retryable IntegrationError', () => {
+    const err = mapAWSError(
+      { name: 'ValidationError', message: 'bad', $fault: 'client', $metadata: { httpStatusCode: 400 } },
+      'Failed to assume AWS role'
+    )
+    expect(err).toBeInstanceOf(IntegrationError)
+    expect(err).not.toBeInstanceOf(RetryableError)
+    expect((err as IntegrationError).status).toBe(400)
+  })
+
+  it('treats unclassified / server-side failures as retryable', () => {
+    const err = mapAWSError(new Error('Could not load credentials from any providers'), 'Failed to assume AWS role')
+    expect(err).toBeInstanceOf(RetryableError)
+    expect(err.message).toContain('Could not load credentials from any providers')
   })
 })

--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -202,15 +202,17 @@ describe('STS credential caching', () => {
     expect(mockStsSend).toHaveBeenCalledTimes(3)
   })
 
-  it('does not cache when STS omits an expiration', async () => {
+  it('fails fast when STS returns credentials without an expiration', async () => {
+    // STS always returns Expiration in practice; a response missing it is malformed, so we treat
+    // it as an auth failure rather than caching a credential of unknown lifetime.
     mockStsSend.mockResolvedValue({
       Credentials: { AccessKeyId: 'AKIA', SecretAccessKey: 'secret', SessionToken: 'token' }
     })
 
-    await upload(newClient())
-    await upload(newClient())
+    const err = await upload(newClient()).catch((e: unknown) => e)
 
-    expect(mockStsSend).toHaveBeenCalledTimes(4)
+    expect(err).toBeInstanceOf(IntegrationError)
+    expect((err as IntegrationError).status).toBe(403)
   })
 
   describe('DataDog metrics', () => {
@@ -252,19 +254,6 @@ describe('STS credential caching', () => {
     it('does not throw when no statsContext is provided', async () => {
       mockStsSend.mockResolvedValue(stsOk())
       await expect(upload(newClient())).resolves.toBeDefined()
-    })
-
-    it('emits sts_credential_no_expiration (and never sets) when STS omits an expiration', async () => {
-      mockStsSend.mockResolvedValue({
-        Credentials: { AccessKeyId: 'AKIA', SecretAccessKey: 'secret', SessionToken: 'token' }
-      })
-      const { statsContext, incr } = makeStatsContext()
-
-      await upload(clientWithStats(statsContext))
-
-      const names = incr.mock.calls.map((c: unknown[]) => c[0])
-      expect(names.filter((n: string) => n === 'sts_credential_no_expiration')).toHaveLength(2) // both hops
-      expect(names).not.toContain('sts_credential_cache_set')
     })
   })
 })

--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { Client, clearCredentialsCache, isAWSError, mapAWSError } from '../syncToS3/client'
 import { _Error as AWSError } from '@aws-sdk/client-s3'
 import { APIError, IntegrationError, RetryableError } from '@segment/actions-core'
+import type { StatsContext } from '@segment/actions-core'
 import { Settings } from '../generated-types'
 
 // Controllable STS send mock so tests can simulate assume-role failures.
@@ -210,5 +211,47 @@ describe('STS credential caching', () => {
     await upload(newClient())
 
     expect(mockStsSend).toHaveBeenCalledTimes(4)
+  })
+
+  describe('DataDog metrics', () => {
+    const stsOk = () => ({
+      Credentials: {
+        AccessKeyId: 'AKIAEXAMPLE',
+        SecretAccessKey: 'secret',
+        SessionToken: 'token',
+        Expiration: new Date(Date.now() + 60 * 60 * 1000)
+      }
+    })
+
+    const makeStatsContext = () => {
+      const incr = jest.fn()
+      const statsContext = { statsClient: { incr }, tags: ['dest:s3'] } as unknown as StatsContext
+      return { statsContext, incr }
+    }
+    const clientWithStats = (statsContext: StatsContext) =>
+      new Client(settings.s3_aws_region, settings.iam_role_arn, settings.iam_external_id, statsContext)
+
+    it('emits miss + set on first assume-role, hit on the second, tagged per role_type', async () => {
+      mockStsSend.mockResolvedValue(stsOk())
+      const { statsContext, incr } = makeStatsContext()
+
+      // First upload: both hops miss then set. Second upload: both hops hit.
+      await upload(clientWithStats(statsContext))
+      await upload(clientWithStats(statsContext))
+
+      const names = incr.mock.calls.map((c: unknown[]) => c[0])
+      expect(names.filter((n: string) => n === 'sts_credential_cache_miss')).toHaveLength(2)
+      expect(names.filter((n: string) => n === 'sts_credential_cache_set')).toHaveLength(2)
+      expect(names.filter((n: string) => n === 'sts_credential_cache_hit')).toHaveLength(2)
+
+      // Metrics carry the caller's tags plus the role_type of each hop.
+      expect(incr).toHaveBeenCalledWith('sts_credential_cache_miss', 1, ['dest:s3', 'role_type:intermediary'])
+      expect(incr).toHaveBeenCalledWith('sts_credential_cache_hit', 1, ['dest:s3', 'role_type:customer'])
+    })
+
+    it('does not throw when no statsContext is provided', async () => {
+      mockStsSend.mockResolvedValue(stsOk())
+      await expect(upload(newClient())).resolves.toBeDefined()
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { Client, isAWSError, mapAWSError } from '../syncToS3/client'
+import { Client, clearCredentialsCache, isAWSError, mapAWSError } from '../syncToS3/client'
 import { _Error as AWSError } from '@aws-sdk/client-s3'
 import { APIError, IntegrationError, RetryableError } from '@segment/actions-core'
 import { Settings } from '../generated-types'
@@ -140,5 +140,75 @@ describe('mapAWSError', () => {
     const err = mapAWSError(new Error('Could not load credentials from any providers'), 'Failed to assume AWS role')
     expect(err).toBeInstanceOf(RetryableError)
     expect(err.message).toContain('Could not load credentials from any providers')
+  })
+})
+
+describe('STS credential caching', () => {
+  const settings: Settings = {
+    iam_role_arn: 'arn:aws:iam::123456789012:role/test',
+    s3_aws_bucket_name: 'test-bucket',
+    s3_aws_region: 'us-east-1',
+    iam_external_id: 'external-id'
+  }
+
+  // A minimal successful AssumeRole response whose credentials expire `expiresInMs` from now.
+  const stsResponse = (expiresInMs: number) => ({
+    Credentials: {
+      AccessKeyId: 'AKIAEXAMPLE',
+      SecretAccessKey: 'secret',
+      SessionToken: 'token',
+      Expiration: new Date(Date.now() + expiresInMs)
+    }
+  })
+
+  const newClient = (roleArn = settings.iam_role_arn) =>
+    new Client(settings.s3_aws_region, roleArn, settings.iam_external_id)
+  const upload = (client: Client) => client.uploadS3(settings, 'content', 'file', '', 'csv')
+
+  beforeEach(() => {
+    mockStsSend.mockReset()
+    clearCredentialsCache()
+  })
+
+  it('reuses cached credentials across uploads instead of re-calling STS for every file', async () => {
+    mockStsSend.mockResolvedValue(stsResponse(60 * 60 * 1000))
+
+    await upload(newClient())
+    await upload(newClient())
+
+    // First upload assumes both roles (intermediary + customer) = 2 STS calls.
+    // Second upload finds both cached = 0 STS calls.
+    expect(mockStsSend).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes credentials once they fall within the expiry safety buffer', async () => {
+    // Expires in 1 minute, inside the 5-minute refresh buffer -> never safe to cache.
+    mockStsSend.mockResolvedValue(stsResponse(60 * 1000))
+
+    await upload(newClient())
+    await upload(newClient())
+
+    expect(mockStsSend).toHaveBeenCalledTimes(4)
+  })
+
+  it('caches per role identity while sharing the intermediary role', async () => {
+    mockStsSend.mockResolvedValue(stsResponse(60 * 60 * 1000))
+
+    await upload(newClient('arn:aws:iam::123456789012:role/test'))
+    await upload(newClient('arn:aws:iam::999999999999:role/other'))
+
+    // Intermediary role assumed once (shared), plus one customer assume-role per distinct ARN = 3.
+    expect(mockStsSend).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not cache when STS omits an expiration', async () => {
+    mockStsSend.mockResolvedValue({
+      Credentials: { AccessKeyId: 'AKIA', SecretAccessKey: 'secret', SessionToken: 'token' }
+    })
+
+    await upload(newClient())
+    await upload(newClient())
+
+    expect(mockStsSend).toHaveBeenCalledTimes(4)
   })
 })

--- a/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/__tests__/client.test.ts
@@ -253,5 +253,18 @@ describe('STS credential caching', () => {
       mockStsSend.mockResolvedValue(stsOk())
       await expect(upload(newClient())).resolves.toBeDefined()
     })
+
+    it('emits sts_credential_no_expiration (and never sets) when STS omits an expiration', async () => {
+      mockStsSend.mockResolvedValue({
+        Credentials: { AccessKeyId: 'AKIA', SecretAccessKey: 'secret', SessionToken: 'token' }
+      })
+      const { statsContext, incr } = makeStatsContext()
+
+      await upload(clientWithStats(statsContext))
+
+      const names = incr.mock.calls.map((c: unknown[]) => c[0])
+      expect(names.filter((n: string) => n === 'sts_credential_no_expiration')).toHaveLength(2) // both hops
+      expect(names).not.toContain('sts_credential_cache_set')
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -34,7 +34,15 @@ export class Client {
       RoleSessionName: this.roleSessionName,
       ExternalId: externalId
     })
-    const result = await stsClient.send(command)
+    let result
+    try {
+      result = await stsClient.send(command)
+    } catch (err) {
+      // STS failures used to escape uploadS3's try/catch entirely, so they reached the platform
+      // with no status/code, were classified type:internal and force-retried (even permanent auth
+      // failures). Map them to Segment error classes here so classification is correct.
+      throw mapAWSError(err, 'Failed to assume AWS role')
+    }
     if (
       !result.Credentials ||
       !result.Credentials.AccessKeyId ||
@@ -107,22 +115,49 @@ export class Client {
         throw new RequestTimeoutError()
       }
 
-      if (isAWSError(err)) {
-        // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Interface/_Error/
-        if (err.Code && accessDeniedCodes.has(err.Code)) {
-          throw new APIError(err.Message || err.Code, 403)
-        } else if (err.Code === 'NoSuchBucket') {
-          throw new APIError(err.Message || err.Code, 404)
-        } else if (err.Code === 'SlowDown') {
-          throw new APIError(err.Message || err.Code, 429)
-        } else {
-          throw new RetryableError(err.Message || err.Code || 'Unknown AWS Put error: ' + err)
-        }
-      } else {
-        throw new APIError('Unknown error during AWS PUT: ' + err, 500)
-      }
+      throw mapAWSError(err, 'AWS PUT failed')
     }
   }
+}
+
+/**
+ * Maps an AWS SDK error (S3 `_Error` shape or an STS/service exception) to the appropriate
+ * Segment error class. Permanent, client-side failures (access denied, invalid config, expired
+ * credentials, missing bucket) are surfaced as non-retryable errors; only transient/server-side
+ * or throttling failures are marked retryable. This prevents the platform from force-retrying
+ * errors that will never succeed.
+ */
+export function mapAWSError(err: unknown, context: string): Error {
+  const e = err as {
+    Code?: string
+    Message?: string
+    name?: string
+    message?: string
+    $fault?: 'client' | 'server'
+    $metadata?: { httpStatusCode?: number }
+  }
+  // S3 `_Error` uses Code/Message; STS/service exceptions use name/message.
+  const code = e?.Code ?? e?.name
+  const message = e?.Message ?? e?.message ?? code ?? String(err)
+  const httpStatus = e?.$metadata?.httpStatusCode
+  const detail = `${context}: ${message}`
+
+  if (code && accessDeniedCodes.has(code)) {
+    // Permanent authentication/authorization failure. Not retryable.
+    return new APIError(detail, 403)
+  }
+  if (code === 'NoSuchBucket') {
+    return new APIError(detail, 404)
+  }
+  if (code && throttlingCodes.has(code)) {
+    return new APIError(detail, 429)
+  }
+  // A client fault (4xx that is not throttling) is permanent - do not retry.
+  if (e?.$fault === 'client' || (typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500)) {
+    return new IntegrationError(detail, ErrorCodes.INVALID_AUTHENTICATION, httpStatus ?? 400)
+  }
+  // Transient / server-side / unclassified failures are safe to retry.
+  return new RetryableError(detail)
 }
 
 const accessDeniedCodes = new Set([
@@ -134,8 +169,14 @@ const accessDeniedCodes = new Set([
   'NotSignedUp',
   'AmbiguousGrantByEmailAddress',
   'AuthorizationHeaderMalformed',
-  'RequestExpired'
+  'RequestExpired',
+  // STS assume-role authorization/credential failures
+  'ExpiredToken',
+  'ExpiredTokenException',
+  'AccessDeniedException'
 ])
+
+const throttlingCodes = new Set(['SlowDown', 'Throttling', 'ThrottlingException', 'TooManyRequestsException'])
 
 // isAWSError validates that the error is an generic AWS error
 export function isAWSError(err: unknown): err is AWSError {

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -106,6 +106,11 @@ export class Client {
     if (expiration instanceof Date) {
       credentialsCache.set(cacheKey, { credentials: creds, expiration: expiration.getTime() })
       statsClient?.incr('sts_credential_cache_set', 1, tags)
+    } else {
+      // STS should always return an Expiration; if it ever doesn't we can't safely cache (unknown
+      // lifetime), so we fall back to fetching every time. Emit a metric so this is observable in
+      // DataDog rather than surfacing only as a mysteriously high miss rate.
+      statsClient?.incr('sts_credential_no_expiration', 1, tags)
     }
 
     return creds

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -4,7 +4,8 @@ import { S3Client, PutObjectCommandInput, PutObjectCommand, _Error as AWSError }
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import * as process from 'process'
 import { ErrorCodes, IntegrationError, RetryableError, APIError, RequestTimeoutError } from '@segment/actions-core'
-import { Credentials } from './types'
+import { CachedCredentials, Credentials } from './types'
+import { CREDENTIALS_EXPIRY_BUFFER_MS } from './constants'
 
 /**
  * Module-level STS credential cache, shared across every Client instance.
@@ -18,16 +19,7 @@ import { Credentials } from './types'
  *
  * Keyed by region + role ARN + external id, the inputs that determine the returned credentials.
  */
-interface CachedCredentials {
-  credentials: Credentials
-  expiration: number // epoch millis, from STS Credentials.Expiration
-}
-
 const credentialsCache = new Map<string, CachedCredentials>()
-
-// Refresh this long before the STS-reported expiration so we never hand out credentials that
-// would expire mid-upload.
-const CREDENTIALS_EXPIRY_BUFFER_MS = 5 * 60 * 1000
 
 // Exposed for tests to reset the shared cache between cases.
 export function clearCredentialsCache(): void {

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -4,6 +4,7 @@ import { S3Client, PutObjectCommandInput, PutObjectCommand, _Error as AWSError }
 import { v4 as uuidv4 } from '@lukeed/uuid'
 import * as process from 'process'
 import { ErrorCodes, IntegrationError, RetryableError, APIError, RequestTimeoutError } from '@segment/actions-core'
+import type { StatsContext } from '@segment/actions-core'
 import { CachedCredentials, Credentials } from './types'
 import { CREDENTIALS_EXPIRY_BUFFER_MS } from './constants'
 
@@ -31,27 +32,41 @@ export class Client {
   roleSessionName: string
   region: string
   externalId: string
+  statsContext?: StatsContext
 
-  constructor(region: string, roleArn: string, externalId: string) {
+  constructor(region: string, roleArn: string, externalId: string, statsContext?: StatsContext) {
     this.region = region
     this.roleSessionName = uuidv4()
     this.roleArn = roleArn
     this.externalId = externalId
+    this.statsContext = statsContext
   }
 
   async assumeRole(): Promise<Credentials> {
     const intermediaryARN = process.env.AMAZON_S3_ACTIONS_ROLE_ADDRESS as string
     const intermediaryExternalId = process.env.AMAZON_S3_ACTIONS_EXTERNAL_ID as string
-    const intermediaryCreds = await this.getSTSCredentials(intermediaryARN, intermediaryExternalId)
-    return this.getSTSCredentials(this.roleArn, this.externalId, intermediaryCreds)
+    const intermediaryCreds = await this.getSTSCredentials(intermediaryARN, intermediaryExternalId, 'intermediary')
+    return this.getSTSCredentials(this.roleArn, this.externalId, 'customer', intermediaryCreds)
   }
 
-  private async getSTSCredentials(roleId: string, externalId: string, credentials?: Credentials): Promise<Credentials> {
+  private async getSTSCredentials(
+    roleId: string,
+    externalId: string,
+    roleType: 'intermediary' | 'customer',
+    credentials?: Credentials
+  ): Promise<Credentials> {
+    // Tag every metric with the hop (intermediary vs customer role) so DataDog can break the
+    // cache hit/miss/set counts down per hop of the two-hop assume-role chain.
+    const tags = [...(this.statsContext?.tags ?? []), `role_type:${roleType}`]
+    const statsClient = this.statsContext?.statsClient
+
     const cacheKey = `${this.region}|${roleId}|${externalId ?? ''}`
     const cached = credentialsCache.get(cacheKey)
     if (cached && cached.expiration - CREDENTIALS_EXPIRY_BUFFER_MS > Date.now()) {
+      statsClient?.incr('sts_credential_cache_hit', 1, tags)
       return cached.credentials
     }
+    statsClient?.incr('sts_credential_cache_miss', 1, tags)
 
     const options = { region: this.region, credentials }
     const stsClient = new STSClient(options)
@@ -90,6 +105,7 @@ export class Client {
     const expiration = result.Credentials.Expiration
     if (expiration instanceof Date) {
       credentialsCache.set(cacheKey, { credentials: creds, expiration: expiration.getTime() })
+      statsClient?.incr('sts_credential_cache_set', 1, tags)
     }
 
     return creds

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -84,11 +84,15 @@ export class Client {
       // failures). Map them to Segment error classes here so classification is correct.
       throw mapAWSError(err, 'Failed to assume AWS role')
     }
+    // STS always returns all four fields on a successful AssumeRole (the SDK types them optional,
+    // but the API contract guarantees them; verified in DataDog that Expiration is always present).
+    // Treat a missing field as a malformed response and fail fast rather than cache blindly.
     if (
       !result.Credentials ||
       !result.Credentials.AccessKeyId ||
       !result.Credentials.SecretAccessKey ||
-      !result.Credentials.SessionToken
+      !result.Credentials.SessionToken ||
+      !result.Credentials.Expiration
     ) {
       // TODO: Add more specific error handling
       throw new IntegrationError('Failed to assume role', ErrorCodes.INVALID_AUTHENTICATION, 403)
@@ -99,19 +103,9 @@ export class Client {
       sessionToken: result.Credentials.SessionToken
     }
 
-    // Cache the freshly minted credentials until shortly before STS says they expire. Only cache
-    // when STS reports an expiration; without it we can't know the safe lifetime, so we re-fetch
-    // every time rather than risk handing out credentials of unknown validity.
-    const expiration = result.Credentials.Expiration
-    if (expiration instanceof Date) {
-      credentialsCache.set(cacheKey, { credentials: creds, expiration: expiration.getTime() })
-      statsClient?.incr('sts_credential_cache_set', 1, tags)
-    } else {
-      // STS should always return an Expiration; if it ever doesn't we can't safely cache (unknown
-      // lifetime), so we fall back to fetching every time. Emit a metric so this is observable in
-      // DataDog rather than surfacing only as a mysteriously high miss rate.
-      statsClient?.incr('sts_credential_no_expiration', 1, tags)
-    }
+    // Cache the freshly minted credentials until shortly before STS says they expire.
+    credentialsCache.set(cacheKey, { credentials: creds, expiration: result.Credentials.Expiration.getTime() })
+    statsClient?.incr('sts_credential_cache_set', 1, tags)
 
     return creds
   }

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -6,6 +6,34 @@ import * as process from 'process'
 import { ErrorCodes, IntegrationError, RetryableError, APIError, RequestTimeoutError } from '@segment/actions-core'
 import { Credentials } from './types'
 
+/**
+ * Module-level STS credential cache, shared across every Client instance.
+ *
+ * A new Client is constructed on every upload (see syncToS3/functions.ts), so a per-instance
+ * cache would never be reused. Under high-volume audience syncs the two-hop assume-role chain
+ * (intermediary role -> customer role) re-ran STS on every file, which is the most likely source
+ * of the `rate exceeded` / STS throttling errors seen during load testing. Caching the minted
+ * credentials until just before their STS-reported expiry keeps STS call volume flat as the
+ * number of files grows.
+ *
+ * Keyed by region + role ARN + external id, the inputs that determine the returned credentials.
+ */
+interface CachedCredentials {
+  credentials: Credentials
+  expiration: number // epoch millis, from STS Credentials.Expiration
+}
+
+const credentialsCache = new Map<string, CachedCredentials>()
+
+// Refresh this long before the STS-reported expiration so we never hand out credentials that
+// would expire mid-upload.
+const CREDENTIALS_EXPIRY_BUFFER_MS = 5 * 60 * 1000
+
+// Exposed for tests to reset the shared cache between cases.
+export function clearCredentialsCache(): void {
+  credentialsCache.clear()
+}
+
 export class Client {
   roleArn: string
   roleSessionName: string
@@ -26,7 +54,13 @@ export class Client {
     return this.getSTSCredentials(this.roleArn, this.externalId, intermediaryCreds)
   }
 
-  private async getSTSCredentials(roleId: string, externalId: string, credentials?: Credentials) {
+  private async getSTSCredentials(roleId: string, externalId: string, credentials?: Credentials): Promise<Credentials> {
+    const cacheKey = `${this.region}|${roleId}|${externalId ?? ''}`
+    const cached = credentialsCache.get(cacheKey)
+    if (cached && cached.expiration - CREDENTIALS_EXPIRY_BUFFER_MS > Date.now()) {
+      return cached.credentials
+    }
+
     const options = { region: this.region, credentials }
     const stsClient = new STSClient(options)
     const command = new AssumeRoleCommand({
@@ -52,11 +86,21 @@ export class Client {
       // TODO: Add more specific error handling
       throw new IntegrationError('Failed to assume role', ErrorCodes.INVALID_AUTHENTICATION, 403)
     }
-    return {
+    const creds: Credentials = {
       accessKeyId: result.Credentials.AccessKeyId,
       secretAccessKey: result.Credentials.SecretAccessKey,
       sessionToken: result.Credentials.SessionToken
     }
+
+    // Cache the freshly minted credentials until shortly before STS says they expire. Only cache
+    // when STS reports an expiration; without it we can't know the safe lifetime, so we re-fetch
+    // every time rather than risk handing out credentials of unknown validity.
+    const expiration = result.Credentials.Expiration
+    if (expiration instanceof Date) {
+      credentialsCache.set(cacheKey, { credentials: creds, expiration: expiration.getTime() })
+    }
+
+    return creds
   }
 
   async uploadS3(

--- a/packages/destination-actions/src/destinations/s3/syncToS3/constants.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/constants.ts
@@ -3,3 +3,7 @@ import { HashAlgorithm, Normalization } from './types'
 export const SUPPORTED_HASH_ALGORITHMS: HashAlgorithm[] = ['sha256']
 
 export const SUPPORTED_NORMALIZATIONS: Normalization[] = ['none', 'lowercase', 'trim', 'lowercase_trim']
+
+// Refresh STS credentials this long before their reported expiration so we never hand out
+// credentials that would expire mid-upload.
+export const CREDENTIALS_EXPIRY_BUFFER_MS = 5 * 60 * 1000

--- a/packages/destination-actions/src/destinations/s3/syncToS3/functions.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/functions.ts
@@ -1,5 +1,5 @@
 import { PayloadValidationError } from '@segment/actions-core'
-import type { Features } from '@segment/actions-core'
+import type { Features, StatsContext } from '@segment/actions-core'
 import { processHashing } from '../../../lib/hashing-utils'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
@@ -13,6 +13,7 @@ export async function send(
   settings: Settings,
   rawMapping: RawMapping,
   features?: Features,
+  statsContext?: StatsContext,
   signal?: AbortSignal
 ) {
   const delimiter = payloads[0]?.delimiter
@@ -48,7 +49,7 @@ export async function send(
 
   const fileContent = generateFile(payloads, headers, delimiter, actionColName, batchColName, columnTransforms)
 
-  const s3Client = new Client(settings.s3_aws_region, settings.iam_role_arn, settings.iam_external_id)
+  const s3Client = new Client(settings.s3_aws_region, settings.iam_role_arn, settings.iam_external_id, statsContext)
 
   await s3Client.uploadS3(
     settings,

--- a/packages/destination-actions/src/destinations/s3/syncToS3/index.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/index.ts
@@ -11,14 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "identify" or type = "track"',
   fields: commonFields,
   perform: async (_, data) => {
-    const { payload, settings, signal, features } = data
+    const { payload, settings, signal, features, statsContext } = data
     const rawMapping: RawMapping = (data as unknown as Data).rawMapping
-    return send([payload], settings, rawMapping, features, signal)
+    return send([payload], settings, rawMapping, features, statsContext, signal)
   },
   performBatch: async (_, data) => {
-    const { payload, settings, signal, features } = data
+    const { payload, settings, signal, features, statsContext } = data
     const rawMapping: RawMapping = (data as unknown as Data).rawMapping
-    return send(payload, settings, rawMapping, features, signal)
+    return send(payload, settings, rawMapping, features, statsContext, signal)
   }
 }
 

--- a/packages/destination-actions/src/destinations/s3/syncToS3/types.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/types.ts
@@ -15,6 +15,12 @@ export interface Credentials {
   sessionToken: string
 }
 
+// A cache entry for STS-assumed credentials, held until shortly before their STS-reported expiry.
+export interface CachedCredentials {
+  credentials: Credentials
+  expiration: number // epoch millis, from STS Credentials.Expiration
+}
+
 export interface Data {
   rawMapping: RawMapping
 }


### PR DESCRIPTION
## STRATCONN-6987 (pt.2) — s3 `syncToS3`: cache STS assume-role credentials

> **Stacked on #3993.** Base branch is `t2f/STRATCONN-6987`, so this PR's diff shows only the caching change. Review/merge #3993 first, then this. Once #3993 merges to `main`, GitHub will retarget this PR to `main` automatically.

### 🎫 Ticket
Completes the third scope item of **STRATCONN-6987 — "STS wrap + error classification + credential caching"**. PR #3993 delivered the wrap + error-classification; this PR adds the **credential caching**.

### 🔍 Why
A new `Client` is constructed on **every upload** (`syncToS3/functions.ts:51`), and `assumeRole()` performs a **two-hop STS chain** on each one:

```
assumeRole() -> getSTSCredentials(intermediary role)   // shared across all customers
             -> getSTSCredentials(customer role)         // per (roleArn, externalId, region)
```

So under a high-volume audience sync (many files), STS `AssumeRole` was being called **twice per file**. This is the most likely source of the `rate exceeded` / STS throttling errors observed during NYT load testing — Vara flagged STS (not S3 `PutObject`) as the probable culprit, and STS credential caching was called out as a pre-GA enhancement.

### 🛠 The fix
A **module-level** credential cache (shared across `Client` instances — a per-instance cache would never be reused given the per-upload construction), keyed by `region | roleArn | externalId`:

- Returns cached credentials until **5 minutes before** their STS-reported `Expiration` (safety buffer so nothing expires mid-upload).
- Caches **both hops** — the shared intermediary role (highest value under load, since it's identical for all customers) and the per-customer role.
- **Requires `Expiration`** — it's folded into the existing required-fields validation alongside `AccessKeyId`/`SecretAccessKey`/`SessionToken`, so a response missing it fails fast (403); otherwise credentials are always cached. STS always returns it (confirmed in DataDog).
- No public API or contract change; purely internal.

**Net effect under load:** STS call volume goes from `2 × fileCount` to roughly `2` per credential lifetime (~1 hour default), independent of file count.

### 🧪 Tests
Added a `STS credential caching` suite to `client.test.ts` (extends the mock STS harness introduced in #3993):
- reuses cached credentials across uploads instead of re-calling STS for every file (2 STS calls for 2 uploads, not 4);
- refreshes once credentials fall within the 5-min expiry buffer;
- caches per role identity while sharing the intermediary role;
- fails fast with a 403 when STS returns credentials without an `Expiration` (malformed response).


**Datadog Notebook:** https://segment.datadoghq.com/notebook/15492443/-proj-actions-s3-ga?refresh_mode=paused&tpl_var_env=stage&from_ts=1788952339507&to_ts=1788955939507
<img width="2992" height="3786" alt="image" src="https://github.com/user-attachments/assets/a594339f-1c81-4684-8d55-8d7ca352abb6" />


### ⏳ Cache expiry
Not a fixed TTL — each credential is cached until its **STS-reported `Expiration` minus a 5-minute safety buffer** (`CREDENTIALS_EXPIRY_BUFFER_MS` in `constants.ts`); a cache hit requires `cached.expiration − buffer > now`. We store the real `Expiration` STS returns, not a guessed duration, so the cache adapts automatically if the session length ever changes and can never serve a credential past its real lifetime.

The **5-minute buffer** is the one chosen value:
- **Avoids mid-upload expiry** — any credential handed out has comfortably more life than a single S3 PUT needs.
- **Matches existing precedent** — `lib/AWS/sts.ts` `getAWSCredentialsFromEKS()` caches 55 min against STS's default 1-hour (`DurationSeconds=3600`) token, i.e. the same 5-minute margin. Same as AWS SDK providers, which also refresh a few minutes early.
- **Good ratio** — against a 1-hour session it sacrifices ~8% of the window (~55 min still cached) to eliminate the edge case.

Caveat: 5 min is a conservative default, not empirically tuned. If an upload could ever exceed ~5 min, raise the buffer above the worst-case upload time — it's a single constant. Once the new metrics are live, an unexpectedly high miss rate is the signal to revisit the buffer (or session duration).

### 📊 Observability (DataDog)
Emits three counters from `Client.getSTSCredentials`, each tagged `role_type:intermediary` / `role_type:customer` (plus the caller's `statsContext.tags`):
- `sts_credential_cache_hit` — served from cache
- `sts_credential_cache_miss` — had to call STS `AssumeRole`
- `sts_credential_cache_set` — freshly minted creds written to cache

`statsContext` is threaded from the `perform`/`performBatch` bundle through `send()` into the `Client`; when absent, the `incr` calls are no-ops. Watch the hit ratio `hit / (hit + miss)` during the NYT load-test re-run — it should climb toward ~1.0 as file count grows.

### 🧩 Design note: why an in-memory cache and not `StateContext`

A reasonable question is whether this should use the framework's `StateContext` (the platform-managed, cross-request K/V store with TTL) instead of a module-level in-memory `Map`. We deliberately chose in-memory. Rationale:

- **Security (the deciding factor).** `StateContext` values are persisted by the monoservice and carried in the request/response `context` fields — they can be logged and live wherever subscription state lives. Caching there would mean persisting **live AWS `secretAccessKey` + `sessionToken`** outside process memory. Every current `StateContext` user in this repo stores a *non-secret* scalar (linkedin-audiences → `dmpSegmentId`, twilio-studio → a cooling-off marker, braze-cohorts → `cohort_name`); none stores a credential. In-memory keeps the STS secrets in process memory only and never serializes them anywhere.

- **Consistent with existing AWS precedent.** The two existing STS/credential caches in this repo are both in-memory module-level, not `StateContext`: `lib/AWS/sts.ts` `getAWSCredentialsFromEKS()` (caches assumed creds, ~55 min) and `lib/AWS/s3.ts` `getS3Client()` (caches the S3 client per monoservice instance). This PR mirrors that pattern for the customer assume-role path.

- **Fits the runtime.** The destination runs in the long-lived Integrations Monoservice (K8s pods), so a module-level cache persists across requests per pod. The throttling risk is per-prefix / per-flow, so per-pod caching is sufficient to flatten STS call volume (from `2 × fileCount` to ~2 per role per credential lifetime) and clear the `rate exceeded` errors observed in load testing.

- **`StateContext` is string-only, optional, and out of reach here.** It only exists in the `perform` bundle (our STS call is two layers down in `client.ts`), is not guaranteed present (`stateContext?`), and would require JSON-serializing the credential blob — i.e. secrets-in-a-string in shared state. Its coarse TTL also can't do the precise "STS `Expiration` minus 5-min buffer" freshness check we have here.

If cross-pod credential sharing is ever needed, that's a deliberate platform/security decision — but `StateContext` would still be the wrong home for live credentials, and there's no evidence it's needed for the current scale.

### ✅ Verification
- ✅ `tsc --noEmit` — clean for the changed files
- ✅ `eslint` — clean for the changed files
- ⚠️ **Jest not run locally** — this machine's `node_modules` has a pre-existing jest major-version skew (hoisted `jest-runtime@27.3.1` vs `jest@30`) that fails **all** test suites (including untouched ones like `slack`), and the internal registry is unreachable from here to repair it. The new tests follow the exact mock pattern already in `client.test.ts`; **CI will execute them.**

### ▶️ Follow-up
After this merges, re-run the actions-s3 load test with @Parag to confirm the STS throttling is gone before the NYT GA go-ahead.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


