### PR TITLE
[cleanup] [Google Campaign Manager 360] Bump default API version to v5

### DIFF
--- a/packages/destination-actions/src/destinations/google-campaign-manager-360/versioning-info.ts
+++ b/packages/destination-actions/src/destinations/google-campaign-manager-360/versioning-info.ts
@@ -2,7 +2,7 @@
  * Campaign Manager 360 dfareporting API version (default/stable).
  * API reference: https://developers.google.com/doubleclick-advertisers/deprecation
  */
-export const GOOGLE_CM360_API_VERSION = 'v4'
+export const GOOGLE_CM360_API_VERSION = 'v5'
 
 /** GOOGLE_CM360_CANARY_API_VERSION
  * Campaign Manager 360 dfareporting API version (canary).


### PR DESCRIPTION
## Summary
- Promotes the CM360 dfareporting API version from v4 to v5 as the stable default. The `cm360-canary-api-version` Flagon gate is left in place (both stable and canary constants now point at v5) so we retain instant rollback capability during the observation period, per [STRATCONN-6611](https://twilio-engineering.atlassian.net/browse/STRATCONN-6611).
- v5 has been rolled out to all tiers and is showing consistent success since rollout (see ticket comments).
- Flag/version-selection logic (`getApiVersion`) and old-version code are left untouched — cleanup of the flag itself is a follow-up once the observation period passes.

## Test plan
- [x] `versioning-info.ts` change reviewed against the prior promotion precedent (#3818, LinkedIn Audiences bump)
- [x] `tsc --noEmit` passes for the destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STRATCONN-6611]: https://twilio-engineering.atlassian.net/browse/STRATCONN-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