### PR TITLE
STRATCONN-6978 - [Amazon Conversions Api] - fix perform() silently reporting HTTP errors as success

### DIFF
--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/index.test.ts
@@ -8,6 +8,9 @@ const testDestination = createTestIntegration(Destination)
 describe('trackConversion', () => {
     beforeEach(() => {
         nock.cleanAll()
+        // testAction only drains `responses` on the non-throwing path, so a test that expects
+        // a rejection can leak a stale response into the next test. Reset explicitly.
+        testDestination.responses = []
     })
 
     const event = createTestEvent({
@@ -81,6 +84,57 @@ describe('trackConversion', () => {
                         timestamp: '2023-01-01T12:00:00Z',
                         matchKeys: {
                             email: 'invalid_email'
+                        },
+                        enable_batching: true
+                    }
+                })
+            ).rejects.toThrow()
+        })
+
+        // Documents today's (buggy) default behavior. Remove this test once the
+        // actions-amazon-conversions-api-throw-http-errors flag is fully rolled out and removed.
+        it('should NOT throw on a non-2xx response when the throw-http-errors flag is off (default)', async () => {
+            nock(`${Region.NA}`)
+                .post('/adsApi/v1/create/events')
+                .reply(401, { message: 'Unauthorized exception while handling 3P Request: Invalid token' })
+
+            const responses = await testDestination.testAction('trackConversion', {
+                event,
+                settings,
+                mapping: {
+                    name: 'test_conversion',
+                    eventType: 'ADD_TO_SHOPPING_CART',
+                    eventActionSource: 'website',
+                    countryCode: 'US',
+                    timestamp: '2023-01-01T12:00:00Z',
+                    matchKeys: {
+                        email: 'test@example.com'
+                    },
+                    enable_batching: true
+                }
+            })
+
+            expect(responses.length).toBeGreaterThan(0)
+        })
+
+        it('should throw on a 401 response when the throw-http-errors flag is on', async () => {
+            nock(`${Region.NA}`)
+                .post('/adsApi/v1/create/events')
+                .reply(401, { message: 'Unauthorized exception while handling 3P Request: Invalid token' })
+
+            await expect(
+                testDestination.testAction('trackConversion', {
+                    event,
+                    settings,
+                    features: { 'actions-amazon-conversions-api-throw-http-errors': true },
+                    mapping: {
+                        name: 'test_conversion',
+                        eventType: 'ADD_TO_SHOPPING_CART',
+                        eventActionSource: 'website',
+                        countryCode: 'US',
+                        timestamp: '2023-01-01T12:00:00Z',
+                        matchKeys: {
+                            email: 'test@example.com'
                         },
                         enable_batching: true
                     }

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
 import { Region } from '../../types'
+import { FLAGON_THROW_HTTP_ERRORS } from '../utils'
 
 const testDestination = createTestIntegration(Destination)
 
@@ -115,6 +116,7 @@ describe('trackConversion', () => {
             })
 
             expect(responses.length).toBeGreaterThan(0)
+            expect(responses[0].status).toBe(401)
         })
 
         it('should throw on a 401 response when the throw-http-errors flag is on', async () => {
@@ -126,7 +128,7 @@ describe('trackConversion', () => {
                 testDestination.testAction('trackConversion', {
                     event,
                     settings,
-                    features: { 'actions-amazon-conversions-api-throw-http-errors': true },
+                    features: { [FLAGON_THROW_HTTP_ERRORS]: true },
                     mapping: {
                         name: 'test_conversion',
                         eventType: 'ADD_TO_SHOPPING_CART',

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/__tests__/utils.test.ts
@@ -250,7 +250,7 @@ describe('trackConversion utils', () => {
       )
     })
 
-    it('should respect throwHttpErrors value always being false', async () => {
+    it('should default throwHttpErrors to false when not specified', async () => {
       nock(settings.region).post('/adsApi/v1/create/events').reply(400, { error: 'Bad Request' })
 
       const mockRequest = jest.fn().mockResolvedValue({
@@ -264,6 +264,24 @@ describe('trackConversion utils', () => {
         expect.any(String),
         expect.objectContaining({
           throwHttpErrors: false
+        })
+      )
+
+      mockRequest.mockClear()
+    })
+
+    it('should pass throwHttpErrors: true through when explicitly requested', async () => {
+      const mockRequest = jest.fn().mockResolvedValue({
+        status: 200,
+        data: { success: true }
+      })
+
+      await sendEventsRequest(mockRequest as unknown as RequestClient, settings, eventData, true)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          throwHttpErrors: true
         })
       )
 

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/index.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/index.ts
@@ -2,7 +2,13 @@ import { ActionDefinition, MultiStatusResponse } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import type { EventData, EventMultiStatusResponse } from '../types'
-import { sendEventsRequest, handleBatchResponse, prepareEventData, handleResponse } from './utils'
+import {
+  sendEventsRequest,
+  handleBatchResponse,
+  prepareEventData,
+  handleResponse,
+  FLAGON_THROW_HTTP_ERRORS
+} from './utils'
 import { fields } from './fields'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -11,9 +17,13 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields,
 
-  perform: async (request, { payload, settings }) => {
+  perform: async (request, { payload, settings, features }) => {
     const eventData = prepareEventData(payload, settings)
-    const response = await sendEventsRequest<EventMultiStatusResponse>(request, settings, eventData)
+    // STRATCONN-6978: behind this flag, a non-2xx response throws instead of being silently
+    // reported as a successful delivery, restoring the pre-existing OAuth re-auth/retry path.
+    // performBatch is intentionally unaffected - it already handles this correctly.
+    const throwHttpErrors = Boolean(features?.[FLAGON_THROW_HTTP_ERRORS])
+    const response = await sendEventsRequest<EventMultiStatusResponse>(request, settings, eventData, throwHttpErrors)
     return handleResponse(response)
   },
 

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -27,6 +27,13 @@ import type { Payload } from './generated-types'
 import { AMAZON_CONVERSIONS_API_EVENTS_VERSION } from '../versioning-info'
 
 /**
+ * Feature flag gating the fix for the single-event (`perform`) path silently reporting
+ * HTTP errors (including 401s that should trigger an OAuth re-auth) as successful deliveries.
+ * See STRATCONN-6978. Does not affect `performBatch`, which already throws correctly.
+ */
+export const FLAGON_THROW_HTTP_ERRORS = 'actions-amazon-conversions-api-throw-http-errors'
+
+/**
  * Helper function to validate if a string value exists and is not empty
  *
  * @param value The string value to validate
@@ -139,7 +146,8 @@ export function smartHash(value: string, normalizeFunction?: (value: string) => 
 export async function sendEventsRequest<ImportConversionEventsResponse>(
   request: RequestClient,
   settings: Settings,
-  eventData: EventData | EventData[]
+  eventData: EventData | EventData[],
+  throwHttpErrors = false
 ): Promise<ModifiedResponse<ImportConversionEventsResponse>> {
   // Ensure eventData is always an array
   const events = Array.isArray(eventData) ? eventData : [eventData]
@@ -155,7 +163,7 @@ export async function sendEventsRequest<ImportConversionEventsResponse>(
         'Amazon-Ads-AccountId': settings.advertiserId,
         'Amazon-Ads-ClientId': process.env.ACTIONS_AMAZON_CONVERSIONS_API_CLIENT_ID || ''
       },
-      throwHttpErrors: false
+      throwHttpErrors
     }
   )
 }

--- a/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
+++ b/packages/destination-actions/src/destinations/amazon-conversions-api/trackConversion/utils.ts
@@ -29,7 +29,9 @@ import { AMAZON_CONVERSIONS_API_EVENTS_VERSION } from '../versioning-info'
 /**
  * Feature flag gating the fix for the single-event (`perform`) path silently reporting
  * HTTP errors (including 401s that should trigger an OAuth re-auth) as successful deliveries.
- * See STRATCONN-6978. Does not affect `performBatch`, which already throws correctly.
+ * See STRATCONN-6978. Does not affect `performBatch`, which already preserves the real
+ * non-2xx/207 status in the returned `MultiStatusResponse` so core's retry/reauth logic
+ * can act on it.
  */
 export const FLAGON_THROW_HTTP_ERRORS = 'actions-amazon-conversions-api-throw-http-errors'
 


### PR DESCRIPTION
Fixes a deliverability bug for non batch code path for the Amazon Conversions API destination.  

`perform()` (single-event, non-batch path) calls Amazon's Events API with `throwHttpErrors: false` and never inspects the response status. A real HTTP error (e.g. an expired-token 401) is therefore recorded as `"Action Executed"` (success) in Segment's event-delivery UI, and the framework's existing 401->reauth logic never fires since nothing throws.

`performBatch()` does not have this problem — its non-207 branch already preserves the real status into the returned `MultiStatusResponse`, which core's retry/reauth logic reads correctly.

Confirmed live against Amazon's API with a real expired token + refresh token: single-event path silently 'succeeds', batch path correctly retries and recovers.

## Fix
Behind a feature flag (`actions-amazon-conversions-api-throw-http-errors`, default off):
- `perform()` now passes `throwHttpErrors: true` to `sendEventsRequest`
- `performBatch()` is untouched — it already works correctly.

## Testing
- Added unit tests covering flag on/off behavior for `perform()`.
- Full `amazon-conversions-api` suite passes (1257/1257 suites).
- Live-tested against real Amazon API with an expired token (see STRATCONN-6978 for details).
- Full proof-of-testing (live staging traces for both perform() and performBatch(), flag on/off): https://docs.google.com/document/d/1N1u0OS8h-ITEFzQiK4H8Ke1LRctUrWTEe6w3nibwzcE/edit?tab=t.5tb3jyoqeqib

Ref: STRATCONN-6978