### PR TITLE
Release

### DIFF
--- a/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
+++ b/packages/browser-destinations/destinations/braze-cloud-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-braze-cloud-plugins",
-  "version": "1.123.0",
+  "version": "1.124.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -20,7 +20,7 @@
   },
   "typings": "./dist/esm",
   "dependencies": {
-    "@segment/analytics-browser-actions-braze": "^1.123.0",
+    "@segment/analytics-browser-actions-braze": "^1.124.0",
     "@segment/browser-destination-runtime": "^1.106.0"
   },
   "peerDependencies": {

--- a/packages/browser-destinations/destinations/braze/package.json
+++ b/packages/browser-destinations/destinations/braze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics-browser-actions-braze",
-  "version": "1.123.0",
+  "version": "1.124.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.521.0",
+  "version": "3.522.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destinations-manifest/package.json
+++ b/packages/destinations-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/destinations-manifest",
-  "version": "1.172.0",
+  "version": "1.173.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",
@@ -21,8 +21,8 @@
     "@segment/analytics-browser-actions-adobe-target": "^1.108.0",
     "@segment/analytics-browser-actions-algolia-plugins": "^1.84.0",
     "@segment/analytics-browser-actions-amplitude-plugins": "^1.107.0",
-    "@segment/analytics-browser-actions-braze": "^1.123.0",
-    "@segment/analytics-browser-actions-braze-cloud-plugins": "^1.123.0",
+    "@segment/analytics-browser-actions-braze": "^1.124.0",
+    "@segment/analytics-browser-actions-braze-cloud-plugins": "^1.124.0",
     "@segment/analytics-browser-actions-bucket": "^1.88.0",
     "@segment/analytics-browser-actions-cdpresolution": "^1.94.0",
     "@segment/analytics-browser-actions-cj": "^1.21.0",


### PR DESCRIPTION
This PR was opened by action-cli's trigger-action-destinations-publish command.
Merging it bumps package versions ahead of an internal-only NPM Artifactory publish.

# Changed packages
- packages/browser-destinations/destinations/braze-cloud-plugins/package.json
- packages/browser-destinations/destinations/braze/package.json
- packages/destination-actions/package.json
- packages/destinations-manifest/package.json