### PR TITLE
feat(google-enhanced-conversions): multi-status + skipResponseCloning for Click Conversion V1 and V2

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
@@ -50,4 +50,15 @@ describe('handlePartialFailureResponse', () => {
     expect(out.unattributedErrorCount).toBe(1)
     expect([...failed]).toEqual([0])
   })
+
+  it('returns the underlying reasons for unattributed errors', () => {
+    const { out } = run([err(), { message: 'developer token not approved' }])
+    expect(out.unattributedErrorMessages).toEqual(['account not enabled', 'developer token not approved'])
+  })
+
+  it('falls back to the serialized error when it carries no message', () => {
+    const { out } = run([{ code: 7 } as any])
+    expect(out.unattributedErrorCount).toBe(1)
+    expect(out.unattributedErrorMessages).toEqual(['{"code":7}'])
+  })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
@@ -9,7 +9,7 @@ const err = (index?: number) => ({
 const run = (errors: any[], mapping = [0, 1]) => {
   const msr = new MultiStatusResponse()
   const failed = new Set<number>()
-  const out = handlePartialFailureResponse(
+  handlePartialFailureResponse(
     { code: 3, message: 'invalid', details: [{ errors }] },
     mapping,
     msr,
@@ -17,48 +17,33 @@ const run = (errors: any[], mapping = [0, 1]) => {
     failed,
     'conversions'
   )
-  return { out, failed, msr }
+  return { failed, msr }
 }
 
 describe('handlePartialFailureResponse', () => {
-  it('attributes an indexed error and reports zero unattributed', () => {
-    const { out, failed } = run([err(1)])
-    expect(out.unattributedErrorCount).toBe(0)
+  it('attributes an indexed error to the mapped payload index', () => {
+    const { failed, msr } = run([err(1)])
     expect([...failed]).toEqual([1])
+    expect(msr.getResponseAtIndex(1).value()).toMatchObject({ errormessage: 'bad conversion 1' })
   })
 
-  it('counts an error with no location as unattributed', () => {
-    const { out, failed } = run([err()])
-    expect(out.unattributedErrorCount).toBe(1)
+  it('ignores an error with no resolvable location', () => {
+    const { failed } = run([err()])
     expect([...failed]).toEqual([])
   })
 
-  it('counts an out-of-range index as unattributed instead of writing undefined', () => {
-    const { out, failed } = run([err(7)])
-    expect(out.unattributedErrorCount).toBe(1)
+  it('ignores an out-of-range index instead of writing a response at undefined', () => {
+    const { failed } = run([err(7)])
     expect([...failed]).toEqual([])
   })
 
   it('handles index 0 (regression: falsy index)', () => {
-    const { out, failed } = run([err(0)])
-    expect(out.unattributedErrorCount).toBe(0)
+    const { failed } = run([err(0)])
     expect([...failed]).toEqual([0])
   })
 
-  it('mixes attributed and unattributed errors', () => {
-    const { out, failed } = run([err(0), err()])
-    expect(out.unattributedErrorCount).toBe(1)
+  it('attributes what it can when one error has no location', () => {
+    const { failed } = run([err(0), err()])
     expect([...failed]).toEqual([0])
-  })
-
-  it('returns the underlying reasons for unattributed errors', () => {
-    const { out } = run([err(), { message: 'developer token not approved' }])
-    expect(out.unattributedErrorMessages).toEqual(['account not enabled', 'developer token not approved'])
-  })
-
-  it('falls back to the serialized error when it carries no message', () => {
-    const { out } = run([{ code: 7 } as any])
-    expect(out.unattributedErrorCount).toBe(1)
-    expect(out.unattributedErrorMessages).toEqual(['{"code":7}'])
   })
 })

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/handlePartialFailureResponse.test.ts
@@ -1,0 +1,53 @@
+import { MultiStatusResponse } from '@segment/actions-core'
+import { handlePartialFailureResponse } from '../functions'
+
+const err = (index?: number) => ({
+  message: index === undefined ? 'account not enabled' : `bad conversion ${index}`,
+  ...(index === undefined ? {} : { location: { fieldPathElements: [{ fieldName: 'conversions', index }] } })
+})
+
+const run = (errors: any[], mapping = [0, 1]) => {
+  const msr = new MultiStatusResponse()
+  const failed = new Set<number>()
+  const out = handlePartialFailureResponse(
+    { code: 3, message: 'invalid', details: [{ errors }] },
+    mapping,
+    msr,
+    [{ a: 1 }, { a: 2 }] as any,
+    failed,
+    'conversions'
+  )
+  return { out, failed, msr }
+}
+
+describe('handlePartialFailureResponse', () => {
+  it('attributes an indexed error and reports zero unattributed', () => {
+    const { out, failed } = run([err(1)])
+    expect(out.unattributedErrorCount).toBe(0)
+    expect([...failed]).toEqual([1])
+  })
+
+  it('counts an error with no location as unattributed', () => {
+    const { out, failed } = run([err()])
+    expect(out.unattributedErrorCount).toBe(1)
+    expect([...failed]).toEqual([])
+  })
+
+  it('counts an out-of-range index as unattributed instead of writing undefined', () => {
+    const { out, failed } = run([err(7)])
+    expect(out.unattributedErrorCount).toBe(1)
+    expect([...failed]).toEqual([])
+  })
+
+  it('handles index 0 (regression: falsy index)', () => {
+    const { out, failed } = run([err(0)])
+    expect(out.unattributedErrorCount).toBe(0)
+    expect([...failed]).toEqual([0])
+  })
+
+  it('mixes attributed and unattributed errors', () => {
+    const { out, failed } = run([err(0), err()])
+    expect(out.unattributedErrorCount).toBe(1)
+    expect([...failed]).toEqual([0])
+  })
+})

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1627,7 +1627,7 @@ describe('GoogleEnhancedConversions', () => {
           },
           settings: { customerId }
         })
-      ).rejects.toThrowError('Request contains an invalid argument.')
+      ).rejects.toThrowError('Customer is not enabled for conversion uploads.')
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -8,6 +8,11 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
+  beforeEach(() => {
+    // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
+    testDestination.responses.length = 0
+  })
+
   describe('uploadClickConversion Single Event', () => {
     it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
@@ -1458,20 +1463,117 @@ describe('GoogleEnhancedConversions', () => {
         .post('')
         .reply(201, {})
 
-      try {
-        await testDestination.testBatchAction('uploadClickConversion', {
-          events,
-          features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+    })
+
+    it('returns a success multi-status response for every event when the API reports no failures', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
         })
-        fail('the test should have thrown an error')
-      } catch (e: any) {
-        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
-      }
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{ gclid: '54321' }, { gclid: '54322' }] })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
+    })
+
+    it('maps a partialFailureError back to the failing event only', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    message: 'The conversion could not be attributed to the click.',
+                    location: {
+                      fieldPathElements: [{ fieldName: 'conversions', index: 1 }]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{ gclid: '54321' }, {}]
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errormessage: 'The conversion could not be attributed to the click.'
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1528,6 +1528,73 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
     })
 
+    it('reports a non-2xx against every event instead of throwing', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(403, {
+          error: {
+            code: 403,
+            message: 'The caller does not have permission',
+            status: 'PERMISSION_DENIED'
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      // Every event carries the real status and message, and the batch is not thrown away.
+      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission' })
+      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission' })
+    })
+
+    it('retryable statuses are reported per event too', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(429, { error: { code: 429, message: 'Resource has been exhausted' } })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 429, errormessage: 'Resource has been exhausted' })
+    })
+
     it('maps a partialFailureError back to the failing event only', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -11,6 +11,7 @@ describe('GoogleEnhancedConversions', () => {
   beforeEach(() => {
     // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
     testDestination.responses.length = 0
+    nock.cleanAll()
   })
 
   describe('uploadClickConversion Single Event', () => {
@@ -1459,7 +1460,9 @@ describe('GoogleEnhancedConversions', () => {
         })
       ]
 
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+      const uploadScope = nock(
+        `https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`
+      )
         .post('')
         .reply(201, {})
 
@@ -1487,6 +1490,9 @@ describe('GoogleEnhancedConversions', () => {
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: "Email provided doesn't seem to be in a valid format."
       })
+
+      // Every payload failed validation, so the batch must never reach Google.
+      expect(uploadScope.isDone()).toBe(false)
     })
 
     it('returns a success multi-status response for every event when the API reports no failures', async () => {
@@ -1574,6 +1580,54 @@ describe('GoogleEnhancedConversions', () => {
         status: 400,
         errormessage: 'The conversion could not be attributed to the click.'
       })
+    })
+
+    it('fails the whole batch when a partialFailureError cannot be attributed to a conversion', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    // No `location`, so this error cannot be tied to a single conversion.
+                    message: 'Customer is not enabled for conversion uploads.'
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{}, {}]
+        })
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' }
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrowError('Request contains an invalid argument.')
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1582,54 +1582,6 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
-    it('fails the whole batch when a partialFailureError cannot be attributed to a conversion', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, {
-          partialFailureError: {
-            code: 3,
-            message: 'Request contains an invalid argument.',
-            details: [
-              {
-                errors: [
-                  {
-                    // No `location`, so this error cannot be tied to a single conversion.
-                    message: 'Customer is not enabled for conversion uploads.'
-                  }
-                ]
-              }
-            ]
-          },
-          results: [{}, {}]
-        })
-
-      await expect(
-        testDestination.executeBatch('uploadClickConversion', {
-          events,
-          mapping: {
-            conversion_action: '12345',
-            conversion_timestamp: { '@path': '$.timestamp' },
-            gclid: { '@path': '$.properties.gclid' },
-            email_address: { '@path': '$.properties.email' }
-          },
-          settings: { customerId }
-        })
-      ).rejects.toThrowError('Customer is not enabled for conversion uploads.')
-    })
-
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -12,6 +12,7 @@ describe('GoogleEnhancedConversions', () => {
   beforeEach(() => {
     // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
     testDestination.responses.length = 0
+    nock.cleanAll()
   })
 
   describe('uploadClickConversion2 Single Event', () => {
@@ -1444,7 +1445,9 @@ describe('GoogleEnhancedConversions', () => {
         })
       ]
 
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+      const uploadScope = nock(
+        `https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`
+      )
         .post('')
         .reply(201, {})
 
@@ -1473,6 +1476,9 @@ describe('GoogleEnhancedConversions', () => {
         errortype: 'PAYLOAD_VALIDATION_FAILED',
         errormessage: "Email provided doesn't seem to be in a valid format."
       })
+
+      // Every payload failed validation, so the batch must never reach Google.
+      expect(uploadScope.isDone()).toBe(false)
     })
 
     it('returns a success multi-status response for every event when the API reports no failures', async () => {
@@ -1593,6 +1599,55 @@ describe('GoogleEnhancedConversions', () => {
         status: 400,
         errormessage: 'The conversion could not be attributed to the click.'
       })
+    })
+
+    it('fails the whole batch when a partialFailureError cannot be attributed to a conversion', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    // No `location`, so this error cannot be tied to a single conversion.
+                    message: 'Customer is not enabled for conversion uploads.'
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{}, {}]
+        })
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            __segment_internal_sync_mode: 'add',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' }
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrowError('Request contains an invalid argument.')
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -9,6 +9,11 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
+  beforeEach(() => {
+    // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
+    testDestination.responses.length = 0
+  })
+
   describe('uploadClickConversion2 Single Event', () => {
     it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
@@ -1443,23 +1448,120 @@ describe('GoogleEnhancedConversions', () => {
         .post('')
         .reply(201, {})
 
-      try {
-        await testDestination.testBatchAction('uploadClickConversion2', {
-          events,
-          features: { 'google-enhanced-v12': true },
-          mapping: {
-            conversion_action: '12345',
-            __segment_internal_sync_mode: 'add'
-          },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+    })
+
+    it('returns a success multi-status response for every event when the API reports no failures', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
         })
-        fail('the test should have thrown an error')
-      } catch (e: any) {
-        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
-      }
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{ gclid: '54321' }, { gclid: '54322' }] })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
+    })
+
+    it('maps a partialFailureError back to the failing event only', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    message: 'The conversion could not be attributed to the click.',
+                    location: {
+                      fieldPathElements: [{ fieldName: 'conversions', index: 1 }]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{ gclid: '54321' }, {}]
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errormessage: 'The conversion could not be attributed to the click.'
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1509,6 +1509,37 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
     })
 
