### PR TITLE
STRATCONN-7017: validate S3 object key characters against AWS allowed set

### DIFF
--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -115,8 +115,8 @@ describe('uploadS3 object key character validation', () => {
 
     expect(error).toBeInstanceOf(PayloadValidationError)
     // Points at both parts and lists the distinct bad characters.
-    expect(error.message).toContain('folder name has disallowed character(s): "#"')
-    expect(error.message).toContain('filename prefix has disallowed character(s): "@"')
+    expect(error.message).toContain("folder name has disallowed character(s): '#'")
+    expect(error.message).toContain("filename prefix has disallowed character(s): '@'")
     // The surrounding (potentially PII-laden) values are not echoed.
     expect(error.message).not.toContain('secret-pii')
     expect(error.message).not.toContain('user@example')
@@ -204,25 +204,25 @@ describe('uploadS3 object key — AWS object-keys guideline coverage', () => {
     await reject('launch\u{1F680}') // 🚀
   })
 
-  it('reports a non-BMP character as a single code point, not surrogate halves', async () => {
+  it('reports a non-BMP character as a single code point (U+XXXX), not surrogate halves', async () => {
     const err = await newClient().uploadS3(settings, 'body', 'launch\u{1F680}', '', 'csv').catch((e) => e as Error)
-    // With the regex `u` flag the emoji is one character in the message, not "\ud83d", "\ude00".
-    expect(err.message).toContain('"\u{1F680}"')
+    // With the regex `u` flag the emoji is one code point, rendered U+1F680 — not "\ud83d", "\ude00".
+    expect(err.message).toContain('U+1F680')
     expect(err.message).not.toContain('ud83d')
   })
 
   // --- Reporting completeness ---
   it('de-duplicates repeated disallowed characters within a part', async () => {
     const err = await newClient().uploadS3(settings, 'body', 'a#b#c@d@', '', 'csv').catch((e) => e as Error)
-    expect(err.message).toContain('filename prefix has disallowed character(s): "#", "@"')
+    expect(err.message).toContain("filename prefix has disallowed character(s): '#', '@'")
   })
 
   it('caps the number of distinct disallowed characters listed per part', async () => {
-    // 13 distinct disallowed characters; only the first 10 are listed, then "…and 3 more".
+    // 13 distinct disallowed characters; only the first 10 are listed, then "...and 3 more".
+    // Order of first appearance: # % ^ ~ < > | { } [  (shown)  then  ] " @  (elided).
     const err = await newClient().uploadS3(settings, 'body', 'a#%^~<>|{}[]"@', '', 'csv').catch((e) => e as Error)
-    expect(err.message).toContain('…and 3 more')
-    // Exactly 10 quoted characters precede the summary.
-    const listed = (err.message.match(/"[^"]*"/g) ?? []).length
-    expect(listed).toBe(10)
+    expect(err.message).toContain('...and 3 more')
+    expect(err.message).toContain("'['") // 10th distinct char is listed
+    expect(err.message).not.toContain("']'") // 11th distinct char is elided
   })
 })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -94,28 +94,30 @@ describe('uploadS3 object key character validation', () => {
   it('rejects an object key with a disallowed character and does not PUT', async () => {
     const client = newClient()
 
-    // A space is outside the AWS "safe" set.
-    const promise = client.uploadS3(settings, 'my file', '', 'folder', 'csv')
+    // A space (in the filename prefix) is outside the AWS "safe" set.
+    const promise = client.uploadS3(settings, 'file,content', 'my file', 'folder', 'csv')
 
     await expect(promise).rejects.toThrow(PayloadValidationError)
     await expect(promise).rejects.toThrow('outside the allowed set')
+    await expect(promise).rejects.toThrow('filename prefix has disallowed character(s)')
     // Fails fast: no role assumption and no PUT are attempted.
     expect(stsSend).not.toHaveBeenCalled()
     expect(s3Send).not.toHaveBeenCalled()
   })
 
-  it('names the distinct offending characters but not the full key', async () => {
+  it('names the offending part(s) and their distinct characters but not the full key', async () => {
     const client = newClient()
 
-    // Two disallowed chars ('#' and '@') plus otherwise-sensitive content.
+    // Disallowed char in each part: '@' in the filename prefix, '#' in the folder name.
     const error = await client
-      .uploadS3(settings, 'user@example', '', 'reports#secret-pii', 'csv')
+      .uploadS3(settings, 'file,content', 'user@example', 'reports#secret-pii', 'csv')
       .catch((e) => e as Error)
 
     expect(error).toBeInstanceOf(PayloadValidationError)
-    expect(error.message).toContain('"#"')
-    expect(error.message).toContain('"@"')
-    // The surrounding (potentially PII-laden) key content is not echoed.
+    // Points at both parts and lists the distinct bad characters.
+    expect(error.message).toContain('folder name has disallowed character(s): "#"')
+    expect(error.message).toContain('filename prefix has disallowed character(s): "@"')
+    // The surrounding (potentially PII-laden) values are not echoed.
     expect(error.message).not.toContain('secret-pii')
     expect(error.message).not.toContain('user@example')
   })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -131,3 +131,82 @@ describe('uploadS3 object key character validation', () => {
     expect(s3Send).toHaveBeenCalledTimes(1)
   })
 })
+
+// Systematic coverage of the character categories in AWS's object key naming guidelines:
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+// Policy: allow only the "Safe characters" set plus "/" (folder delimiter); reject everything else
+// ("characters that might require special handling" — except "/" — plus "characters to avoid",
+// ASCII control characters, and any non-ASCII / non-printable byte).
+describe('uploadS3 object key — AWS object-keys guideline coverage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stsSend.mockResolvedValue(validStsResponse)
+    s3Send.mockResolvedValue({})
+  })
+
+  const reject = async (filenamePrefix: string, folder = '') => {
+    const promise = newClient().uploadS3(settings, 'body', filenamePrefix, folder, 'csv')
+    await expect(promise).rejects.toBeInstanceOf(PayloadValidationError)
+    await expect(promise).rejects.toThrow('outside the allowed set')
+    // Fails fast, before any AWS call.
+    expect(stsSend).not.toHaveBeenCalled()
+    expect(s3Send).not.toHaveBeenCalled()
+  }
+
+  const accept = async (filenamePrefix: string, folder = '') => {
+    const result = await newClient().uploadS3(settings, 'body', filenamePrefix, folder, 'csv')
+    expect(result).toEqual({ statusCode: 200, message: 'Upload successful' })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  }
+
+  // --- "Safe characters": accepted ---
+  const SAFE_SPECIALS = ['!', '-', '_', '.', '*', "'", '(', ')']
+  it.each(SAFE_SPECIALS)('accepts safe special character %j', async (ch) => {
+    await accept(`file${ch}name`)
+  })
+
+  it('accepts a key mixing letters, digits, and every safe special character', async () => {
+    await accept("aZ09-file_name.v1*(final)!'")
+  })
+
+  it('accepts "/" as the folder path separator (multi-level paths)', async () => {
+    await accept('report', 'team/exports/2026/09')
+  })
+
+  // --- "Characters that might require special handling": rejected (except "/", tested above) ---
+  const SPECIAL_HANDLING = ['&', '$', '@', '=', ';', ':', '+', ' ', ',', '?']
+  it.each(SPECIAL_HANDLING)('rejects special-handling character %j', async (ch) => {
+    await reject(`file${ch}name`)
+  })
+
+  // --- "Characters to avoid": rejected ---
+  const AVOID = ['\\', '{', '^', '}', '%', '`', ']', '"', '>', '[', '~', '<', '#', '|']
+  it.each(AVOID)('rejects avoid character %j', async (ch) => {
+    await reject(`file${ch}name`)
+  })
+
+  // --- ASCII control characters (0x00-0x1F, 0x7F): rejected ---
+  const CONTROL_CODES = [0x00, 0x09, 0x0a, 0x0d, 0x1f, 0x7f] // NUL, TAB, LF, CR, US, DEL
+  it.each(CONTROL_CODES.map((code) => [code.toString(16).padStart(2, '0'), String.fromCharCode(code)] as const))(
+    'rejects ASCII control character 0x%s',
+    async (_hex, ch) => {
+      await reject(`file${ch}name`)
+    }
+  )
+
+  // --- Non-ASCII / non-printable bytes: rejected ---
+  const NON_ASCII = ['\u00E9', '\u20AC', '\u4E2D', '\u00A0'] // accented latin, euro sign, CJK, non-breaking space
+  it.each(NON_ASCII)('rejects non-ASCII character %j', async (ch) => {
+    await reject(`file${ch}name`)
+  })
+
+  it('rejects a multi-code-unit emoji in the key', async () => {
+    await reject('launch\u{1F680}') // 🚀
+  })
+
+  // --- Reporting completeness ---
+  it('de-duplicates repeated disallowed characters within a part', async () => {
+    const err = await newClient().uploadS3(settings, 'body', 'a#b#c@d@', '', 'csv').catch((e) => e as Error)
+    expect(err.message).toContain('filename prefix has disallowed character(s): "#", "@"')
+  })
+})

--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -204,9 +204,25 @@ describe('uploadS3 object key — AWS object-keys guideline coverage', () => {
     await reject('launch\u{1F680}') // 🚀
   })
 
+  it('reports a non-BMP character as a single code point, not surrogate halves', async () => {
+    const err = await newClient().uploadS3(settings, 'body', 'launch\u{1F680}', '', 'csv').catch((e) => e as Error)
+    // With the regex `u` flag the emoji is one character in the message, not "\ud83d", "\ude00".
+    expect(err.message).toContain('"\u{1F680}"')
+    expect(err.message).not.toContain('ud83d')
+  })
+
   // --- Reporting completeness ---
   it('de-duplicates repeated disallowed characters within a part', async () => {
     const err = await newClient().uploadS3(settings, 'body', 'a#b#c@d@', '', 'csv').catch((e) => e as Error)
     expect(err.message).toContain('filename prefix has disallowed character(s): "#", "@"')
+  })
+
+  it('caps the number of distinct disallowed characters listed per part', async () => {
+    // 13 distinct disallowed characters; only the first 10 are listed, then "…and 3 more".
+    const err = await newClient().uploadS3(settings, 'body', 'a#%^~<>|{}[]"@', '', 'csv').catch((e) => e as Error)
+    expect(err.message).toContain('…and 3 more')
+    // Exactly 10 quoted characters precede the summary.
+    const listed = (err.message.match(/"[^"]*"/g) ?? []).length
+    expect(listed).toBe(10)
   })
 })

--- a/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/__tests__/client.test.ts
@@ -83,3 +83,49 @@ describe('uploadS3 object key length guard', () => {
     expect(s3Send).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('uploadS3 object key character validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stsSend.mockResolvedValue(validStsResponse)
+    s3Send.mockResolvedValue({})
+  })
+
+  it('rejects an object key with a disallowed character and does not PUT', async () => {
+    const client = newClient()
+
+    // A space is outside the AWS "safe" set.
+    const promise = client.uploadS3(settings, 'my file', '', 'folder', 'csv')
+
+    await expect(promise).rejects.toThrow(PayloadValidationError)
+    await expect(promise).rejects.toThrow('outside the allowed set')
+    // Fails fast: no role assumption and no PUT are attempted.
+    expect(stsSend).not.toHaveBeenCalled()
+    expect(s3Send).not.toHaveBeenCalled()
+  })
+
+  it('names the distinct offending characters but not the full key', async () => {
+    const client = newClient()
+
+    // Two disallowed chars ('#' and '@') plus otherwise-sensitive content.
+    const error = await client
+      .uploadS3(settings, 'user@example', '', 'reports#secret-pii', 'csv')
+      .catch((e) => e as Error)
+
+    expect(error).toBeInstanceOf(PayloadValidationError)
+    expect(error.message).toContain('"#"')
+    expect(error.message).toContain('"@"')
+    // The surrounding (potentially PII-laden) key content is not echoed.
+    expect(error.message).not.toContain('secret-pii')
+    expect(error.message).not.toContain('user@example')
+  })
+
+  it('accepts a key using the full allowed set (letters, digits, / ! - _ . * \' ( )) and PUTs', async () => {
+    const client = newClient()
+
+    const result = await client.uploadS3(settings, 'file,content', "export-file_v1.2*('ok')", 'my-folder', 'csv')
+
+    expect(result).toEqual({ statusCode: 200, message: 'Upload successful' })
+    expect(s3Send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -16,6 +16,12 @@ import { Credentials } from './types'
 // AWS enforces a hard limit of 1024 bytes (UTF-8) on S3 object keys.
 const MAX_S3_OBJECT_KEY_BYTES = 1024
 
+// AWS "safe" object-key characters (0-9 a-z A-Z and ! - _ . * ' ( )), plus '/' as the folder
+// separator. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
+// We reject keys containing anything outside this set rather than sanitizing — we never mutate
+// customer-provided keys.
+const DISALLOWED_S3_OBJECT_KEY_CHARS = /[^A-Za-z0-9!\-_.*'()/]/g
+
 export class Client {
   roleArn: string
   roleSessionName: string
@@ -99,6 +105,18 @@ export class Client {
       throw new PayloadValidationError(
         `S3 object key exceeds the AWS limit of ${MAX_S3_OBJECT_KEY_BYTES} bytes (got ${objectKeyBytes} bytes). ` +
           `Shorten the folder name and/or filename prefix.`
+      )
+    }
+
+    // Reject keys with characters outside AWS's safe set up front, rather than silently overwriting
+    // a customer's prior files (key collisions) or failing late/opaquely at the PUT.
+    const disallowed = objectKey.match(DISALLOWED_S3_OBJECT_KEY_CHARS)
+    if (disallowed) {
+      // Surface only the distinct offending characters, not the full key (it may contain PII).
+      const distinct = [...new Set(disallowed)].map((c) => JSON.stringify(c)).join(', ')
+      throw new PayloadValidationError(
+        `S3 object key contains characters outside the allowed set (A-Z a-z 0-9 / ! - _ . * ' ( )). ` +
+          `Disallowed character(s): ${distinct}. Adjust the folder name and/or filename prefix.`
       )
     }
 

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -16,16 +16,35 @@ import { Credentials } from './types'
 // AWS enforces a hard limit of 1024 bytes (UTF-8) on S3 object keys.
 const MAX_S3_OBJECT_KEY_BYTES = 1024
 
-// AWS "safe" object-key characters (0-9 a-z A-Z and ! - _ . * ' ( )), plus '/' as the folder
-// separator. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
-// We reject keys containing anything outside this set rather than sanitizing — we never mutate
-// customer-provided keys. The `u` flag makes matching operate on Unicode code points so a non-BMP
+// Single source of truth for the allowed S3 object-key characters: AWS's "safe" special characters
+// plus '/' (the folder separator), in addition to letters and digits. Both the matcher and the
+// human-readable error text below are derived from this, so they can't drift apart. See
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html. We reject keys with
+// anything outside this set rather than sanitizing — we never mutate customer-provided keys.
+const ALLOWED_S3_OBJECT_KEY_SPECIALS = "!-_.*'()/"
+
+// Matcher for disallowed characters, built from the set above (regex metacharacters escaped for use
+// in a character class). The `u` flag makes matching operate on Unicode code points, so a non-BMP
 // character (e.g. an emoji) is reported as one character, not two surrogate halves.
-const DISALLOWED_S3_OBJECT_KEY_CHARS = /[^A-Za-z0-9!\-_.*'()/]/gu
+const DISALLOWED_S3_OBJECT_KEY_CHARS = new RegExp(
+  `[^A-Za-z0-9${ALLOWED_S3_OBJECT_KEY_SPECIALS.replace(/[-\\\]^]/g, '\\$&')}]`,
+  'gu'
+)
+
+// Human-readable allowed set for the error message, also derived from the set above.
+const ALLOWED_S3_OBJECT_KEY_DESC = `A-Z a-z 0-9 ${[...ALLOWED_S3_OBJECT_KEY_SPECIALS].join(' ')}`
 
 // Cap how many distinct offending characters we list per part, so a pathological key can't bloat
 // the error message / logs.
 const MAX_REPORTED_DISALLOWED_CHARS = 10
+
+// Render a disallowed character for the error message: a printable ASCII glyph is shown as-is in
+// quotes; anything else (space, control characters, non-ASCII, emoji) as U+XXXX so the message
+// stays readable and grep-able regardless of the character.
+function describeDisallowedChar(ch: string): string {
+  const cp = ch.codePointAt(0) ?? 0
+  return cp > 0x20 && cp < 0x7f ? `'${ch}'` : `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`
+}
 
 export class Client {
   roleArn: string
@@ -127,16 +146,16 @@ export class Client {
         const bad = value.match(DISALLOWED_S3_OBJECT_KEY_CHARS)
         if (!bad) return null
         const distinct = [...new Set(bad)]
-        const shown = distinct.slice(0, MAX_REPORTED_DISALLOWED_CHARS).map((c) => JSON.stringify(c))
+        const shown = distinct.slice(0, MAX_REPORTED_DISALLOWED_CHARS).map(describeDisallowedChar)
         const more = distinct.length - shown.length
-        const list = more > 0 ? `${shown.join(', ')}, …and ${more} more` : shown.join(', ')
+        const list = more > 0 ? `${shown.join(', ')}, ...and ${more} more` : shown.join(', ')
         return `${label} has disallowed character(s): ${list}`
       })
       .filter((entry): entry is string => entry !== null)
 
     if (offending.length > 0) {
       throw new PayloadValidationError(
-        `S3 object key contains characters outside the allowed set (A-Z a-z 0-9 / ! - _ . * ' ( )). ` +
+        `S3 object key contains characters outside the allowed set (${ALLOWED_S3_OBJECT_KEY_DESC}). ` +
           `${offending.join('; ')}.`
       )
     }

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -19,8 +19,13 @@ const MAX_S3_OBJECT_KEY_BYTES = 1024
 // AWS "safe" object-key characters (0-9 a-z A-Z and ! - _ . * ' ( )), plus '/' as the folder
 // separator. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html.
 // We reject keys containing anything outside this set rather than sanitizing — we never mutate
-// customer-provided keys.
-const DISALLOWED_S3_OBJECT_KEY_CHARS = /[^A-Za-z0-9!\-_.*'()/]/g
+// customer-provided keys. The `u` flag makes matching operate on Unicode code points so a non-BMP
+// character (e.g. an emoji) is reported as one character, not two surrogate halves.
+const DISALLOWED_S3_OBJECT_KEY_CHARS = /[^A-Za-z0-9!\-_.*'()/]/gu
+
+// Cap how many distinct offending characters we list per part, so a pathological key can't bloat
+// the error message / logs.
+const MAX_REPORTED_DISALLOWED_CHARS = 10
 
 export class Client {
   roleArn: string
@@ -120,9 +125,12 @@ export class Client {
     )
       .map(([label, value]) => {
         const bad = value.match(DISALLOWED_S3_OBJECT_KEY_CHARS)
-        return bad
-          ? `${label} has disallowed character(s): ${[...new Set(bad)].map((c) => JSON.stringify(c)).join(', ')}`
-          : null
+        if (!bad) return null
+        const distinct = [...new Set(bad)]
+        const shown = distinct.slice(0, MAX_REPORTED_DISALLOWED_CHARS).map((c) => JSON.stringify(c))
+        const more = distinct.length - shown.length
+        const list = more > 0 ? `${shown.join(', ')}, …and ${more} more` : shown.join(', ')
+        return `${label} has disallowed character(s): ${list}`
       })
       .filter((entry): entry is string => entry !== null)
 

--- a/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
+++ b/packages/destination-actions/src/destinations/s3/syncToS3/client.ts
@@ -109,14 +109,27 @@ export class Client {
     }
 
     // Reject keys with characters outside AWS's safe set up front, rather than silently overwriting
-    // a customer's prior files (key collisions) or failing late/opaquely at the PUT.
-    const disallowed = objectKey.match(DISALLOWED_S3_OBJECT_KEY_CHARS)
-    if (disallowed) {
-      // Surface only the distinct offending characters, not the full key (it may contain PII).
-      const distinct = [...new Set(disallowed)].map((c) => JSON.stringify(c)).join(', ')
+    // a customer's prior files (key collisions) or failing late/opaquely at the PUT. Point at the
+    // specific input(s) at fault and their distinct bad characters, but never echo the full value —
+    // it may contain PII.
+    const offending = (
+      [
+        ['folder name', folderName],
+        ['filename prefix', filename_prefix]
+      ] as const
+    )
+      .map(([label, value]) => {
+        const bad = value.match(DISALLOWED_S3_OBJECT_KEY_CHARS)
+        return bad
+          ? `${label} has disallowed character(s): ${[...new Set(bad)].map((c) => JSON.stringify(c)).join(', ')}`
+          : null
+      })
+      .filter((entry): entry is string => entry !== null)
+
+    if (offending.length > 0) {
       throw new PayloadValidationError(
         `S3 object key contains characters outside the allowed set (A-Z a-z 0-9 / ! - _ . * ' ( )). ` +
-          `Disallowed character(s): ${distinct}. Adjust the folder name and/or filename prefix.`
+          `${offending.join('; ')}.`
       )
     }
 


### PR DESCRIPTION
## STRATCONN-7017 — s3 `syncToS3`: validate S3 object key character set

Child of epic **STRATCONN-6986** (actions-s3 GA). Complements **STRATCONN-6990** (key *length* guard) with *character-set* validation.

### 🔍 Why
The S3 object key is built as `s3_aws_folder_name + filename_prefix` (`client.ts`) with **no character validation** — and `s3_aws_folder_name` has zero input restrictions. A key containing characters outside AWS's safe set risks **silent key-collision overwrites** of a customer's prior files, or an opaque late failure at the PUT. Raised in the actions-s3 GA review ([doc](https://docs.google.com/document/d/1BxRnSbsiLKmt5tgZ_kT4VXM4p0NuMGrXY-_ngL-5vGQ/edit)) and [Slack thread](https://twilio.slack.com/archives/C0BUCQL3YJW/p1788941013067049?thread_ts=1788844407.710689&cid=C0BUCQL3YJW).

### 🛠 The change
Reject — never sanitize — an object key that contains characters outside AWS's [safe object-key set](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html):

- **Allowed:** `A-Z a-z 0-9` and `! - _ . * ' ( )`, **plus `/`** (folder separator).
- Anything else throws a non-retryable `PayloadValidationError`, **before** any role assumption or PUT.
- The error names the **distinct offending characters** but **never echoes the full key** (may contain PII), consistent with the length guard.
- **We do not mutate customer-provided keys** — if a customer wants transformation, they can do it explicitly in the mapping. This only enforces validity.

### 🧭 Design decisions (from the thread)
- **Strict "safe" set + `/`** (not the looser "reject only avoid-chars" option) — cleanest keys, and the folder separator stays usable.
- **Hard validation, no feature flag** — consistent with how the 6990 length guard shipped. Note this can reject object keys some customers send today; that's the intended behavior (fail loudly instead of silently colliding), but flagging is the fallback if we want a softer rollout.

### 🧪 Tests
Added an `uploadS3 object key character validation` suite:
- rejects a key with a disallowed character (space) and does **not** assume-role or PUT;
- names the distinct offending chars (`#`, `@`) without echoing the surrounding key content;
- accepts a key using the full allowed set (`/ ! - _ . * ' ( )`) and proceeds to PUT.

#### E2E UI test

Valid character tests:

<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/6181c965-22b7-49a8-b05f-fa9dd23d2f5e" />
<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/f3326401-d46b-41e2-9e55-5b8d9344e0d1" />

Invalid case test:
<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/e633ba7b-a792-4733-88fe-82f7dddf6bec" />
<img width="2992" height="1700" alt="image" src="https://github.com/user-attachments/assets/55ea4a2d-b4b2-468b-b6fa-9ae93769e8b9" />



### ✅ Verification
- ✅ `tsc --noEmit` — clean
- ✅ `eslint` — clean
- ✅ Regex behavior sanity-checked directly in node (safe keys pass; space/`#`/`@`/`{}`/`=`/`&` rejected)
- ⚠️ Jest not run locally (pre-existing jest version skew in this workspace + unreachable internal registry); **CI will execute the tests.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)