### PR TITLE
STRATCONN-7013 - [Amazon Conversions API] - Fix Cannot hash an empty string error on match key hashing

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
@@ -183,7 +183,7 @@ describe('trackConversion utils', () => {
         name: 'event1',
         conversionType: ConversionTypeV2.PAGE_VIEW,
         eventSource: 'website',
-        eventIngestionMethod: "SERVER_TO_SERVER",
+        eventIngestionMethod: 'SERVER_TO_SERVER'
       },
       countryCode: 'US',
       eventTime: '2023-01-01T12:00:00Z'
@@ -231,7 +231,10 @@ describe('trackConversion utils', () => {
         data: { success: true }
       })
 
-      const multipleEvents = [eventData, { ...eventData, eventDescription: { ...eventData.eventDescription, name: 'second_event' } }]
+      const multipleEvents = [
+        eventData,
+        { ...eventData, eventDescription: { ...eventData.eventDescription, name: 'second_event' } }
+      ]
 
       const response = await sendEventsRequest<EventMultiStatusResponse>(
         mockRequest as unknown as RequestClient,
@@ -311,7 +314,7 @@ describe('trackConversion utils', () => {
         status: 207,
         data: {
           success: [],
-          error: [{ index: 0, errors: [{ code: "BAD_REQUEST", message: 'Invalid data' }] }]
+          error: [{ index: 0, errors: [{ code: 'BAD_REQUEST', message: 'Invalid data' }] }]
         }
       } as unknown as ModifiedResponse<EventMultiStatusResponse>
 
@@ -321,7 +324,7 @@ describe('trackConversion utils', () => {
         status: 400,
         data: {
           success: [],
-          error: [{ index: 0, errors: [{ code: "BAD_REQUEST", message: 'Invalid data' }] }]
+          error: [{ index: 0, errors: [{ code: 'BAD_REQUEST', message: 'Invalid data' }] }]
         }
       })
     })
@@ -363,14 +366,13 @@ describe('trackConversion utils', () => {
     })
 
     it('should process 207 multistatus responses from a performBatch() correctly', () => {
-
       const validPayloads = [
         {
           eventDescription: {
             name: 'event1',
             conversionType: ConversionTypeV2.PAGE_VIEW,
             eventSource: 'website',
-            eventIngestionMethod: "SERVER_TO_SERVER",
+            eventIngestionMethod: 'SERVER_TO_SERVER'
           },
           countryCode: 'US',
           eventTime: '2023-01-01T12:00:00Z'
@@ -380,7 +382,7 @@ describe('trackConversion utils', () => {
             name: 'event2',
             conversionType: ConversionTypeV2.PAGE_VIEW,
             eventSource: 'website',
-            eventIngestionMethod: "SERVER_TO_SERVER",
+            eventIngestionMethod: 'SERVER_TO_SERVER'
           },
           countryCode: 'US',
           eventTime: '2023-01-01T12:00:00Z'
@@ -391,7 +393,7 @@ describe('trackConversion utils', () => {
         status: 207,
         data: {
           success: [{ index: 0, event: validPayloads[0] }],
-          error: [{ index: 1, errors: [{ code: "BAD_REQUEST", message: 'Invalid data' }] }]
+          error: [{ index: 1, errors: [{ code: 'BAD_REQUEST', message: 'Invalid data' }] }]
         }
       } as unknown as ModifiedResponse<EventMultiStatusResponse>
 
@@ -438,7 +440,7 @@ describe('trackConversion utils', () => {
             name: 'event1',
             conversionType: ConversionTypeV2.PAGE_VIEW,
             eventSource: 'website',
-            eventIngestionMethod: "SERVER_TO_SERVER",
+            eventIngestionMethod: 'SERVER_TO_SERVER'
           },
           countryCode: 'US',
           eventTime: '2023-01-01T12:00:00Z'
@@ -477,7 +479,7 @@ describe('trackConversion utils', () => {
           name: payload.name,
           conversionType: payload.eventType,
           eventSource: payload.eventActionSource,
-          eventIngestionMethod: "SERVER_TO_SERVER",
+          eventIngestionMethod: 'SERVER_TO_SERVER'
         },
         countryCode: payload.countryCode,
         eventTime: payload.timestamp
@@ -578,6 +580,110 @@ describe('trackConversion utils', () => {
         countryCode: 'US',
         timestamp: '2023-01-01T12:00:00Z',
         matchKeys: {},
+        enable_batching: true
+      }
+
+      expect(() => prepareEventData(payload, settings)).toThrow('At least one valid match key must be provided')
+    })
+
+    it('should skip match key fields that normalize down to an empty string instead of throwing', () => {
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          email: 'test@example.com',
+          // Non-empty, but strips down to '' once non-digit characters are removed
+          phone: '+++'
+        },
+        enable_batching: true
+      }
+
+      expect(() => prepareEventData(payload, settings)).not.toThrow()
+
+      const result = prepareEventData(payload, settings)
+      expect(result.matchKeys?.length).toBe(1)
+      expect(result.matchKeys?.map((mk) => mk.type)).toEqual(['EMAIL'])
+    })
+
+    it('should skip normalizeStandard fields (e.g. firstName) that normalize down to an empty string', () => {
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          email: 'test@example.com',
+          // Non-empty, but strips down to '' once non-alphanumeric characters are removed
+          firstName: '!!!'
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+      expect(result.matchKeys?.length).toBe(1)
+      expect(result.matchKeys?.map((mk) => mk.type)).toEqual(['EMAIL'])
+    })
+
+    it('should skip postalCode when it normalizes down to an empty string', () => {
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          email: 'test@example.com',
+          // Whitespace-only, strips down to '' once whitespace is removed
+          postalCode: '   '
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+      expect(result.matchKeys?.length).toBe(1)
+      expect(result.matchKeys?.map((mk) => mk.type)).toEqual(['EMAIL'])
+    })
+
+    it('should skip email when it is whitespace-only', () => {
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          email: '   ',
+          firstName: 'John'
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+      expect(result.matchKeys?.length).toBe(1)
+      expect(result.matchKeys?.map((mk) => mk.type)).toEqual(['FIRST_NAME'])
+    })
+
+    it('should throw "At least one valid match key must be provided" when every hashable field normalizes to empty', () => {
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          email: '!!!',
+          phone: '+++',
+          firstName: '!!!',
+          lastName: '!!!',
+          address: '!!!',
+          city: '!!!',
+          state: '!!!',
+          postalCode: '   '
+        },
         enable_batching: true
       }
 
@@ -689,7 +795,7 @@ describe('trackConversion utils', () => {
         currencyCode: 'USD',
         unitsSold: 2,
         clientDedupeId: 'dedup-123',
-        dataProcessingOptions: ["LIMITED_DATA_USE"],
+        dataProcessingOptions: ['LIMITED_DATA_USE'],
         matchKeys: {
           email: 'test@example.com'
         },

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock'
+import * as crypto from 'crypto'
 import {
   hasStringValue,
   validateConsent,
@@ -665,6 +666,28 @@ describe('trackConversion utils', () => {
       const result = prepareEventData(payload, settings)
       expect(result.matchKeys?.length).toBe(1)
       expect(result.matchKeys?.map((mk) => mk.type)).toEqual(['FIRST_NAME'])
+    })
+
+    it('should pass an already-hashed phone value through unchanged instead of normalizing it', () => {
+      // A real hash (hex digest) contains a-f letters. If it were run through normalizePhone
+      // (which strips all non-digit characters) before the already-hashed check, it would be
+      // mangled instead of passed through as-is.
+      const alreadyHashedPhone = crypto.createHash('sha256').update('15551234567').digest('hex')
+      const payload = {
+        name: 'test_event',
+        eventType: ConversionTypeV2.PAGE_VIEW,
+        eventActionSource: 'WEBSITE',
+        countryCode: 'US',
+        timestamp: '2023-01-01T12:00:00Z',
+        matchKeys: {
+          phone: alreadyHashedPhone
+        },
+        enable_batching: true
+      }
+
+      const result = prepareEventData(payload, settings)
+      const phoneKey = result.matchKeys?.find((mk) => mk.type === 'PHONE')
+      expect(phoneKey?.values[0]).toBe(alreadyHashedPhone)
     })
 
     it('should throw "At least one valid match key must be provided" when every hashable field normalizes to empty', () => {

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -128,6 +128,15 @@ export function smartHash(value: string, normalizeFunction?: (value: string) => 
 }
 
 /**
+ * Determines whether a match key value is safe to hash. Some values (e.g. "+++")
+ * are non-empty but normalize down to an empty string, which would otherwise
+ * cause the hashing utility to throw "Cannot hash an empty string".
+ */
+function isHashable(value: string | null | undefined, normalizeFunction: (value: string) => string): value is string {
+  return typeof value === 'string' && normalizeFunction(value).length > 0
+}
+
+/**
  * Sends event data to the Amazon Conversions API
  *
  * @param request The request client
@@ -273,7 +282,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
   // Process match keys
   let matchKeys: MatchKeyV1[] = []
 
-  if (email && typeof email === 'string') {
+  if (isHashable(email, normalizeEmail)) {
     const hashedEmail = smartHash(email, normalizeEmail)
     matchKeys.push({
       type: MatchKeyTypeV1.EMAIL,
@@ -281,7 +290,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (phone && typeof phone === 'string') {
+  if (isHashable(phone, normalizePhone)) {
     const hashedPhone = smartHash(phone, normalizePhone)
     matchKeys.push({
       type: MatchKeyTypeV1.PHONE,
@@ -289,7 +298,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (firstName && typeof firstName === 'string') {
+  if (isHashable(firstName, normalizeStandard)) {
     const hashedFirstName = smartHash(firstName, normalizeStandard)
     matchKeys.push({
       type: MatchKeyTypeV1.FIRST_NAME,
@@ -297,7 +306,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (lastName && typeof lastName === 'string') {
+  if (isHashable(lastName, normalizeStandard)) {
     const hashedLastName = smartHash(lastName, normalizeStandard)
     matchKeys.push({
       type: MatchKeyTypeV1.LAST_NAME,
@@ -305,7 +314,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (address && typeof address === 'string') {
+  if (isHashable(address, normalizeStandard)) {
     const hashedAddress = smartHash(address, normalizeStandard)
     matchKeys.push({
       type: MatchKeyTypeV1.ADDRESS,
@@ -313,7 +322,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (city && typeof city === 'string') {
+  if (isHashable(city, normalizeStandard)) {
     const hashedCity = smartHash(city, normalizeStandard)
     matchKeys.push({
       type: MatchKeyTypeV1.CITY,
@@ -321,7 +330,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (state && typeof state === 'string') {
+  if (isHashable(state, normalizeStandard)) {
     const hashedState = smartHash(state, normalizeStandard)
     matchKeys.push({
       type: MatchKeyTypeV1.STATE,
@@ -329,7 +338,7 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
     })
   }
 
-  if (postalCode && typeof postalCode === 'string') {
+  if (isHashable(postalCode, normalizePostal)) {
     const hashedPostalCode = smartHash(postalCode, normalizePostal)
     matchKeys.push({
       type: MatchKeyTypeV1.POSTAL,

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -32,7 +32,7 @@ import { AMAZON_CONVERSIONS_API_EVENTS_VERSION } from '../versioning-info'
  * @param value The string value to validate
  * @returns true if the value is a non-empty string, false otherwise
  */
-export function hasStringValue(value: string | null | undefined): boolean {
+export function hasStringValue(value: string | null | undefined): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
 

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -6,7 +6,7 @@ import {
   ModifiedResponse,
   APIError
 } from '@segment/actions-core'
-import { processHashing } from '../../../lib/hashing-utils'
+import { processHashing, EmptyValueError } from '../../../lib/hashing-utils'
 import type { Settings } from '../generated-types'
 import type {
   EventData,
@@ -128,12 +128,27 @@ export function smartHash(value: string, normalizeFunction?: (value: string) => 
 }
 
 /**
- * Determines whether a match key value is safe to hash. Some values (e.g. "+++")
- * are non-empty but normalize down to an empty string, which would otherwise
- * cause the hashing utility to throw "Cannot hash an empty string".
+ * Hashes a match key value and appends it to matchKeys. Some values (e.g. "+++" for phone)
+ * are non-empty but normalize down to an empty string, which would otherwise cause the
+ * hashing utility to throw "Cannot hash an empty string" - that error is caught here and
+ * the field is skipped instead, without normalizing the value more than once.
  */
-function isHashable(value: string | null | undefined, normalizeFunction: (value: string) => string): value is string {
-  return typeof value === 'string' && normalizeFunction(value).length > 0
+function addHashedMatchKey(
+  matchKeys: MatchKeyV1[],
+  type: MatchKeyTypeV1,
+  value: string | null | undefined,
+  normalizeFunction: (value: string) => string
+): void {
+  if (!hasStringValue(value)) {
+    return
+  }
+  try {
+    matchKeys.push({ type, values: [smartHash(value, normalizeFunction)] })
+  } catch (err) {
+    if (!(err instanceof EmptyValueError)) {
+      throw err
+    }
+  }
 }
 
 /**
@@ -282,69 +297,14 @@ export function prepareEventData(payload: Payload, settings: Settings): EventDat
   // Process match keys
   let matchKeys: MatchKeyV1[] = []
 
-  if (isHashable(email, normalizeEmail)) {
-    const hashedEmail = smartHash(email, normalizeEmail)
-    matchKeys.push({
-      type: MatchKeyTypeV1.EMAIL,
-      values: [hashedEmail]
-    })
-  }
-
-  if (isHashable(phone, normalizePhone)) {
-    const hashedPhone = smartHash(phone, normalizePhone)
-    matchKeys.push({
-      type: MatchKeyTypeV1.PHONE,
-      values: [hashedPhone]
-    })
-  }
-
-  if (isHashable(firstName, normalizeStandard)) {
-    const hashedFirstName = smartHash(firstName, normalizeStandard)
-    matchKeys.push({
-      type: MatchKeyTypeV1.FIRST_NAME,
-      values: [hashedFirstName]
-    })
-  }
-
-  if (isHashable(lastName, normalizeStandard)) {
-    const hashedLastName = smartHash(lastName, normalizeStandard)
-    matchKeys.push({
-      type: MatchKeyTypeV1.LAST_NAME,
-      values: [hashedLastName]
-    })
-  }
-
-  if (isHashable(address, normalizeStandard)) {
-    const hashedAddress = smartHash(address, normalizeStandard)
-    matchKeys.push({
-      type: MatchKeyTypeV1.ADDRESS,
-      values: [hashedAddress]
-    })
-  }
-
-  if (isHashable(city, normalizeStandard)) {
-    const hashedCity = smartHash(city, normalizeStandard)
-    matchKeys.push({
-      type: MatchKeyTypeV1.CITY,
-      values: [hashedCity]
-    })
-  }
-
-  if (isHashable(state, normalizeStandard)) {
-    const hashedState = smartHash(state, normalizeStandard)
-    matchKeys.push({
-      type: MatchKeyTypeV1.STATE,
-      values: [hashedState]
-    })
-  }
-
-  if (isHashable(postalCode, normalizePostal)) {
-    const hashedPostalCode = smartHash(postalCode, normalizePostal)
-    matchKeys.push({
-      type: MatchKeyTypeV1.POSTAL,
-      values: [hashedPostalCode]
-    })
-  }
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.EMAIL, email, normalizeEmail)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.PHONE, phone, normalizePhone)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.FIRST_NAME, firstName, normalizeStandard)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.LAST_NAME, lastName, normalizeStandard)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.ADDRESS, address, normalizeStandard)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.CITY, city, normalizeStandard)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.STATE, state, normalizeStandard)
+  addHashedMatchKey(matchKeys, MatchKeyTypeV1.POSTAL, postalCode, normalizePostal)
 
   if (maid && typeof maid === 'string') {
     matchKeys.push({


### PR DESCRIPTION
## Summary

Fixes [STRATCONN-7013](https://twilio-engineering.atlassian.net/browse/STRATCONN-7013). Customers were seeing `Cannot hash an empty string` errors from the Amazon Conversions API destination's `trackConversion` action.

## Root cause

In `trackConversion/utils.ts`, match key fields (email, phone, firstName, lastName, address, city, state, postalCode) were guarded with `if (field && typeof field === 'string')` before being hashed via `smartHash`. This correctly excludes truly empty strings, but some non-empty values (e.g. `"+++"` for phone, or whitespace-only strings) normalize down to an empty string via the field's normalization function (e.g. `normalizePhone` strips all non-digit characters) *before* hashing. The shared hashing utility then throws `EmptyValueError('Cannot hash an empty string')` because it only checks emptiness on the raw input, not after normalization.

## Fix

Scoped entirely to the Amazon Conversions API destination code (no changes to the shared `hashing-utils.ts`). Added an `addHashedMatchKey(matchKeys, type, value, normalizeFunction)` helper that hashes each match key value via `smartHash` and catches the `EmptyValueError` it throws when a value normalizes down to empty, skipping that field instead of letting the error propagate. This preserves `processHashing`'s existing "already-hashed passthrough" check (which runs on the raw value before normalization) rather than normalizing up front, which would have broken that passthrough for fields like phone.

## Testing

- Added regression tests covering: a field normalizing to empty via each normalizer (`normalizePhone`, `normalizeStandard`, `normalizePostal`), a whitespace-only field, the case where every hashable field normalizes to empty (correctly falls through to the existing "At least one valid match key must be provided" error), and an already-hashed value passing through unchanged.
- Verified the new tests fail with the exact `EmptyValueError` on the pre-fix code, and pass with the fix.
- Full `destination-actions` test suite passes.
- Lint clean, no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STRATCONN-7013]: https://twilio-engineering.atlassian.net/browse/STRATCONN-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