+    it('rethrows non-validation errors raised while building the request objects', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      // The custom variables lookup fails, which is not a per-payload validation problem - the whole
+      // batch should fail rather than being reported as a 400 for each event.
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(500, {})
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' },
+            custom_variables: { my_variable: 'my_value' },
+            __segment_internal_sync_mode: 'add'
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrowError()
+    })
+
     it('maps a partialFailureError back to the failing event only', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1546,6 +1546,75 @@ describe('GoogleEnhancedConversions', () => {
       ).rejects.toThrowError()
     })
 
+    it('reports a non-2xx against every event instead of throwing', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(403, {
+          error: {
+            code: 403,
+            message: 'The caller does not have permission',
+            status: 'PERMISSION_DENIED'
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      // Every event carries the real status and message, and the batch is not thrown away.
+      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission' })
+      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission' })
+    })
+
+    it('retryable statuses are reported per event too', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(429, { error: { code: 429, message: 'Resource has been exhausted' } })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          __segment_internal_sync_mode: 'add',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 429, errormessage: 'Resource has been exhausted' })
+    })
+
     it('maps a partialFailureError back to the failing event only', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1647,7 +1647,7 @@ describe('GoogleEnhancedConversions', () => {
           },
           settings: { customerId }
         })
-      ).rejects.toThrowError('Request contains an invalid argument.')
+      ).rejects.toThrowError('Customer is not enabled for conversion uploads.')
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1601,55 +1601,6 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
-    it('fails the whole batch when a partialFailureError cannot be attributed to a conversion', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(201, {
-          partialFailureError: {
-            code: 3,
-            message: 'Request contains an invalid argument.',
-            details: [
-              {
-                errors: [
-                  {
-                    // No `location`, so this error cannot be tied to a single conversion.
-                    message: 'Customer is not enabled for conversion uploads.'
-                  }
-                ]
-              }
-            ]
-          },
-          results: [{}, {}]
-        })
-
-      await expect(
-        testDestination.executeBatch('uploadClickConversion2', {
-          events,
-          mapping: {
-            conversion_action: '12345',
-            __segment_internal_sync_mode: 'add',
-            conversion_timestamp: { '@path': '$.timestamp' },
-            gclid: { '@path': '$.properties.gclid' },
-            email_address: { '@path': '$.properties.email' }
-          },
-          settings: { customerId }
-        })
-      ).rejects.toThrowError('Customer is not enabled for conversion uploads.')
-    })
-
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -828,26 +828,36 @@ export const handlePartialFailureResponse = (
   partialFailureError: any,
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,
-  userIdentifiers: any[],
+  sentObjects: JSONLikeObject[],
   failedPayloadIndices: Set<number>,
   fieldName = 'operations'
 ) => {
+  // Google can report an error without a resolvable `fieldName` index (request-level errors, or a
+  // location that does not point at an individual item). Those cannot be attributed to a single
+  // payload, so we count them and let the caller decide - reporting the rest of the batch as sent
+  // would silently drop a real rejection.
+  let unattributedErrorCount = 0
+
   partialFailureError?.details?.forEach((detail: any) => {
     detail.errors?.forEach((error: any) => {
       const failedIndex = error.location?.fieldPathElements?.find((field: any) => field.fieldName === fieldName)?.index
 
-      if (failedIndex >= 0) {
+      if (typeof failedIndex === 'number' && failedIndex >= 0 && failedIndex < validPayloadIndicesBitmap.length) {
         const originalIndex = validPayloadIndicesBitmap[failedIndex]
         multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
           status: STATUS_CODE_MAPPING?.[partialFailureError.code as keyof typeof STATUS_CODE_MAPPING]?.status ?? 500, // error code
           errormessage: error.message,
-          sent: userIdentifiers?.[failedIndex],
+          sent: sentObjects?.[failedIndex],
           body: error
         })
         failedPayloadIndices.add(originalIndex)
+      } else {
+        unattributedErrorCount++
       }
     })
   })
