### PR TITLE
[STRATCONN-7010] multi-status + skipResponseCloning for Click Conversion V1 and V2

### DIFF
--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -8,6 +8,11 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
+  beforeEach(() => {
+    // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
+    testDestination.responses.length = 0
+  })
+
   describe('uploadClickConversion Single Event', () => {
     it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
@@ -1458,20 +1463,117 @@ describe('GoogleEnhancedConversions', () => {
         .post('')
         .reply(201, {})
 
-      try {
-        await testDestination.testBatchAction('uploadClickConversion', {
-          events,
-          features: { 'google-enhanced-v12': true },
-          mapping: { conversion_action: '12345' },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+    })
+
+    it('returns a success multi-status response for every event when the API reports no failures', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
         })
-        fail('the test should have thrown an error')
-      } catch (e: any) {
-        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
-      }
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{ gclid: '54321' }, { gclid: '54322' }] })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
+    })
+
+    it('maps a partialFailureError back to the failing event only', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    message: 'The conversion could not be attributed to the click.',
+                    location: {
+                      fieldPathElements: [{ fieldName: 'conversions', index: 1 }]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{ gclid: '54321' }, {}]
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errormessage: 'The conversion could not be attributed to the click.'
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1615,53 +1615,6 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
     })
 
-    it('reports a CONCURRENT_MODIFICATION failure as retryable', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(400, {
-          error: {
-            code: 400,
-            message: 'Request contains an invalid argument.',
-            details: [
-              {
-                errors: [
-                  {
-                    errorCode: { databaseError: 'CONCURRENT_MODIFICATION' }
-                  }
-                ]
-              }
-            ]
-          }
-        })
-
-      const responses = await testDestination.executeBatch('uploadClickConversion', {
-        events,
-        mapping: {
-          conversion_action: '12345',
-          conversion_timestamp: { '@path': '$.timestamp' },
-          gclid: { '@path': '$.properties.gclid' },
-          email_address: { '@path': '$.properties.email' }
-        },
-        settings: { customerId }
-      })
-
-      expect(responses[0]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
-      expect(responses[1]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
-    })
-
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1576,6 +1576,92 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
+    it('reports an HTTP level failure against every event that was sent', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(403, {
+          error: {
+            code: 403,
+            message: 'The caller does not have permission.',
+            status: 'PERMISSION_DENIED'
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+    })
+
+    it('reports a CONCURRENT_MODIFICATION failure as retryable', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(400, {
+          error: {
+            code: 400,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    errorCode: { databaseError: 'CONCURRENT_MODIFICATION' }
+                  }
+                ]
+              }
+            ]
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' }
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
+      expect(responses[1]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
+    })
+
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1623,6 +1623,33 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
+    it('rethrows a network failure so the whole batch retries', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .replyWithError('socket hang up')
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' }
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrow()
+    })
+
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion.test.ts
@@ -1611,8 +1611,16 @@ describe('GoogleEnhancedConversions', () => {
         settings: { customerId }
       })
 
-      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
-      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+      expect(responses[0]).toMatchObject({
+        status: 403,
+        errormessage: 'The caller does not have permission.',
+        sent: { gclid: '54321' }
+      })
+      expect(responses[1]).toMatchObject({
+        status: 403,
+        errormessage: 'The caller does not have permission.',
+        sent: { gclid: '54322' }
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1631,8 +1631,16 @@ describe('GoogleEnhancedConversions', () => {
         settings: { customerId }
       })
 
-      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
-      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+      expect(responses[0]).toMatchObject({
+        status: 403,
+        errormessage: 'The caller does not have permission.',
+        sent: { gclid: '54321' }
+      })
+      expect(responses[1]).toMatchObject({
+        status: 403,
+        errormessage: 'The caller does not have permission.',
+        sent: { gclid: '54322' }
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -9,6 +9,11 @@ const timestamp = new Date('Thu Jun 10 2021 11:08:04 GMT-0700 (Pacific Daylight 
 const customerId = '1234'
 
 describe('GoogleEnhancedConversions', () => {
+  beforeEach(() => {
+    // `executeBatch` does not drain the recorded responses the way `testAction`/`testBatchAction` do
+    testDestination.responses.length = 0
+  })
+
   describe('uploadClickConversion2 Single Event', () => {
     it('sends an event with default mappings - basic', async () => {
       const event = createTestEvent({
@@ -1443,23 +1448,120 @@ describe('GoogleEnhancedConversions', () => {
         .post('')
         .reply(201, {})
 
-      try {
-        await testDestination.testBatchAction('uploadClickConversion2', {
-          events,
-          features: { 'google-enhanced-v12': true },
-          mapping: {
-            conversion_action: '12345',
-            __segment_internal_sync_mode: 'add'
-          },
-          useDefaultMappings: true,
-          settings: {
-            customerId
-          }
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        features: { 'google-enhanced-v12': true },
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: {
+          customerId
+        }
+      })
+
+      expect(responses[0]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: "Email provided doesn't seem to be in a valid format."
+      })
+    })
+
+    it('returns a success multi-status response for every event when the API reports no failures', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
         })
-        fail('the test should have thrown an error')
-      } catch (e: any) {
-        expect(e.message).toBe("Email provided doesn't seem to be in a valid format.")
-      }
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, { results: [{ gclid: '54321' }, { gclid: '54322' }] })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
+    })
+
+    it('maps a partialFailureError back to the failing event only', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(201, {
+          partialFailureError: {
+            code: 3,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    message: 'The conversion could not be attributed to the click.',
+                    location: {
+                      fieldPathElements: [{ fieldName: 'conversions', index: 1 }]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          results: [{ gclid: '54321' }, {}]
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 200, body: { gclid: '54321' } })
+      expect(responses[1]).toMatchObject({
+        status: 400,
+        errormessage: 'The conversion could not be attributed to the click.'
+      })
     })
 
     it('Deny User Data and Personalised Consent State', async () => {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1635,54 +1635,6 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
     })
 
-    it('reports a CONCURRENT_MODIFICATION failure as retryable', async () => {
-      const events: SegmentEvent[] = [
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 1',
-          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
-        }),
-        createTestEvent({
-          timestamp,
-          event: 'Test Event 2',
-          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
-        })
-      ]
-
-      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
-        .post('')
-        .reply(400, {
-          error: {
-            code: 400,
-            message: 'Request contains an invalid argument.',
-            details: [
-              {
-                errors: [
-                  {
-                    errorCode: { databaseError: 'CONCURRENT_MODIFICATION' }
-                  }
-                ]
-              }
-            ]
-          }
-        })
-
-      const responses = await testDestination.executeBatch('uploadClickConversion2', {
-        events,
-        mapping: {
-          conversion_action: '12345',
-          conversion_timestamp: { '@path': '$.timestamp' },
-          gclid: { '@path': '$.properties.gclid' },
-          email_address: { '@path': '$.properties.email' },
-          __segment_internal_sync_mode: 'add'
-        },
-        settings: { customerId }
-      })
-
-      expect(responses[0]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
-      expect(responses[1]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
-    })
-
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1643,6 +1643,34 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
+    it('rethrows a network failure so the whole batch retries', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .replyWithError('socket hang up')
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' },
+            __segment_internal_sync_mode: 'add'
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrow()
+    })
+
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1509,6 +1509,37 @@ describe('GoogleEnhancedConversions', () => {
       expect(responses[1]).toMatchObject({ status: 200, body: { gclid: '54322' } })
     })
 
+    it('rethrows non-validation errors raised while building the request objects', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        })
+      ]
+
+      // The custom variables lookup fails, which is not a per-payload validation problem - the whole
+      // batch should fail rather than being reported as a 400 for each event.
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}/googleAds:searchStream`)
+        .post('')
+        .reply(500, {})
+
+      await expect(
+        testDestination.executeBatch('uploadClickConversion2', {
+          events,
+          mapping: {
+            conversion_action: '12345',
+            conversion_timestamp: { '@path': '$.timestamp' },
+            gclid: { '@path': '$.properties.gclid' },
+            email_address: { '@path': '$.properties.email' },
+            custom_variables: { my_variable: 'my_value' },
+            __segment_internal_sync_mode: 'add'
+          },
+          settings: { customerId }
+        })
+      ).rejects.toThrowError()
+    })
+
     it('maps a partialFailureError back to the failing event only', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/__tests__/uploadClickConversion2.test.ts
@@ -1595,6 +1595,94 @@ describe('GoogleEnhancedConversions', () => {
       })
     })
 
+    it('reports an HTTP level failure against every event that was sent', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(403, {
+          error: {
+            code: 403,
+            message: 'The caller does not have permission.',
+            status: 'PERMISSION_DENIED'
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+      expect(responses[1]).toMatchObject({ status: 403, errormessage: 'The caller does not have permission.' })
+    })
+
+    it('reports a CONCURRENT_MODIFICATION failure as retryable', async () => {
+      const events: SegmentEvent[] = [
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 1',
+          properties: { gclid: '54321', email: 'test@gmail.com', orderId: '1234', total: '200', currency: 'USD' }
+        }),
+        createTestEvent({
+          timestamp,
+          event: 'Test Event 2',
+          properties: { gclid: '54322', email: 'test2@gmail.com', orderId: '1235', total: '200', currency: 'USD' }
+        })
+      ]
+
+      nock(`https://googleads.googleapis.com/${API_VERSION}/customers/${customerId}:uploadClickConversions`)
+        .post('')
+        .reply(400, {
+          error: {
+            code: 400,
+            message: 'Request contains an invalid argument.',
+            details: [
+              {
+                errors: [
+                  {
+                    errorCode: { databaseError: 'CONCURRENT_MODIFICATION' }
+                  }
+                ]
+              }
+            ]
+          }
+        })
+
+      const responses = await testDestination.executeBatch('uploadClickConversion2', {
+        events,
+        mapping: {
+          conversion_action: '12345',
+          conversion_timestamp: { '@path': '$.timestamp' },
+          gclid: { '@path': '$.properties.gclid' },
+          email_address: { '@path': '$.properties.email' },
+          __segment_internal_sync_mode: 'add'
+        },
+        settings: { customerId }
+      })
+
+      expect(responses[0]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
+      expect(responses[1]).toMatchObject({ status: 429, errortype: 'RETRYABLE_BATCH_FAILURE' })
+    })
+
     it('Deny User Data and Personalised Consent State', async () => {
       const events: SegmentEvent[] = [
         createTestEvent({

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -766,7 +766,7 @@ export const verifyCustomerId = (customerId: string | undefined) => {
   return customerId.replace(/-/g, '')
 }
 
-const handleGoogleAdsAPIErrorResponse = (
+export const handleGoogleAdsAPIErrorResponse = (
   error: any,
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -766,7 +766,7 @@ export const verifyCustomerId = (customerId: string | undefined) => {
   return customerId.replace(/-/g, '')
 }
 
-export const handleGoogleAdsAPIErrorResponse = (
+const handleGoogleAdsAPIErrorResponse = (
   error: any,
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,
@@ -824,11 +824,32 @@ const updateMultiStatusResponseWithSuccess = (
   })
 }
 
+/* Reports an API level failure against every item that was sent, attributing each event the item it
+   sent rather than the whole request body.
+ */
+export const handleGoogleAdsAPIErrorResponsePerItem = (
+  error: any,
+  validPayloadIndicesBitmap: number[],
+  multiStatusResponse: MultiStatusResponse,
+  sentItems: JSONLikeObject[],
+  failedPayloadIndices?: Set<number>
+) => {
+  const parsedError = parseGoogleAdsError(error?.response?.data?.error)
+  validPayloadIndicesBitmap.forEach((originalIndex, itemIndex) => {
+    multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
+      ...parsedError,
+      body: error,
+      sent: sentItems[itemIndex]
+    })
+    failedPayloadIndices?.add(originalIndex)
+  })
+}
+
 export const handlePartialFailureResponse = (
   partialFailureError: any,
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,
-  userIdentifiers: any[],
+  sentItems: any[],
   failedPayloadIndices: Set<number>,
   fieldName = 'operations'
 ) => {
@@ -841,7 +862,7 @@ export const handlePartialFailureResponse = (
         multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
           status: STATUS_CODE_MAPPING?.[partialFailureError.code as keyof typeof STATUS_CODE_MAPPING]?.status ?? 500, // error code
           errormessage: error.message,
-          sent: userIdentifiers?.[failedIndex],
+          sent: sentItems?.[failedIndex],
           body: error
         })
         failedPayloadIndices.add(originalIndex)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -829,16 +829,26 @@ const updateMultiStatusResponseWithSuccess = (
  */
 export const handleGoogleAdsAPIErrorResponsePerItem = (
   error: any,
-  validPayloadIndicesBitmap: number[],
+  requestIndexToPayloadIndex: number[],
   multiStatusResponse: MultiStatusResponse,
   sentItems: JSONLikeObject[],
   failedPayloadIndices?: Set<number>
 ) => {
-  const parsedError = parseGoogleAdsError(error?.response?.data?.error)
-  validPayloadIndicesBitmap.forEach((originalIndex, itemIndex) => {
+  // Only an HTTP failure carries a per event verdict. A network or timeout failure says nothing
+  // about the individual conversions, so it is rethrown and the whole batch retries.
+  if (!(error instanceof HTTPError)) {
+    throw error
+  }
+
+  const response = error.response as ModifiedResponse | undefined
+  const parsedError = parseGoogleAdsError((response?.data as any)?.error)
+  requestIndexToPayloadIndex.forEach((originalIndex, itemIndex) => {
     multiStatusResponse.setErrorResponseAtIndex(originalIndex, {
       ...parsedError,
-      body: error,
+      // Google does not always answer with its error envelope, e.g. a proxy responding with HTML.
+      status: parsedError.status ?? response?.status ?? 500,
+      errormessage: parsedError.errormessage ?? error.message,
+      body: error as unknown as JSONLikeObject,
       sent: sentItems[itemIndex]
     })
     failedPayloadIndices?.add(originalIndex)

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/functions.ts
@@ -829,13 +829,12 @@ export const handlePartialFailureResponse = (
   validPayloadIndicesBitmap: number[],
   multiStatusResponse: MultiStatusResponse,
   userIdentifiers: any[],
-  failedPayloadIndices: Set<number>
+  failedPayloadIndices: Set<number>,
+  fieldName = 'operations'
 ) => {
   partialFailureError?.details?.forEach((detail: any) => {
     detail.errors?.forEach((error: any) => {
-      const failedIndex = error.location?.fieldPathElements?.find(
-        (field: any) => field.fieldName === 'operations'
-      )?.index
+      const failedIndex = error.location?.fieldPathElements?.find((field: any) => field.fieldName === fieldName)?.index
 
       if (failedIndex >= 0) {
         const originalIndex = validPayloadIndicesBitmap[failedIndex]
@@ -972,7 +971,11 @@ const extractBatchUserIdentifiers = (
 }
 
 // Helper function to determine operation type
-const determineOperationType = (payload: UserListPayload, syncMode?: string, audienceMembership?: AudienceMembership) => {
+const determineOperationType = (
+  payload: UserListPayload,
+  syncMode?: string,
+  audienceMembership?: AudienceMembership
+) => {
   if (
     payload.event_name === 'Audience Entered' ||
     syncMode === 'add' ||

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -26,7 +26,8 @@ import {
   getConversionActionDynamicData,
   formatPhone,
   getSessionAttributesKeyValuePairs,
-  handlePartialFailureResponse
+  handlePartialFailureResponse,
+  handleGoogleAdsAPIErrorResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -576,25 +577,41 @@ const action: ActionDefinition<Settings, Payload> = {
       return multiStatusResponse
     }
 
-    const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/${getApiVersion(
-        features,
-        statsContext
-      )}/customers/${customerId}:uploadClickConversions`,
-      {
-        method: 'post',
-        headers: {
-          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
-        },
-        skipResponseCloning: true,
-        json: {
-          conversions: request_objects,
-          partialFailure: true
-        }
-      }
-    )
-
     const failedPayloadIndices = new Set<number>()
+
+    let response: ModifiedResponse<PartialErrorResponse>
+
+    try {
+      response = await request(
+        `https://googleads.googleapis.com/${getApiVersion(
+          features,
+          statsContext
+        )}/customers/${customerId}:uploadClickConversions`,
+        {
+          method: 'post',
+          headers: {
+            'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+          },
+          skipResponseCloning: true,
+          json: {
+            conversions: request_objects,
+            partialFailure: true
+          }
+        }
+      )
+    } catch (error) {
+      // Report the HTTP level failure against every event that was sent, consistent with the user
+      // list path in handleUpdate.
+      handleGoogleAdsAPIErrorResponse(
+        error,
+        requestIndexToPayloadIndex,
+        multiStatusResponse,
+        { conversions: request_objects } as unknown as JSONLikeObject,
+        failedPayloadIndices
+      )
+      return multiStatusResponse
+    }
+
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -3,7 +3,9 @@ import {
   PayloadValidationError,
   ModifiedResponse,
   RequestClient,
-  DynamicFieldResponse
+  DynamicFieldResponse,
+  MultiStatusResponse,
+  JSONLikeObject
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -23,7 +25,8 @@ import {
   commonEmailValidation,
   getConversionActionDynamicData,
   formatPhone,
-  getSessionAttributesKeyValuePairs
+  getSessionAttributesKeyValuePairs,
+  handlePartialFailureResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -433,6 +436,7 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: [request_object],
           partialFailure: true
@@ -456,8 +460,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const getCustomVariables = memoizedGetCustomVariables()
 
-    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-      payload.map(async (payload) => {
+    const multiStatusResponse = new MultiStatusResponse()
+
+    const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
+      {
         let cartItems: CartItemInterface[] = []
         if (payload.items) {
           cartItems = payload.items.map((product) => {
@@ -537,8 +543,41 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         return request_object
+      }
+    }
+
+    // Build a request object per payload. Payloads which fail validation are marked as errors in the
+    // multi-status response and excluded from the request sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const validPayloadIndicesBitmap: number[] = []
+
+    const builtRequestObjects = await Promise.all(
+      payload.map(async (payloadItem, index) => {
+        try {
+          return { index, request_object: await buildRequestObject(payloadItem) }
+        } catch (error) {
+          return { index, error: error as Error }
+        }
       })
     )
+
+    for (const built of builtRequestObjects) {
+      if ('error' in built && built.error) {
+        multiStatusResponse.setErrorResponseAtIndex(built.index, {
+          status: 400,
+          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errormessage: built.error.message
+        })
+        continue
+      }
+      request_objects.push(built.request_object)
+      validPayloadIndicesBitmap.push(built.index)
+    }
+
+    // Nothing left to send to Google
+    if (request_objects.length === 0) {
+      return multiStatusResponse
+    }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
       `https://googleads.googleapis.com/${getApiVersion(
@@ -550,6 +589,7 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: request_objects,
           partialFailure: true
@@ -557,8 +597,32 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     )
 
-    handleGoogleErrors(response)
-    return response
+    const failedPayloadIndices = new Set<number>()
+    const partialFailureError = response.data?.partialFailureError
+
+    if (partialFailureError) {
+      handlePartialFailureResponse(
+        partialFailureError,
+        validPayloadIndicesBitmap,
+        multiStatusResponse,
+        request_objects as unknown as JSONLikeObject[],
+        failedPayloadIndices,
+        'conversions'
+      )
+    }
+
+    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+      if (failedPayloadIndices.has(originalIndex)) {
+        return
+      }
+      multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
+        status: 200,
+        sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+        body: (response.data?.results?.[requestIndex] ?? {}) as JSONLikeObject
+      })
+    })
+
+    return multiStatusResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -462,120 +462,114 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const multiStatusResponse = new MultiStatusResponse()
 
-    const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      let cartItems: CartItemInterface[] = []
-      if (payload.items) {
-        cartItems = payload.items.map((product) => {
-          return {
-            productId: product.product_id,
-            quantity: product.quantity,
-            unitPrice: product.price
-          } as CartItemInterface
-        })
-      }
-
-      const { session_attributes_encoded, user_ip_address } = payload
-
-      const request_object: ClickConversionRequestObjectInterface = {
-        conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
-        conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-        gclid: payload.gclid,
-        gbraid: payload.gbraid,
-        wbraid: payload.wbraid,
-        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
-        orderId: payload.order_id,
-        conversionValue: payload.value,
-        currencyCode: payload.currency,
-        conversionEnvironment: payload.conversion_environment,
-        cartData: {
-          merchantId: payload.merchant_id,
-          feedCountryCode: payload.merchant_country_code,
-          feedLanguageCode: payload.merchant_language_code,
-          localTransactionCost: payload.local_cost,
-          items: cartItems
-        },
-        userIdentifiers: []
-      }
-
-      // Add Consent Signals 'adUserData' if it is defined
-      if (payload.ad_user_data_consent_state) {
-        request_object['consent'] = {
-          adUserData: payload.ad_user_data_consent_state
+    const requestObjectResults = await Promise.allSettled(
+      payload.map(async (payload) => {
+        let cartItems: CartItemInterface[] = []
+        if (payload.items) {
+          cartItems = payload.items.map((product) => {
+            return {
+              productId: product.product_id,
+              quantity: product.quantity,
+              unitPrice: product.price
+            } as CartItemInterface
+          })
         }
-      }
 
-      // Add Consent Signals 'adPersonalization' if it is defined
-      if (payload.ad_personalization_consent_state) {
-        request_object['consent'] = {
-          ...request_object['consent'],
-          adPersonalization: payload.ad_personalization_consent_state
+        const { session_attributes_encoded, user_ip_address } = payload
+
+        const request_object: ClickConversionRequestObjectInterface = {
+          conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
+          conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+          gclid: payload.gclid,
+          gbraid: payload.gbraid,
+          wbraid: payload.wbraid,
+          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
+          orderId: payload.order_id,
+          conversionValue: payload.value,
+          currencyCode: payload.currency,
+          conversionEnvironment: payload.conversion_environment,
+          cartData: {
+            merchantId: payload.merchant_id,
+            feedCountryCode: payload.merchant_country_code,
+            feedLanguageCode: payload.merchant_language_code,
+            localTransactionCost: payload.local_cost,
+            items: cartItems
+          },
+          userIdentifiers: []
         }
-      }
 
-      // Retrieves all of the custom variables that the customer has created in their Google Ads account
-      if (payload.custom_variables) {
-        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-        if (customVariableIds?.data?.length) {
-          request_object.customVariables = formatCustomVariables(
-            payload.custom_variables,
-            customVariableIds.data[0].results
-          )
-        }
-      }
-
-      if (payload.email_address) {
-        const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
-
-        request_object.userIdentifiers.push({
-          hashedEmail: validatedEmail
-        } as UserIdentifierInterface)
-      }
-
-      if (payload.phone_number) {
-        request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
-            formatPhone(value, payload.phone_country_code)
-          )
-        } as UserIdentifierInterface)
-      }
-
-      return request_object
-    }
-
-    // Build a request object per payload. Payloads which fail validation are marked as errors in the
-    // multi-status response and excluded from the request sent to Google.
-    const request_objects: ClickConversionRequestObjectInterface[] = []
-    const requestIndexToPayloadIndex: number[] = []
-
-    const builtRequestObjects = await Promise.all(
-      payload.map(async (payloadItem, index) => {
-        try {
-          return { index, request_object: await buildRequestObject(payloadItem) }
-        } catch (error) {
-          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
-          // while fetching custom variables) is rethrown so the whole batch is retried.
-          if (error instanceof PayloadValidationError) {
-            return { index, error }
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payload.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payload.ad_user_data_consent_state
           }
-          throw error
         }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payload.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payload.ad_personalization_consent_state
+          }
+        }
+
+        // Retrieves all of the custom variables that the customer has created in their Google Ads account
+        if (payload.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payload.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        if (payload.email_address) {
+          const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+
+          request_object.userIdentifiers.push({
+            hashedEmail: validatedEmail
+          } as UserIdentifierInterface)
+        }
+
+        if (payload.phone_number) {
+          request_object.userIdentifiers.push({
+            hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
+              formatPhone(value, payload.phone_country_code)
+            )
+          } as UserIdentifierInterface)
+        }
+
+        return request_object
       })
     )
 
-    for (const built of builtRequestObjects) {
-      if ('error' in built && built.error) {
-        multiStatusResponse.setErrorResponseAtIndex(built.index, {
-          status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
-          errormessage: built.error.message
-        })
-        continue
+    // Payloads which fail validation are reported as per-event errors and excluded from the request
+    // sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const requestIndexToPayloadIndex: number[] = []
+
+    requestObjectResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        request_objects.push(result.value)
+        requestIndexToPayloadIndex.push(index)
+        return
       }
-      request_objects.push(built.request_object)
-      requestIndexToPayloadIndex.push(built.index)
-    }
+
+      // Only payload validation failures are reported per event. Anything else (e.g. a failure while
+      // fetching custom variables) is rethrown so the whole batch is retried.
+      if (!(result.reason instanceof PayloadValidationError)) {
+        throw result.reason
+      }
+
+      multiStatusResponse.setErrorResponseAtIndex(index, {
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: result.reason.message
+      })
+    })
 
     // Nothing left to send to Google
     if (request_objects.length === 0) {
@@ -618,6 +612,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }
+
       multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
         status: 200,
         sent: request_objects[requestIndex] as unknown as JSONLikeObject,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -27,7 +27,7 @@ import {
   formatPhone,
   getSessionAttributesKeyValuePairs,
   handlePartialFailureResponse,
-  handleGoogleAdsAPIErrorResponse
+  handleGoogleAdsAPIErrorResponsePerItem
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -600,13 +600,13 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       )
     } catch (error) {
-      // Report the HTTP level failure against every event that was sent, consistent with the user
-      // list path in handleUpdate.
-      handleGoogleAdsAPIErrorResponse(
+      // Report the HTTP level failure against every event that was sent, each attributed the
+      // conversion it sent.
+      handleGoogleAdsAPIErrorResponsePerItem(
         error,
         requestIndexToPayloadIndex,
         multiStatusResponse,
-        { conversions: request_objects } as unknown as JSONLikeObject,
+        request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices
       )
       return multiStatusResponse
@@ -619,7 +619,7 @@ const action: ActionDefinition<Settings, Payload> = {
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
-        request_objects as unknown as JSONLikeObject[],
+        request_objects,
         failedPayloadIndices,
         'conversions'
       )

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion/index.ts
@@ -463,100 +463,103 @@ const action: ActionDefinition<Settings, Payload> = {
     const multiStatusResponse = new MultiStatusResponse()
 
     const buildRequestObject = async (payload: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      {
-        let cartItems: CartItemInterface[] = []
-        if (payload.items) {
-          cartItems = payload.items.map((product) => {
-            return {
-              productId: product.product_id,
-              quantity: product.quantity,
-              unitPrice: product.price
-            } as CartItemInterface
-          })
-        }
-
-        const { session_attributes_encoded, user_ip_address } = payload
-
-        const request_object: ClickConversionRequestObjectInterface = {
-          conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
-          conversionDateTime: convertTimestamp(payload.conversion_timestamp),
-          gclid: payload.gclid,
-          gbraid: payload.gbraid,
-          wbraid: payload.wbraid,
-          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
-          orderId: payload.order_id,
-          conversionValue: payload.value,
-          currencyCode: payload.currency,
-          conversionEnvironment: payload.conversion_environment,
-          cartData: {
-            merchantId: payload.merchant_id,
-            feedCountryCode: payload.merchant_country_code,
-            feedLanguageCode: payload.merchant_language_code,
-            localTransactionCost: payload.local_cost,
-            items: cartItems
-          },
-          userIdentifiers: []
-        }
-
-        // Add Consent Signals 'adUserData' if it is defined
-        if (payload.ad_user_data_consent_state) {
-          request_object['consent'] = {
-            adUserData: payload.ad_user_data_consent_state
-          }
-        }
-
-        // Add Consent Signals 'adPersonalization' if it is defined
-        if (payload.ad_personalization_consent_state) {
-          request_object['consent'] = {
-            ...request_object['consent'],
-            adPersonalization: payload.ad_personalization_consent_state
-          }
-        }
-
-        // Retrieves all of the custom variables that the customer has created in their Google Ads account
-        if (payload.custom_variables) {
-          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-          if (customVariableIds?.data?.length) {
-            request_object.customVariables = formatCustomVariables(
-              payload.custom_variables,
-              customVariableIds.data[0].results
-            )
-          }
-        }
-
-        if (payload.email_address) {
-          const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
-
-          request_object.userIdentifiers.push({
-            hashedEmail: validatedEmail
-          } as UserIdentifierInterface)
-        }
-
-        if (payload.phone_number) {
-          request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
-              formatPhone(value, payload.phone_country_code)
-            )
-          } as UserIdentifierInterface)
-        }
-
-        return request_object
+      let cartItems: CartItemInterface[] = []
+      if (payload.items) {
+        cartItems = payload.items.map((product) => {
+          return {
+            productId: product.product_id,
+            quantity: product.quantity,
+            unitPrice: product.price
+          } as CartItemInterface
+        })
       }
+
+      const { session_attributes_encoded, user_ip_address } = payload
+
+      const request_object: ClickConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payload.conversion_action}`,
+        conversionDateTime: convertTimestamp(payload.conversion_timestamp),
+        gclid: payload.gclid,
+        gbraid: payload.gbraid,
+        wbraid: payload.wbraid,
+        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payload) : {}),
+        orderId: payload.order_id,
+        conversionValue: payload.value,
+        currencyCode: payload.currency,
+        conversionEnvironment: payload.conversion_environment,
+        cartData: {
+          merchantId: payload.merchant_id,
+          feedCountryCode: payload.merchant_country_code,
+          feedLanguageCode: payload.merchant_language_code,
+          localTransactionCost: payload.local_cost,
+          items: cartItems
+        },
+        userIdentifiers: []
+      }
+
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payload.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payload.ad_user_data_consent_state
+        }
+      }
+
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payload.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payload.ad_personalization_consent_state
+        }
+      }
+
+      // Retrieves all of the custom variables that the customer has created in their Google Ads account
+      if (payload.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payload.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      if (payload.email_address) {
+        const validatedEmail: string = processHashing(payload.email_address, 'sha256', 'hex', commonEmailValidation)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payload.phone_number) {
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: processHashing(payload.phone_number, 'sha256', 'hex', (value) =>
+            formatPhone(value, payload.phone_country_code)
+          )
+        } as UserIdentifierInterface)
+      }
+
+      return request_object
     }
 
     // Build a request object per payload. Payloads which fail validation are marked as errors in the
     // multi-status response and excluded from the request sent to Google.
     const request_objects: ClickConversionRequestObjectInterface[] = []
-    const validPayloadIndicesBitmap: number[] = []
+    const requestIndexToPayloadIndex: number[] = []
 
     const builtRequestObjects = await Promise.all(
       payload.map(async (payloadItem, index) => {
         try {
           return { index, request_object: await buildRequestObject(payloadItem) }
         } catch (error) {
-          return { index, error: error as Error }
+          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
+          // while fetching custom variables) is rethrown so the whole batch is retried.
+          if (error instanceof PayloadValidationError) {
+            return { index, error }
+          }
+          throw error
         }
       })
     )
@@ -571,7 +574,7 @@ const action: ActionDefinition<Settings, Payload> = {
         continue
       }
       request_objects.push(built.request_object)
-      validPayloadIndicesBitmap.push(built.index)
+      requestIndexToPayloadIndex.push(built.index)
     }
 
     // Nothing left to send to Google
@@ -603,7 +606,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (partialFailureError) {
       handlePartialFailureResponse(
         partialFailureError,
-        validPayloadIndicesBitmap,
+        requestIndexToPayloadIndex,
         multiStatusResponse,
         request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices,
@@ -611,7 +614,7 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+    requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -27,7 +27,8 @@ import {
   memoizedGetCustomVariables,
   formatPhone,
   getSessionAttributesKeyValuePairs,
-  handlePartialFailureResponse
+  handlePartialFailureResponse,
+  handleGoogleAdsAPIErrorResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -594,24 +595,40 @@ const action: ActionDefinition<Settings, Payload> = {
       return multiStatusResponse
     }
 
-    const response: ModifiedResponse<PartialErrorResponse> = await request(
-      `https://googleads.googleapis.com/${getApiVersion(
-        features,
-        statsContext
-      )}/customers/${customerId}:uploadClickConversions`,
-      {
-        method: 'post',
-        headers: {
-          'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
-        },
-        skipResponseCloning: true,
-        json: {
-          conversions: request_objects,
-          partialFailure: true
-        }
-      }
-    )
     const failedPayloadIndices = new Set<number>()
+
+    let response: ModifiedResponse<PartialErrorResponse>
+
+    try {
+      response = await request(
+        `https://googleads.googleapis.com/${getApiVersion(
+          features,
+          statsContext
+        )}/customers/${customerId}:uploadClickConversions`,
+        {
+          method: 'post',
+          headers: {
+            'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
+          },
+          skipResponseCloning: true,
+          json: {
+            conversions: request_objects,
+            partialFailure: true
+          }
+        }
+      )
+    } catch (error) {
+      // Report the HTTP level failure against every event that was sent, consistent with the user
+      // list path in handleUpdate.
+      handleGoogleAdsAPIErrorResponse(
+        error,
+        requestIndexToPayloadIndex,
+        multiStatusResponse,
+        { conversions: request_objects } as unknown as JSONLikeObject,
+        failedPayloadIndices
+      )
+      return multiStatusResponse
+    }
     const partialFailureError = response.data?.partialFailureError
 
     if (partialFailureError) {

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -476,119 +476,118 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const multiStatusResponse = new MultiStatusResponse()
 
-    const buildRequestObject = async (payloadItem: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      let cartItems: CartItemInterface[] = []
-      if (payloadItem.items && Array.isArray(payloadItem.items)) {
-        cartItems = payloadItem.items.map((product) => {
-          return {
-            productId: product.product_id,
-            quantity: product.quantity,
-            unitPrice: product.price
-          } as CartItemInterface
-        })
-      }
-
-      const { session_attributes_encoded, user_ip_address } = payloadItem
-
-      const request_object: ClickConversionRequestObjectInterface = {
-        conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
-        conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
-        gclid: payloadItem.gclid,
-        gbraid: payloadItem.gbraid,
-        wbraid: payloadItem.wbraid,
-        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
-        orderId: payloadItem.order_id,
-        conversionValue: payloadItem.value,
-        currencyCode: payloadItem.currency,
-        conversionEnvironment: payloadItem.conversion_environment,
-        cartData: {
-          merchantId: payloadItem.merchant_id,
-          feedCountryCode: payloadItem.merchant_country_code,
-          feedLanguageCode: payloadItem.merchant_language_code,
-          localTransactionCost: payloadItem.local_cost,
-          items: cartItems
-        },
-        userIdentifiers: []
-      }
-      // Add Consent Signals 'adUserData' if it is defined
-      if (payloadItem.ad_user_data_consent_state) {
-        request_object['consent'] = {
-          adUserData: payloadItem.ad_user_data_consent_state
+    const requestObjectResults = await Promise.allSettled(
+      payload.map(async (payloadItem) => {
+        let cartItems: CartItemInterface[] = []
+        if (payloadItem.items && Array.isArray(payloadItem.items)) {
+          cartItems = payloadItem.items.map((product) => {
+            return {
+              productId: product.product_id,
+              quantity: product.quantity,
+              unitPrice: product.price
+            } as CartItemInterface
+          })
         }
-      }
 
-      // Add Consent Signals 'adPersonalization' if it is defined
-      if (payloadItem.ad_personalization_consent_state) {
-        request_object['consent'] = {
-          ...request_object['consent'],
-          adPersonalization: payloadItem.ad_personalization_consent_state
+        const { session_attributes_encoded, user_ip_address } = payloadItem
+
+        const request_object: ClickConversionRequestObjectInterface = {
+          conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+          gclid: payloadItem.gclid,
+          gbraid: payloadItem.gbraid,
+          wbraid: payloadItem.wbraid,
+          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
+          orderId: payloadItem.order_id,
+          conversionValue: payloadItem.value,
+          currencyCode: payloadItem.currency,
+          conversionEnvironment: payloadItem.conversion_environment,
+          cartData: {
+            merchantId: payloadItem.merchant_id,
+            feedCountryCode: payloadItem.merchant_country_code,
+            feedLanguageCode: payloadItem.merchant_language_code,
+            localTransactionCost: payloadItem.local_cost,
+            items: cartItems
+          },
+          userIdentifiers: []
         }
-      }
-
-      // Retrieves all of the custom variables that the customer has created in their Google Ads account
-      if (payloadItem.custom_variables) {
-        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-        if (customVariableIds?.data?.length) {
-          request_object.customVariables = formatCustomVariables(
-            payloadItem.custom_variables,
-            customVariableIds.data[0].results
-          )
-        }
-      }
-
-      if (payloadItem.email_address) {
-        const validatedEmail: string = processHashing(payloadItem.email_address, 'sha256', 'hex', commonEmailValidation)
-
-        request_object.userIdentifiers.push({
-          hashedEmail: validatedEmail
-        } as UserIdentifierInterface)
-      }
-
-      if (payloadItem.phone_number) {
-        request_object.userIdentifiers.push({
-          hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
-            formatPhone(value, payloadItem.phone_country_code)
-          )
-        } as UserIdentifierInterface)
-      }
-
-      return request_object
-    }
-
-    // Build a request object per payload. Payloads which fail validation are marked as errors in the
-    // multi-status response and excluded from the request sent to Google.
-    const request_objects: ClickConversionRequestObjectInterface[] = []
-    const requestIndexToPayloadIndex: number[] = []
-
-    const builtRequestObjects = await Promise.all(
-      payload.map(async (payloadItem, index) => {
-        try {
-          return { index, request_object: await buildRequestObject(payloadItem) }
-        } catch (error) {
-          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
-          // while fetching custom variables) is rethrown so the whole batch is retried.
-          if (error instanceof PayloadValidationError) {
-            return { index, error }
+        // Add Consent Signals 'adUserData' if it is defined
+        if (payloadItem.ad_user_data_consent_state) {
+          request_object['consent'] = {
+            adUserData: payloadItem.ad_user_data_consent_state
           }
-          throw error
         }
+
+        // Add Consent Signals 'adPersonalization' if it is defined
+        if (payloadItem.ad_personalization_consent_state) {
+          request_object['consent'] = {
+            ...request_object['consent'],
+            adPersonalization: payloadItem.ad_personalization_consent_state
+          }
+        }
+
+        // Retrieves all of the custom variables that the customer has created in their Google Ads account
+        if (payloadItem.custom_variables) {
+          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+          if (customVariableIds?.data?.length) {
+            request_object.customVariables = formatCustomVariables(
+              payloadItem.custom_variables,
+              customVariableIds.data[0].results
+            )
+          }
+        }
+
+        if (payloadItem.email_address) {
+          const validatedEmail: string = processHashing(
+            payloadItem.email_address,
+            'sha256',
+            'hex',
+            commonEmailValidation
+          )
+
+          request_object.userIdentifiers.push({
+            hashedEmail: validatedEmail
+          } as UserIdentifierInterface)
+        }
+
+        if (payloadItem.phone_number) {
+          request_object.userIdentifiers.push({
+            hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+              formatPhone(value, payloadItem.phone_country_code)
+            )
+          } as UserIdentifierInterface)
+        }
+
+        return request_object
       })
     )
 
-    for (const built of builtRequestObjects) {
-      if ('error' in built && built.error) {
-        multiStatusResponse.setErrorResponseAtIndex(built.index, {
-          status: 400,
-          errortype: 'PAYLOAD_VALIDATION_FAILED',
-          errormessage: built.error.message
-        })
-        continue
+    // Payloads which fail validation are reported as per-event errors and excluded from the request
+    // sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const requestIndexToPayloadIndex: number[] = []
+
+    requestObjectResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        request_objects.push(result.value)
+        requestIndexToPayloadIndex.push(index)
+        return
       }
-      request_objects.push(built.request_object)
-      requestIndexToPayloadIndex.push(built.index)
-    }
+
+      // Only payload validation failures are reported per event. Anything else (e.g. a failure while
+      // fetching custom variables) is rethrown so the whole batch is retried.
+      if (!(result.reason instanceof PayloadValidationError)) {
+        throw result.reason
+      }
+
+      multiStatusResponse.setErrorResponseAtIndex(index, {
+        status: 400,
+        errortype: 'PAYLOAD_VALIDATION_FAILED',
+        errormessage: result.reason.message
+      })
+    })
 
     // Nothing left to send to Google
     if (request_objects.length === 0) {
@@ -612,7 +611,6 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     )
-
     const failedPayloadIndices = new Set<number>()
     const partialFailureError = response.data?.partialFailureError
 
@@ -631,6 +629,7 @@ const action: ActionDefinition<Settings, Payload> = {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }
+
       multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
         status: 200,
         sent: request_objects[requestIndex] as unknown as JSONLikeObject,

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -4,7 +4,9 @@ import {
   ModifiedResponse,
   RequestClient,
   DynamicFieldResponse,
-  IntegrationError
+  IntegrationError,
+  MultiStatusResponse,
+  JSONLikeObject
 } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -24,7 +26,8 @@ import {
   getConversionActionDynamicData,
   memoizedGetCustomVariables,
   formatPhone,
-  getSessionAttributesKeyValuePairs
+  getSessionAttributesKeyValuePairs,
+  handlePartialFailureResponse
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -441,6 +444,7 @@ const action: ActionDefinition<Settings, Payload> = {
           headers: {
             'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
           },
+          skipResponseCloning: true,
           json: {
             conversions: [request_object],
             partialFailure: true
@@ -470,8 +474,10 @@ const action: ActionDefinition<Settings, Payload> = {
 
     const getCustomVariables = memoizedGetCustomVariables()
 
-    const request_objects: ClickConversionRequestObjectInterface[] = await Promise.all(
-      payload.map(async (payloadItem) => {
+    const multiStatusResponse = new MultiStatusResponse()
+
+    const buildRequestObject = async (payloadItem: Payload): Promise<ClickConversionRequestObjectInterface> => {
+      {
         let cartItems: CartItemInterface[] = []
         if (payloadItem.items && Array.isArray(payloadItem.items)) {
           cartItems = payloadItem.items.map((product) => {
@@ -555,8 +561,41 @@ const action: ActionDefinition<Settings, Payload> = {
         }
 
         return request_object
+      }
+    }
+
+    // Build a request object per payload. Payloads which fail validation are marked as errors in the
+    // multi-status response and excluded from the request sent to Google.
+    const request_objects: ClickConversionRequestObjectInterface[] = []
+    const validPayloadIndicesBitmap: number[] = []
+
+    const builtRequestObjects = await Promise.all(
+      payload.map(async (payloadItem, index) => {
+        try {
+          return { index, request_object: await buildRequestObject(payloadItem) }
+        } catch (error) {
+          return { index, error: error as Error }
+        }
       })
     )
+
+    for (const built of builtRequestObjects) {
+      if ('error' in built && built.error) {
+        multiStatusResponse.setErrorResponseAtIndex(built.index, {
+          status: 400,
+          errortype: 'PAYLOAD_VALIDATION_FAILED',
+          errormessage: built.error.message
+        })
+        continue
+      }
+      request_objects.push(built.request_object)
+      validPayloadIndicesBitmap.push(built.index)
+    }
+
+    // Nothing left to send to Google
+    if (request_objects.length === 0) {
+      return multiStatusResponse
+    }
 
     const response: ModifiedResponse<PartialErrorResponse> = await request(
       `https://googleads.googleapis.com/${getApiVersion(
@@ -568,14 +607,40 @@ const action: ActionDefinition<Settings, Payload> = {
         headers: {
           'developer-token': `${process.env.ADWORDS_DEVELOPER_TOKEN}`
         },
+        skipResponseCloning: true,
         json: {
           conversions: request_objects,
           partialFailure: true
         }
       }
     )
-    handleGoogleErrors(response)
-    return response
+
+    const failedPayloadIndices = new Set<number>()
+    const partialFailureError = response.data?.partialFailureError
+
+    if (partialFailureError) {
+      handlePartialFailureResponse(
+        partialFailureError,
+        validPayloadIndicesBitmap,
+        multiStatusResponse,
+        request_objects as unknown as JSONLikeObject[],
+        failedPayloadIndices,
+        'conversions'
+      )
+    }
+
+    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+      if (failedPayloadIndices.has(originalIndex)) {
+        return
+      }
+      multiStatusResponse.setSuccessResponseAtIndex(originalIndex, {
+        status: 200,
+        sent: request_objects[requestIndex] as unknown as JSONLikeObject,
+        body: (response.data?.results?.[requestIndex] ?? {}) as JSONLikeObject
+      })
+    })
+
+    return multiStatusResponse
   }
 }
 

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -477,104 +477,102 @@ const action: ActionDefinition<Settings, Payload> = {
     const multiStatusResponse = new MultiStatusResponse()
 
     const buildRequestObject = async (payloadItem: Payload): Promise<ClickConversionRequestObjectInterface> => {
-      {
-        let cartItems: CartItemInterface[] = []
-        if (payloadItem.items && Array.isArray(payloadItem.items)) {
-          cartItems = payloadItem.items.map((product) => {
-            return {
-              productId: product.product_id,
-              quantity: product.quantity,
-              unitPrice: product.price
-            } as CartItemInterface
-          })
-        }
-
-        const { session_attributes_encoded, user_ip_address } = payloadItem
-
-        const request_object: ClickConversionRequestObjectInterface = {
-          conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
-          conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
-          gclid: payloadItem.gclid,
-          gbraid: payloadItem.gbraid,
-          wbraid: payloadItem.wbraid,
-          ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
-          ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
-          ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
-          orderId: payloadItem.order_id,
-          conversionValue: payloadItem.value,
-          currencyCode: payloadItem.currency,
-          conversionEnvironment: payloadItem.conversion_environment,
-          cartData: {
-            merchantId: payloadItem.merchant_id,
-            feedCountryCode: payloadItem.merchant_country_code,
-            feedLanguageCode: payloadItem.merchant_language_code,
-            localTransactionCost: payloadItem.local_cost,
-            items: cartItems
-          },
-          userIdentifiers: []
-        }
-        // Add Consent Signals 'adUserData' if it is defined
-        if (payloadItem.ad_user_data_consent_state) {
-          request_object['consent'] = {
-            adUserData: payloadItem.ad_user_data_consent_state
-          }
-        }
-
-        // Add Consent Signals 'adPersonalization' if it is defined
-        if (payloadItem.ad_personalization_consent_state) {
-          request_object['consent'] = {
-            ...request_object['consent'],
-            adPersonalization: payloadItem.ad_personalization_consent_state
-          }
-        }
-
-        // Retrieves all of the custom variables that the customer has created in their Google Ads account
-        if (payloadItem.custom_variables) {
-          const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
-          if (customVariableIds?.data?.length) {
-            request_object.customVariables = formatCustomVariables(
-              payloadItem.custom_variables,
-              customVariableIds.data[0].results
-            )
-          }
-        }
-
-        if (payloadItem.email_address) {
-          const validatedEmail: string = processHashing(
-            payloadItem.email_address,
-            'sha256',
-            'hex',
-            commonEmailValidation
-          )
-
-          request_object.userIdentifiers.push({
-            hashedEmail: validatedEmail
-          } as UserIdentifierInterface)
-        }
-
-        if (payloadItem.phone_number) {
-          request_object.userIdentifiers.push({
-            hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
-              formatPhone(value, payloadItem.phone_country_code)
-            )
-          } as UserIdentifierInterface)
-        }
-
-        return request_object
+      let cartItems: CartItemInterface[] = []
+      if (payloadItem.items && Array.isArray(payloadItem.items)) {
+        cartItems = payloadItem.items.map((product) => {
+          return {
+            productId: product.product_id,
+            quantity: product.quantity,
+            unitPrice: product.price
+          } as CartItemInterface
+        })
       }
+
+      const { session_attributes_encoded, user_ip_address } = payloadItem
+
+      const request_object: ClickConversionRequestObjectInterface = {
+        conversionAction: `customers/${customerId}/conversionActions/${payloadItem.conversion_action}`,
+        conversionDateTime: convertTimestamp(payloadItem.conversion_timestamp),
+        gclid: payloadItem.gclid,
+        gbraid: payloadItem.gbraid,
+        wbraid: payloadItem.wbraid,
+        ...(user_ip_address ? { userIpAddress: user_ip_address } : {}),
+        ...(session_attributes_encoded ? { sessionAttributesEncoded: session_attributes_encoded } : {}),
+        ...(!session_attributes_encoded ? getSessionAttributesKeyValuePairs(payloadItem) : {}),
+        orderId: payloadItem.order_id,
+        conversionValue: payloadItem.value,
+        currencyCode: payloadItem.currency,
+        conversionEnvironment: payloadItem.conversion_environment,
+        cartData: {
+          merchantId: payloadItem.merchant_id,
+          feedCountryCode: payloadItem.merchant_country_code,
+          feedLanguageCode: payloadItem.merchant_language_code,
+          localTransactionCost: payloadItem.local_cost,
+          items: cartItems
+        },
+        userIdentifiers: []
+      }
+      // Add Consent Signals 'adUserData' if it is defined
+      if (payloadItem.ad_user_data_consent_state) {
+        request_object['consent'] = {
+          adUserData: payloadItem.ad_user_data_consent_state
+        }
+      }
+
+      // Add Consent Signals 'adPersonalization' if it is defined
+      if (payloadItem.ad_personalization_consent_state) {
+        request_object['consent'] = {
+          ...request_object['consent'],
+          adPersonalization: payloadItem.ad_personalization_consent_state
+        }
+      }
+
+      // Retrieves all of the custom variables that the customer has created in their Google Ads account
+      if (payloadItem.custom_variables) {
+        const customVariableIds = await getCustomVariables(customerId, auth, request, features, statsContext)
+        if (customVariableIds?.data?.length) {
+          request_object.customVariables = formatCustomVariables(
+            payloadItem.custom_variables,
+            customVariableIds.data[0].results
+          )
+        }
+      }
+
+      if (payloadItem.email_address) {
+        const validatedEmail: string = processHashing(payloadItem.email_address, 'sha256', 'hex', commonEmailValidation)
+
+        request_object.userIdentifiers.push({
+          hashedEmail: validatedEmail
+        } as UserIdentifierInterface)
+      }
+
+      if (payloadItem.phone_number) {
+        request_object.userIdentifiers.push({
+          hashedPhoneNumber: processHashing(payloadItem.phone_number, 'sha256', 'hex', (value) =>
+            formatPhone(value, payloadItem.phone_country_code)
+          )
+        } as UserIdentifierInterface)
+      }
+
+      return request_object
     }
 
     // Build a request object per payload. Payloads which fail validation are marked as errors in the
     // multi-status response and excluded from the request sent to Google.
     const request_objects: ClickConversionRequestObjectInterface[] = []
-    const validPayloadIndicesBitmap: number[] = []
+    const requestIndexToPayloadIndex: number[] = []
 
     const builtRequestObjects = await Promise.all(
       payload.map(async (payloadItem, index) => {
         try {
           return { index, request_object: await buildRequestObject(payloadItem) }
         } catch (error) {
-          return { index, error: error as Error }
+          // Only per-payload validation failures are reported per event. Anything else (e.g. a failure
+          // while fetching custom variables) is rethrown so the whole batch is retried.
+          if (error instanceof PayloadValidationError) {
+            return { index, error }
+          }
+          throw error
         }
       })
     )
@@ -589,7 +587,7 @@ const action: ActionDefinition<Settings, Payload> = {
         continue
       }
       request_objects.push(built.request_object)
-      validPayloadIndicesBitmap.push(built.index)
+      requestIndexToPayloadIndex.push(built.index)
     }
 
     // Nothing left to send to Google
@@ -621,7 +619,7 @@ const action: ActionDefinition<Settings, Payload> = {
     if (partialFailureError) {
       handlePartialFailureResponse(
         partialFailureError,
-        validPayloadIndicesBitmap,
+        requestIndexToPayloadIndex,
         multiStatusResponse,
         request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices,
@@ -629,7 +627,7 @@ const action: ActionDefinition<Settings, Payload> = {
       )
     }
 
-    validPayloadIndicesBitmap.forEach((originalIndex, requestIndex) => {
+    requestIndexToPayloadIndex.forEach((originalIndex, requestIndex) => {
       if (failedPayloadIndices.has(originalIndex)) {
         return
       }

--- a/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
+++ b/packages/destination-actions/src/destinations/google-enhanced-conversions/uploadClickConversion2/index.ts
@@ -28,7 +28,7 @@ import {
   formatPhone,
   getSessionAttributesKeyValuePairs,
   handlePartialFailureResponse,
-  handleGoogleAdsAPIErrorResponse
+  handleGoogleAdsAPIErrorResponsePerItem
 } from '../functions'
 import { GOOGLE_ENHANCED_CONVERSIONS_BATCH_SIZE } from '../constants'
 import { processHashing } from '../../../lib/hashing-utils'
@@ -618,13 +618,13 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       )
     } catch (error) {
-      // Report the HTTP level failure against every event that was sent, consistent with the user
-      // list path in handleUpdate.
-      handleGoogleAdsAPIErrorResponse(
+      // Report the HTTP level failure against every event that was sent, each attributed the
+      // conversion it sent.
+      handleGoogleAdsAPIErrorResponsePerItem(
         error,
         requestIndexToPayloadIndex,
         multiStatusResponse,
-        { conversions: request_objects } as unknown as JSONLikeObject,
+        request_objects as unknown as JSONLikeObject[],
         failedPayloadIndices
       )
       return multiStatusResponse
@@ -636,7 +636,7 @@ const action: ActionDefinition<Settings, Payload> = {
         partialFailureError,
         requestIndexToPayloadIndex,
         multiStatusResponse,
-        request_objects as unknown as JSONLikeObject[],
+        request_objects,
         failedPayloadIndices,
         'conversions'
       )


### PR DESCRIPTION
[JIRA](https://twilio-engineering.atlassian.net/browse/STRATCONN-7010)

Response from uploadClickConversions API is very large and we are often running into timeout errors even if delivery is suscessful. Also, even though the conversions api supports multistatus, the action doesn't parse and returns errors correctly.
In this PR, we 
- Add skipResponseCloning as true to request to conversions API
- Implement multistatus response handling similar to how userList action does.

Upload click conversions and click conversions v2 are the same functionally except for syncmode support in v2 action

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [x] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron.


[Stage and local testing results for review](https://docs.google.com/document/d/1YJMrSPEbqbrNW4GV8QWyEPViiYpc69661fTimNuqInU/edit?tab=t.0)

## Security Review

- [x] **Reviewed all field definitions** for sensitive data (API keys, tokens, passwords, client secrets) and confirmed they use `type: 'password'` — no field definitions are added or modified by this change.

## New Destination Checklist

N/A — existing destination.
