### PR TITLE
[LinkedIn Audiences] Read client ID/secret from env for token refresh

### DIFF
--- a/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/__tests__/index.test.ts
@@ -116,4 +116,109 @@ describe('Linkedin Audiences', () => {
       )
     })
   })
+
+  describe('refreshAccessToken', () => {
+    const OLD_ENV = process.env
+
+    beforeEach(() => {
+      jest.resetModules() // Most important - it clears the cache
+      process.env = { ...OLD_ENV } // Make a copy
+
+      process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID = 'client_id'
+      process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_SECRET = 'client_secret'
+    })
+
+    afterAll(() => {
+      process.env = OLD_ENV // Restore old environment
+    })
+
+    it('should correctly request a new access token', async () => {
+      nock(`https://www.linkedin.com`)
+        .post('/oauth/v2/accessToken', {
+          grant_type: 'refresh_token',
+          client_id: 'client_id',
+          client_secret: 'client_secret',
+          refresh_token: 'refresh_token'
+        })
+        .reply(200, {
+          access_token: 'new_token',
+          expires_in: 5183999,
+          refresh_token: 'refresh_token',
+          refresh_token_expires_in: 31535960,
+          scope: 'r_basicprofile,rw_ads,rw_dmp_segments'
+        })
+
+      const response = await testDestination.refreshAccessToken(validSettings, {
+        refreshToken: 'refresh_token',
+        // The OAuth2ClientCredentials type requires these values below, however they are not actually
+        // passed into the function at runtime. The type is incorrect. Passing fake values here to satisfy the type.
+        clientId: 'fake-unused-client_id',
+        clientSecret: 'fake-unused-client_secret',
+        accessToken: 'fake-unused-access-token'
+      })
+
+      expect(response).toEqual({ accessToken: 'new_token' })
+    })
+
+    it('should throw an error if the client id is missing when requesting a new access token', async () => {
+      process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID = undefined
+
+      await expect(
+        testDestination.refreshAccessToken(validSettings, {
+          refreshToken: 'refresh_token',
+          // The OAuth2ClientCredentials type requires these values below, however they are not actually
+          // passed into the function at runtime. The type is incorrect. Passing fake values here to satisfy the type.
+          clientId: 'fake-unused-client_id',
+          clientSecret: 'fake-unused-client_secret',
+          accessToken: 'fake-unused-access-token'
+        })
+      ).rejects.toThrowError('Missing client ID')
+    })
+
+    it('should throw an error if the client secret is missing when requesting a new access token', async () => {
+      process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_SECRET = undefined
+
+      await expect(
+        testDestination.refreshAccessToken(validSettings, {
+          refreshToken: 'refresh_token',
+          // The OAuth2ClientCredentials type requires these values below, however they are not actually
+          // passed into the function at runtime. The type is incorrect. Passing fake values here to satisfy the type.
+          clientId: 'fake-unused-client_id',
+          clientSecret: 'fake-unused-client_secret',
+          accessToken: 'fake-unused-access-token'
+        })
+      ).rejects.toThrowError('Missing client secret')
+    })
+
+    it('should throw an error if the refresh token is missing when requesting a new access token', async () => {
+      await expect(
+        testDestination.refreshAccessToken(validSettings, {
+          refreshToken: '',
+          // The OAuth2ClientCredentials type requires these values below, however they are not actually
+          // passed into the function at runtime. The type is incorrect. Passing fake values here to satisfy the type.
+          clientId: 'fake-unused-client_id',
+          clientSecret: 'fake-unused-client_secret',
+          accessToken: 'fake-unused-access-token'
+        })
+      ).rejects.toThrowError('Missing refresh token. Please re-authenticate to fetch a new refresh token.')
+    })
+
+    it('should throw an error if the refresh token is invalid or expired', async () => {
+      nock(`https://www.linkedin.com`).post('/oauth/v2/accessToken').reply(400, {
+        error: 'invalid_grant',
+        error_description: 'refresh token is invalid or expired'
+      })
+
+      await expect(
+        testDestination.refreshAccessToken(validSettings, {
+          refreshToken: 'refresh_token',
+          clientId: 'fake-unused-client_id',
+          clientSecret: 'fake-unused-client_secret',
+          accessToken: 'fake-unused-access-token'
+        })
+      ).rejects.toThrowError(
+        'Invalid Authentication: Your refresh token is invalid or expired. Please re-authenticate to fetch a new refresh token.'
+      )
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/linkedin-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/linkedin-audiences/index.ts
@@ -109,13 +109,32 @@ const destination: DestinationDefinition<Settings> = {
     refreshAccessToken: async (request, { auth }) => {
       let res
 
+      if (!process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID) {
+        throw new IntegrationError(`Missing client ID`, ErrorCodes.OAUTH_REFRESH_FAILED, 500)
+      }
+
+      if (!process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_SECRET) {
+        throw new IntegrationError(`Missing client secret`, ErrorCodes.OAUTH_REFRESH_FAILED, 500)
+      }
+
+      if (!auth?.refreshToken) {
+        throw new IntegrationError(
+          `Missing refresh token. Please re-authenticate to fetch a new refresh token.`,
+          ErrorCodes.OAUTH_REFRESH_FAILED,
+          401
+        )
+      }
+
       try {
         res = await request<RefreshTokenResponse>('https://www.linkedin.com/oauth/v2/accessToken', {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
           body: new URLSearchParams({
             refresh_token: auth.refreshToken,
-            client_id: auth.clientId,
-            client_secret: auth.clientSecret,
+            client_id: process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID,
+            client_secret: process.env.ACTIONS_LINKEDIN_AUDIENCES_CLIENT_SECRET,
             grant_type: 'refresh_token'
           })
         })


### PR DESCRIPTION
https://twilio-engineering.atlassian.net/browse/STRATCONN-6946

## Summary
`refreshAccessToken` in `linkedin-audiences` was sourcing `client_id`/`client_secret` from the per-instance OAuth auth object, which is never populated at runtime — so every refresh request went out with empty credentials and LinkedIn rejected it with `invalid_client`. Customers (e.g. Xero) hit this every ~60 days when their access token expired, and the only recovery was a full manual re-authentication.

This is the identical bug fixed in `linkedin-conversions` (STRATCONN-4076, #2355), which never got the equivalent fix applied to `linkedin-audiences`. This PR mirrors that fix:
- Read `client_id`/`client_secret` from `ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID` / `ACTIONS_LINKEDIN_AUDIENCES_CLIENT_SECRET` env vars instead of the auth object.
- Add guard clauses for missing client ID, missing client secret, and missing refresh token.
- Explicitly set `Content-Type: application/x-www-form-urlencoded` on the refresh request.

**Infra note:** this fix depends on `ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID`/`_CLIENT_SECRET` being provisioned in the deployed destination-actions runtime's environment. The LinkedIn app itself already exists and is used today for the initial OAuth connect flow (via `oauth-service`) — no new LinkedIn app registration is needed, only provisioning the existing app's credentials to whichever service executes this refresh in prod.

## Testing
- [x] Added unit tests for new functionality
- [x] Tested end-to-end using the local server, against the real LinkedIn API (stage credentials)

### Unit tests
Added a `refreshAccessToken` suite mirroring `linkedin-conversions`'s: happy path (asserts the real `client_id`/`client_secret` go out, not empty strings), missing-client-id guard, missing-client-secret guard, missing-refresh-token guard, and `invalid_grant` → `REFRESH_TOKEN_EXPIRED` mapping. All passing (12/12 in the full `linkedin-audiences` suite).

### Real end-to-end evidence (redacted)
Ran the fixed `refreshAccessToken` directly against the real LinkedIn token endpoint using real stage `ACTIONS_LINKEDIN_AUDIENCES_CLIENT_ID`/`_CLIENT_SECRET` pulled from chamber (`oauth-service`), and real refresh tokens from a staging `linkedin-audiences` instance.

**Call 1 — stale/reused refresh token:**
```
POST https://www.linkedin.com/oauth/v2/accessToken
client_id: 86d3...yl91
client_secret: Edto...sNtq
refresh_token: AQX3...9knw
grant_type: refresh_token

→ 401 REFRESH_TOKEN_EXPIRED
"Invalid Authentication: Your refresh token is invalid or expired. Please re-authenticate to fetch a new refresh token."
```
This confirms the fix is sending real, valid app credentials — LinkedIn validates `client_id`/`client_secret` before it even looks at the refresh token, so an `invalid_grant`-mapped response (rather than `invalid_client`) proves the app credentials were accepted; only this particular token was stale.

**Call 2 — freshly re-authenticated staging instance:**
```
POST https://www.linkedin.com/oauth/v2/accessToken
client_id: 86d3...yl91
client_secret: Edto...sNtq
refresh_token: AQUW...P7lg
grant_type: refresh_token

→ SUCCESS
New access_token returned: AQUw...lXek (403 chars, well-formed LinkedIn token)
```
Full happy-path proof: a real refresh_token was successfully exchanged for a new access_token against LinkedIn's production API, using the real stage app credentials.

(Note: per PR #2355's precedent, there's no way to test the natural 60-day-expiry trigger path itself in stage/prod without waiting — LinkedIn's token-revoke endpoint also invalidates the refresh token, so it can't be used to force an expiry for testing. The above directly exercises the same refresh mechanism the framework calls automatically at expiry.)