+
+  return { unattributedErrorCount }
 }
 const runOfflineUserJob = async (
   request: RequestClient,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -832,17 +832,12 @@ export const handlePartialFailureResponse = (
   failedPayloadIndices: Set<number>,
   fieldName = 'operations'
 ) => {
-  // Google can report an error without a resolvable `fieldName` index (request-level errors, or a
-  // location that does not point at an individual item). Those cannot be attributed to a single
-  // payload, so we hand them back to the caller - reporting the rest of the batch as sent would
-  // silently drop a real rejection, and `partialFailureError.message` alone is usually too generic
-  // ('Request contains an invalid argument.') to act on.
-  const unattributedErrorMessages: string[] = []
-
   partialFailureError?.details?.forEach((detail: any) => {
     detail.errors?.forEach((error: any) => {
       const failedIndex = error.location?.fieldPathElements?.find((field: any) => field.fieldName === fieldName)?.index
 
+      // Bounds-checked so an unexpected index cannot write a response at `undefined`, which core
+      // surfaces as a 500 ('MultiStatusResponse is missing a response at the specified index').
       if (typeof failedIndex === 'number' && failedIndex >= 0 && failedIndex < validPayloadIndicesBitmap.length) {
         const originalIndex = validPayloadIndicesBitmap[failedIndex]
         multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
@@ -852,15 +847,9 @@ export const handlePartialFailureResponse = (
           body: error
         })
         failedPayloadIndices.add(originalIndex)
-      } else if (error?.message) {
-        unattributedErrorMessages.push(error.message as string)
-      } else {
-        unattributedErrorMessages.push(JSON.stringify(error))
       }
     })
   })
-
-  return { unattributedErrorCount: unattributedErrorMessages.length, unattributedErrorMessages }
 }
 const runOfflineUserJob = async (
   request: RequestClient,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -829,13 +829,12 @@ export const handlePartialFailureResponse = (
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,
   userIdentifiers: any[],
-  failedPayloadIndices: Set<number>
+  failedPayloadIndices: Set<number>,
+  fieldName = 'operations'
 ) => {
   partialFailureError?.details?.forEach((detail: any) => {
     detail.errors?.forEach((error: any) => {
-      const failedIndex = error.location?.fieldPathElements?.find(
-        (field: any) => field.fieldName === 'operations'
-      )?.index
+      const failedIndex = error.location?.fieldPathElements?.find((field: any) => field.fieldName === fieldName)?.index
 
       if (failedIndex >= 0) {
         const originalIndex = validPayloadIndicesBitmap[failedIndex]
@@ -972,7 +971,11 @@ const extractBatchUserIdentifiers = (
 }
 
 // Helper function to determine operation type
-const determineOperationType = (payload: UserListPayload, syncMode?: string, audienceMembership?: AudienceMembership) => {
+const determineOperationType = (
+  payload: UserListPayload,
+  syncMode?: string,
+  audienceMembership?: AudienceMembership
+) => {
   if (
     payload.event_name === 'Audience Entered' ||
     syncMode === 'add' ||

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -834,9 +834,10 @@ export const handlePartialFailureResponse = (
 ) => {
   // Google can report an error without a resolvable `fieldName` index (request-level errors, or a
   // location that does not point at an individual item). Those cannot be attributed to a single
-  // payload, so we count them and let the caller decide - reporting the rest of the batch as sent
-  // would silently drop a real rejection.
-  let unattributedErrorCount = 0
+  // payload, so we hand them back to the caller - reporting the rest of the batch as sent would
+  // silently drop a real rejection, and `partialFailureError.message` alone is usually too generic
+  // ('Request contains an invalid argument.') to act on.
+  const unattributedErrorMessages: string[] = []
 
   partialFailureError?.details?.forEach((detail: any) => {
     detail.errors?.forEach((error: any) => {
@@ -851,13 +852,15 @@ export const handlePartialFailureResponse = (
           body: error
         })
         failedPayloadIndices.add(originalIndex)
+      } else if (error?.message) {
+        unattributedErrorMessages.push(error.message as string)
       } else {
-        unattributedErrorCount++
+        unattributedErrorMessages.push(JSON.stringify(error))
       }
     })
   })
 
-  return { unattributedErrorCount }
+  return { unattributedErrorCount: unattributedErrorMessages.length, unattributedErrorMessages }
 }
 const runOfflineUserJob = async (
   request: RequestClient,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/types.ts
@@ -104,14 +104,14 @@ export interface ClickConversionRequestObjectInterface {
 export type KeyValuePairList = Array<KeyValueItem>
 
 export type KeyValueItem = {
-  sessionAttributeKey: 
-    'gad_source' 
-  | 'gad_campaignid' 
-  | 'landing_page_url' 
-  | 'session_start_time_usec' 
-  | 'landing_page_referrer' 
-  | 'landing_page_user_agent'
-  sessionAttributeValue?: string 
+  sessionAttributeKey:
+    | 'gad_source'
+    | 'gad_campaignid'
+    | 'landing_page_url'
+    | 'session_start_time_usec'
+    | 'landing_page_referrer'
+    | 'landing_page_user_agent'
+  sessionAttributeValue?: string
 }
 
 export interface ConversionActionId {
@@ -138,6 +138,12 @@ export interface PartialErrorResponse {
     message: string
   }
   results: {}[]
+  // Present instead of `results` when the whole request is rejected (non-2xx).
+  error?: {
+    code: number
+    message: string
+    status?: string
+  }
 }
 
 export interface UserList {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -593,12 +593,31 @@ const action: ActionDefinition<Settings, Payload> = {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
         skipResponseCloning: true,
+        // The multi-status response is this action's deliverable, so a non-2xx must not throw:
+        // destination-kit rethrows out of the subscription handler, which discards the whole
+        // multi-status response and with it every event's per-event attribution.
+        throwHttpErrors: false,
         json: {
           conversions: request_objects,
           partialFailure: true
         }
       }
     )
+
+    // A non-2xx rejects the entire request, so report it against every conversion we sent.
+    if (!response.ok) {
+      const errormessage = response.data?.error?.message ?? response.statusText
+      requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
+        multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
+          status: response.status,
+          errormessage,
+          sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+          body: (response.data ?? response.content) as unknown as JSONLikeObject
+        })
+      })
+
+      return multiStatusResponse
+    }
 
     const failedPayloadIndices = new Set<number>()
     const partialFailureError = response.data?.partialFailureError

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -1,6 +1,5 @@
 import {
   ActionDefinition,
-  IntegrationError,
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
@@ -605,7 +604,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      const { unattributedErrorCount, unattributedErrorMessages } = handlePartialFailureResponse(
+      handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -613,18 +612,6 @@ const action: ActionDefinition<Settings, Payload> = {
         failedPayloadIndices,
         'conversions'
       )
-
-      // Google reported at least one failure we could not tie to a specific conversion. Fail the
-      // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
-      // unattributed events as successfully sent. Surface the underlying reasons, since
-      // `partialFailureError.message` on its own is usually too generic to act on.
-      if (unattributedErrorCount > 0) {
-        throw new IntegrationError(
-          unattributedErrorMessages.join('; ') || partialFailureError.message,
-          'INVALID_ARGUMENT',
-          400
-        )
-      }
     }
 
     requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -464,7 +464,7 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
       let cartItems: CartItemInterface[] = []
-      if (payload.items) {
+      if (payload.items && Array.isArray(payload.items)) {
         cartItems = payload.items.map((product) => {
           return {
             productId: product.product_id,
@@ -604,7 +604,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      handlePartialFailureResponse(
+      const { unattributedErrorCount } = handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -612,6 +612,13 @@ const action: ActionDefinition<Settings, Payload> = {
         failedPayloadIndices,
         'conversions'
       )
+
+      // Google reported at least one failure we could not tie to a specific conversion. Fail the
+      // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
+      // unattributed events as successfully sent.
+      if (unattributedErrorCount > 0) {
+        handleGoogleErrors(response)
+      }
     }
 
     requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -3,7 +3,9 @@ import {
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
-  DynamicFieldResponse
+  DynamicFieldResponse,
+  MultiStatusResponse,
+  JSONLikeObject
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -23,7 +25,8 @@ import {
   commonEmailValidation,
   getConversionActionDynamicData,
   formatPhone,
-  getSessionAttributesKeyValuePairs
+  getSessionAttributesKeyValuePairs,
+  handlePartialFailureResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -433,6 +436,7 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: [request_object],
           partialFailure: true
@@ -456,8 +460,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const getCustomVariables = memoizedGetCustomVariables()
 
-    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-      payload.map(async (payload) => {
+    const multiStatusResponse = new MultiStatusResponse()
+
+    const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
+      {
         let cartItems: CartItemInterface[] = []
         if (payload.items) {
           cartItems = payload.items.map((product) => {
@@ -537,8 +543,41 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         return request_object
+      }
+    }
+
+    // Build a request object per payload. Payloads which fail validation are marked as errors in the
+    // multi-status response and excluded from the request sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const validPayloadIndicesBitmap: number[] = []
+
+    const builtRequestObjects = await Promise.all(
+      payload.map(async (payloadItem, index) => {
+        try {
+          return { index, request_object: await buildRequestObject(payloadItem) }
+        } catch (error) {
+          return { index, error: error as Error }
+        }
       })
     )
+
+    for (const built of builtRequestObjects) {
+      if ('error' in built && built.error) {
+        multiStatusResponse.setErrorResponseAtIndex(built.index, {
+          status: 400,
+          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errormessage: built.error.message
+        })
+        continue
+      }
+      request_objects.push(built.request_object)
+      validPayloadIndicesBitmap.push(built.index)
+    }
+
+    // Nothing left to send to Google
+    if (request_objects.length === 0) {
+      return multiStatusResponse
+    }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
       `https://googleads.googleapis.com/${getApiVersion(
@@ -550,6 +589,7 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: request_objects,
           partialFailure: true
@@ -557,8 +597,32 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     )
 
-    handleGoogleErrors(response)
-    return response
+    const failedPayloadIndices = new Set<number>()
+    const partialFailureError = response.data?.partialFailureError
+
+    if (partialFailureError) {
+      handlePartialFailureResponse(
+        partialFailureError,
+        validPayloadIndicesBitmap,
+        multiStatusResponse,
+        request_objects as unknown as JSONLikeObject[],
+        failedPayloadIndices,
+        'conversions'
+      )
+    }
+
+    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+      if (failedPayloadIndices.has(originalIndex)) {
+        return
+      }
+      multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
+        status: 200,
+        sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+        body: (response.data?.results?.[requestIndex] ?? {}) as JSONLikeObject
+      })
+    })
+
+    return multiStatusResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -1,5 +1,6 @@
 import {
   ActionDefinition,
+  IntegrationError,
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
@@ -604,7 +605,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      const { unattributedErrorCount } = handlePartialFailureResponse(
+      const { unattributedErrorCount, unattributedErrorMessages } = handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -615,9 +616,14 @@ const action: ActionDefinition<Settings, Payload> = {
 
       // Google reported at least one failure we could not tie to a specific conversion. Fail the
       // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
-      // unattributed events as successfully sent.
+      // unattributed events as successfully sent. Surface the underlying reasons, since
+      // `partialFailureError.message` on its own is usually too generic to act on.
       if (unattributedErrorCount > 0) {
-        handleGoogleErrors(response)
+        throw new IntegrationError(
+          unattributedErrorMessages.join('; ') || partialFailureError.message,
+          'INVALID_ARGUMENT',
+          400
+        )
       }
     }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -463,100 +463,103 @@ const action: ActionDefinition<Settings, Payload> = {
     const multiStatusResponse = new MultiStatusResponse()
 
     const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      {
-        let cartItems: CartItemInterface[] = []
-        if (payload.items) {
-          cartItems = payload.items.map((product) => {
-            return {
-              productId: product.product_id,
-              quantity: product.quantity,
-              unitPrice: product.price
-            } as CartItemInterface
-          })
-        }
-
-        const { session_attributes_encoded, user_ip_address } = payload
-
-        const request_object: ClickConversionRequestObjectInterface = {
-          conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
-          conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-          gclid: payload.gclid,
-          gbraid: payload.gbraid,
-          wbraid: payload.wbraid,
-          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
-          orderId: payload.order_id,
-          conversionValue: payload.value,
-          currencyCode: payload.currency,
-          conversionEnvironment: payload.conversion_environment,
-          cartData: {
-            merchantId: payload.merchant_id,
-            feedCountryCode: payload.merchant_country_code,
-            feedLanguageCode: payload.merchant_language_code,
-            localTransactionCost: payload.local_cost,
-            items: cartItems
-          },
-          userIdentifiers: []
-        }
-
-        // Add Consent Signals 'adUserData' if it is defined
-        if (payload.ad_user_data_consent_state) {
-          request_object['consent'] = {
-            adUserData: payload.ad_user_data_consent_state
-          }
-        }
-
-        // Add Consent Signals 'adPersonalization' if it is defined
-        if (payload.ad_personalization_consent_state) {
-          request_object['consent'] = {
-            ...request_object['consent'],
-            adPersonalization: payload.ad_personalization_consent_state
-          }
-        }
-
-        // Retrieves all of the custom variables that the customer has created in their Google Ads account
-        if (payload.custom_variables) {
-          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-          if (customVariableIds?.data?.length) {
-            request_object.customVariables = formatCustomVariables(
-              payload.custom_variables,
-              customVariableIds.data[0].results
-            )
-          }
-        }
-
-        if (payload.email_address) {
-          const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
-
-          request_object.userIdentifiers.push({
-            hashedEmail: validatedEmail
-          } as UserIdentifierInterface)
-        }
-
-        if (payload.phone_number) {
-          request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
-              formatPhone(value, payload.phone_country_code)
-            )
-          } as UserIdentifierInterface)
-        }
-
-        return request_object
+      let cartItems: CartItemInterface[] = []
+      if (payload.items) {
+        cartItems = payload.items.map((product) => {
+          return {
+            productId: product.product_id,
+            quantity: product.quantity,
+            unitPrice: product.price
+          } as CartItemInterface
+        })
       }
+
+      const { session_attributes_encoded, user_ip_address } = payload
+
+      const request_object: ClickConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
+        conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+        gclid: payload.gclid,
+        gbraid: payload.gbraid,
+        wbraid: payload.wbraid,
+        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
+        orderId: payload.order_id,
+        conversionValue: payload.value,
+        currencyCode: payload.currency,
+        conversionEnvironment: payload.conversion_environment,
+        cartData: {
+          merchantId: payload.merchant_id,
+          feedCountryCode: payload.merchant_country_code,
+          feedLanguageCode: payload.merchant_language_code,
+          localTransactionCost: payload.local_cost,
+          items: cartItems
+        },
+        userIdentifiers: []
+      }
+
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payload.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payload.ad_user_data_consent_state
+        }
+      }
+
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payload.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payload.ad_personalization_consent_state
+        }
+      }
+
+      // Retrieves all of the custom variables that the customer has created in their Google Ads account
+      if (payload.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payload.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      if (payload.email_address) {
+        const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payload.phone_number) {
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
+            formatPhone(value, payload.phone_country_code)
+          )
+        } as UserIdentifierInterface)
+      }
+
+      return request_object
     }
 
     // Build a request object per payload. Payloads which fail validation are marked as errors in the
     // multi-status response and excluded from the request sent to Google.
     const request_objects: ClickConversionRequestObjectInterface[] = []
-    const validPayloadIndicesBitmap: number[] = []
+    const requestIndexToPayloadIndex: number[] = []
 
     const builtRequestObjects = await Promise.all(
       payload.map(async (payloadItem, index) => {
         try {
           return { index, request_object: await buildRequestObject(payloadItem) }
         } catch (error) {
-          return { index, error: error as Error }
+          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
+          // while fetching custom variables) is rethrown so the whole batch is retried.
+          if (error instanceof PayloadValidationError) {
+            return { index, error }
+          }
+          throw error
         }
       })
     )
@@ -571,7 +574,7 @@ const action: ActionDefinition<Settings, Payload> = {
         continue
       }
       request_objects.push(built.request_object)
-      validPayloadIndicesBitmap.push(built.index)
+      requestIndexToPayloadIndex.push(built.index)
     }
 
     // Nothing left to send to Google
@@ -603,7 +606,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (partialFailureError) {
       handlePartialFailureResponse(
         partialFailureError,
-        validPayloadIndicesBitmap,
+        requestIndexToPayloadIndex,
         multiStatusResponse,
         request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices,
@@ -611,7 +614,7 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+    requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -617,7 +617,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      const { unattributedErrorCount } = handlePartialFailureResponse(
+      const { unattributedErrorCount, unattributedErrorMessages } = handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -628,9 +628,14 @@ const action: ActionDefinition<Settings, Payload> = {
 
       // Google reported at least one failure we could not tie to a specific conversion. Fail the
       // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
-      // unattributed events as successfully sent.
+      // unattributed events as successfully sent. Surface the underlying reasons, since
+      // `partialFailureError.message` on its own is usually too generic to act on.
       if (unattributedErrorCount > 0) {
-        handleGoogleErrors(response)
+        throw new IntegrationError(
+          unattributedErrorMessages.join('; ') || partialFailureError.message,
+          'INVALID_ARGUMENT',
+          400
+        )
       }
     }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -606,12 +606,31 @@ const action: ActionDefinition<Settings, Payload> = {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
         skipResponseCloning: true,
+        // The multi-status response is this action's deliverable, so a non-2xx must not throw:
+        // destination-kit rethrows out of the subscription handler, which discards the whole
+        // multi-status response and with it every event's per-event attribution.
+        throwHttpErrors: false,
         json: {
           conversions: request_objects,
           partialFailure: true
         }
       }
     )
+
+    // A non-2xx rejects the entire request, so report it against every conversion we sent.
+    if (!response.ok) {
+      const errormessage = response.data?.error?.message ?? response.statusText
+      requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
+        multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
+          status: response.status,
+          errormessage,
+          sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+          body: (response.data ?? response.content) as unknown as JSONLikeObject
+        })
+      })
+
+      return multiStatusResponse
+    }
 
     const failedPayloadIndices = new Set<number>()
     const partialFailureError = response.data?.partialFailureError

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -617,7 +617,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      const { unattributedErrorCount, unattributedErrorMessages } = handlePartialFailureResponse(
+      handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -625,18 +625,6 @@ const action: ActionDefinition<Settings, Payload> = {
         failedPayloadIndices,
         'conversions'
       )
-
-      // Google reported at least one failure we could not tie to a specific conversion. Fail the
-      // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
-      // unattributed events as successfully sent. Surface the underlying reasons, since
-      // `partialFailureError.message` on its own is usually too generic to act on.
-      if (unattributedErrorCount > 0) {
-        throw new IntegrationError(
-          unattributedErrorMessages.join('; ') || partialFailureError.message,
-          'INVALID_ARGUMENT',
-          400
-        )
-      }
     }
 
     requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -4,7 +4,9 @@ import {
   ModifiedResponse,
   RequestClient,
   DynamicFieldResponse,
-  IntegrationError
+  IntegrationError,
+  MultiStatusResponse,
+  JSONLikeObject
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -24,7 +26,8 @@ import {
   getConversionActionDynamicData,
   memoizedGetCustomVariables,
   formatPhone,
-  getSessionAttributesKeyValuePairs
+  getSessionAttributesKeyValuePairs,
+  handlePartialFailureResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -441,6 +444,7 @@ const action: ActionDefinition<Settings, Payload> = {
           headers: {
             'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
           },
+          skipResponseCloning: true,
           json: {
             conversions: [request_object],
             partialFailure: true
@@ -470,8 +474,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const getCustomVariables = memoizedGetCustomVariables()
 
-    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-      payload.map(async (payloadItem) => {
+    const multiStatusResponse = new MultiStatusResponse()
+
+    const buildRequestObject = async (payloadItem: Payload): Promise<ClickConversionRequestObjectInterface> => {
+      {
         let cartItems: CartItemInterface[] = []
         if (payloadItem.items && Array.isArray(payloadItem.items)) {
           cartItems = payloadItem.items.map((product) => {
@@ -555,8 +561,41 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         return request_object
+      }
+    }
+
+    // Build a request object per payload. Payloads which fail validation are marked as errors in the
+    // multi-status response and excluded from the request sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const validPayloadIndicesBitmap: number[] = []
+
+    const builtRequestObjects = await Promise.all(
+      payload.map(async (payloadItem, index) => {
+        try {
+          return { index, request_object: await buildRequestObject(payloadItem) }
+        } catch (error) {
+          return { index, error: error as Error }
+        }
       })
     )
+
+    for (const built of builtRequestObjects) {
+      if ('error' in built && built.error) {
+        multiStatusResponse.setErrorResponseAtIndex(built.index, {
+          status: 400,
+          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errormessage: built.error.message
+        })
+        continue
+      }
+      request_objects.push(built.request_object)
+      validPayloadIndicesBitmap.push(built.index)
+    }
+
+    // Nothing left to send to Google
+    if (request_objects.length === 0) {
+      return multiStatusResponse
+    }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
       `https://googleads.googleapis.com/${getApiVersion(
@@ -568,14 +607,40 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: request_objects,
           partialFailure: true
         }
       }
     )
-    handleGoogleErrors(response)
-    return response
+
+    const failedPayloadIndices = new Set<number>()
+    const partialFailureError = response.data?.partialFailureError
+
+    if (partialFailureError) {
+      handlePartialFailureResponse(
+        partialFailureError,
+        validPayloadIndicesBitmap,
+        multiStatusResponse,
+        request_objects as unknown as JSONLikeObject[],
+        failedPayloadIndices,
+        'conversions'
+      )
+    }
+
+    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+      if (failedPayloadIndices.has(originalIndex)) {
+        return
+      }
+      multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
+        status: 200,
+        sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+        body: (response.data?.results?.[requestIndex] ?? {}) as JSONLikeObject
+      })
+    })
+
+    return multiStatusResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -477,104 +477,102 @@ const action: ActionDefinition<Settings, Payload> = {
     const multiStatusResponse = new MultiStatusResponse()
 
     const buildRequestObject = async (payloadItem: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      {
-        let cartItems: CartItemInterface[] = []
-        if (payloadItem.items && Array.isArray(payloadItem.items)) {
-          cartItems = payloadItem.items.map((product) => {
-            return {
-              productId: product.product_id,
-              quantity: product.quantity,
-              unitPrice: product.price
-            } as CartItemInterface
-          })
-        }
-
-        const { session_attributes_encoded, user_ip_address } = payloadItem
-
-        const request_object: ClickConversionRequestObjectInterface = {
-          conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
-          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
-          gclid: payloadItem.gclid,
-          gbraid: payloadItem.gbraid,
-          wbraid: payloadItem.wbraid,
-          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
-          orderId: payloadItem.order_id,
-          conversionValue: payloadItem.value,
-          currencyCode: payloadItem.currency,
-          conversionEnvironment: payloadItem.conversion_environment,
-          cartData: {
-            merchantId: payloadItem.merchant_id,
-            feedCountryCode: payloadItem.merchant_country_code,
-            feedLanguageCode: payloadItem.merchant_language_code,
-            localTransactionCost: payloadItem.local_cost,
-            items: cartItems
-          },
-          userIdentifiers: []
-        }
-        // Add Consent Signals 'adUserData' if it is defined
-        if (payloadItem.ad_user_data_consent_state) {
-          request_object['consent'] = {
-            adUserData: payloadItem.ad_user_data_consent_state
-          }
-        }
-
-        // Add Consent Signals 'adPersonalization' if it is defined
-        if (payloadItem.ad_personalization_consent_state) {
-          request_object['consent'] = {
-            ...request_object['consent'],
-            adPersonalization: payloadItem.ad_personalization_consent_state
-          }
-        }
-
-        // Retrieves all of the custom variables that the customer has created in their Google Ads account
-        if (payloadItem.custom_variables) {
-          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-          if (customVariableIds?.data?.length) {
-            request_object.customVariables = formatCustomVariables(
-              payloadItem.custom_variables,
-              customVariableIds.data[0].results
-            )
-          }
-        }
-
-        if (payloadItem.email_address) {
-          const validatedEmail: string = processHashing(
-            payloadItem.email_address,
-            'sha256',
-            'hex',
-            commonEmailValidation
-          )
-
-          request_object.userIdentifiers.push({
-            hashedEmail: validatedEmail
-          } as UserIdentifierInterface)
-        }
-
-        if (payloadItem.phone_number) {
-          request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
-              formatPhone(value, payloadItem.phone_country_code)
-            )
-          } as UserIdentifierInterface)
-        }
-
-        return request_object
+      let cartItems: CartItemInterface[] = []
+      if (payloadItem.items && Array.isArray(payloadItem.items)) {
+        cartItems = payloadItem.items.map((product) => {
+          return {
+            productId: product.product_id,
+            quantity: product.quantity,
+            unitPrice: product.price
+          } as CartItemInterface
+        })
       }
+
+      const { session_attributes_encoded, user_ip_address } = payloadItem
+
+      const request_object: ClickConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+        conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+        gclid: payloadItem.gclid,
+        gbraid: payloadItem.gbraid,
+        wbraid: payloadItem.wbraid,
+        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
+        orderId: payloadItem.order_id,
+        conversionValue: payloadItem.value,
+        currencyCode: payloadItem.currency,
+        conversionEnvironment: payloadItem.conversion_environment,
+        cartData: {
+          merchantId: payloadItem.merchant_id,
+          feedCountryCode: payloadItem.merchant_country_code,
+          feedLanguageCode: payloadItem.merchant_language_code,
+          localTransactionCost: payloadItem.local_cost,
+          items: cartItems
+        },
+        userIdentifiers: []
+      }
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payloadItem.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payloadItem.ad_user_data_consent_state
+        }
+      }
+
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payloadItem.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payloadItem.ad_personalization_consent_state
+        }
+      }
+
+      // Retrieves all of the custom variables that the customer has created in their Google Ads account
+      if (payloadItem.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payloadItem.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      if (payloadItem.email_address) {
+        const validatedEmail: string = processHashing(payloadItem.email_address, 'sha256', 'hex', commonEmailValidation)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payloadItem.phone_number) {
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+            formatPhone(value, payloadItem.phone_country_code)
+          )
+        } as UserIdentifierInterface)
+      }
+
+      return request_object
     }
 
     // Build a request object per payload. Payloads which fail validation are marked as errors in the
     // multi-status response and excluded from the request sent to Google.
     const request_objects: ClickConversionRequestObjectInterface[] = []
-    const validPayloadIndicesBitmap: number[] = []
+    const requestIndexToPayloadIndex: number[] = []
 
     const builtRequestObjects = await Promise.all(
       payload.map(async (payloadItem, index) => {
         try {
           return { index, request_object: await buildRequestObject(payloadItem) }
         } catch (error) {
-          return { index, error: error as Error }
+          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
+          // while fetching custom variables) is rethrown so the whole batch is retried.
+          if (error instanceof PayloadValidationError) {
+            return { index, error }
+          }
+          throw error
         }
       })
     )
@@ -589,7 +587,7 @@ const action: ActionDefinition<Settings, Payload> = {
         continue
       }
       request_objects.push(built.request_object)
-      validPayloadIndicesBitmap.push(built.index)
+      requestIndexToPayloadIndex.push(built.index)
     }
 
     // Nothing left to send to Google
@@ -621,7 +619,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (partialFailureError) {
       handlePartialFailureResponse(
         partialFailureError,
-        validPayloadIndicesBitmap,
+        requestIndexToPayloadIndex,
         multiStatusResponse,
         request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices,
@@ -629,7 +627,7 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+    requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -617,7 +617,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {
-      handlePartialFailureResponse(
+      const { unattributedErrorCount } = handlePartialFailureResponse(
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
@@ -625,6 +625,13 @@ const action: ActionDefinition<Settings, Payload> = {
         failedPayloadIndices,
         'conversions'
       )
+
+      // Google reported at least one failure we could not tie to a specific conversion. Fail the
+      // whole batch - as the pre-refactor handleGoogleErrors() did - rather than reporting the
+      // unattributed events as successfully sent.
+      if (unattributedErrorCount > 0) {
+        handleGoogleErrors(response)
+      }
     }
 
     requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {


### PR DESCRIPTION
Adds `skipResponseCloning` and per-event multi-status reporting to both Google Enhanced Conversions click conversion actions — **Click Conversion** (`uploadClickConversion`) and **Click Conversion V2** (`uploadClickConversion2`).

**`skipResponseCloning: true`** is set on the `:uploadClickConversions` requests in `perform` and `performBatch` of both actions, so large Google Ads responses are read directly instead of being cloned.

**Multi-status in `performBatch`** — both actions now return a `MultiStatusResponse` instead of the raw response:

- Payloads that fail validation while their request object is built (e.g. an invalid email) are reported per-event as `PAYLOAD_VALIDATION_FAILED` and excluded from the request sent to Google, instead of failing the whole batch.
- Google's `partialFailureError` is mapped back to the originating event through the `conversions` field path, so only the events Google rejected are marked as errors.
- The remaining events are marked successful with their per-conversion result from `results`.

`handlePartialFailureResponse` in `functions.ts` now takes the field path name to look up (defaulting to `operations`, its existing behaviour for the user list flow) so it can be shared with the conversions upload path.

## Testing

- [x] Added unit tests for new functionality
- [x] Tested end-to-end using the local server
- [x] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change. — no field changes; `performBatch` now reports per-event statuses rather than throwing for the whole batch.
- [x] [Segmenters] Tested in the staging environment


[Test Doc] (https://docs.google.com/document/d/1YJMrSPEbqbrNW4GV8QWyEPViiYpc69661fTimNuqInU/edit?tab=t.0)

## Security Review

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'` — no field definitions changed.
